### PR TITLE
feat: use trusted header to get the user id instead of authentication

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -26,6 +26,8 @@ class AppConfig:
         self.OIDC_REDIRECT_URI = os.environ.get("OIDC_REDIRECT_URI", None)
         self.OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", None)
         self.OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", None)
+        self.USE_TRUSTED_USER_ID_HEADER = os.environ.get("USE_TRUSTED_USER_ID_HEADER", str(False)).lower() in ("true", "1", "t")
+        self.TRUSTED_USER_ID_HEADER = os.environ.get("TRUSTED_USER_ID_HEADER", None)
 
         # session
         self.SESSION_TYPE = os.environ.get("SESSION_TYPE", "cachelib")

--- a/mlflow_oidc_auth/utils.py
+++ b/mlflow_oidc_auth/utils.py
@@ -49,6 +49,10 @@ def get_username():
             username = validate_token(request.authorization.token).get("email")
             app.logger.debug(f"Username from bearer token: {username}")
             return username
+        if config.TRUSTED_USER_ID_HEADER:
+            username = request.headers.get(config.TRUSTED_USER_ID_HEADER)
+            app.logger.debug(f"Username from trusted header {config.TRUSTED_USER_ID_HEADER}: {username}")
+            return username
     return None
 
 


### PR DESCRIPTION
This will add the possibility to trust a custom header providing the user id. In one of our use cases, this is useful when MlFlow runs behind a reverse proxy which is responsible for the authentication.

This PR is in progress. For example it is not clear how the first request of a user should be handled as the user has to be first created in the database.

Fixes https://github.com/mlflow-oidc/mlflow-oidc-auth/issues/69