### PR TITLE
feat: Make alembic version table configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The plugin required the following environment variables but also supported `.env
 | SECRET_KEY             | Key to perform cookie encryption |
 | LOG_LEVEL                   | Application log level |
 | OIDC_USERS_DB_URI | Database connection string |
+| OIDC_ALEMBIC_VERSION_TABLE  | Name of the table to use for alembic versions (defaults to alembic_version if not provided)                                                          |
 
 ## Application session storage configuration
 | Parameter | Description | Default |

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -10,9 +10,11 @@ from mlflow.server import app
 load_dotenv()  # take environment variables from .env.
 app.logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
+
 def get_bool_env_variable(variable, default_value):
     value = os.environ.get(variable, str(default_value))
     return value.lower() in ["true", "1", "t"]
+
 
 class AppConfig:
     def __init__(self):
@@ -30,6 +32,7 @@ class AppConfig:
         self.OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", None)
         self.OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", None)
         self.AUTOMATIC_LOGIN_REDIRECT = get_bool_env_variable("AUTOMATIC_LOGIN_REDIRECT", False)
+        self.OIDC_ALEMBIC_VERSION_TABLE = os.environ.get("OIDC_ALEMBIC_VERSION_TABLE", "alembic_version")
 
         # session
         self.SESSION_TYPE = os.environ.get("SESSION_TYPE", "cachelib")

--- a/mlflow_oidc_auth/db/migrations/env.py
+++ b/mlflow_oidc_auth/db/migrations/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -44,6 +45,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        version_table=os.environ.get("OIDC_ALEMBIC_VERSION_TABLE", "alembic_version"),
     )
 
     with context.begin_transaction():
@@ -64,7 +66,13 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table=os.environ.get(
+                "OIDC_ALEMBIC_VERSION_TABLE", "alembic_version"
+            ),
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/mlflow_oidc_auth/db/migrations/env.py
+++ b/mlflow_oidc_auth/db/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from mlflow_oidc_auth.config import config as app_config
 from mlflow_oidc_auth.db.models import Base
 
 # this is the Alembic Config object, which provides
@@ -45,7 +46,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
-        version_table=os.environ.get("OIDC_ALEMBIC_VERSION_TABLE", "alembic_version"),
+        version_table=app_config.OIDC_ALEMBIC_VERSION_TABLE,
     )
 
     with context.begin_transaction():
@@ -69,9 +70,7 @@ def run_migrations_online() -> None:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            version_table=os.environ.get(
-                "OIDC_ALEMBIC_VERSION_TABLE", "alembic_version"
-            ),
+            version_table=app_config.OIDC_ALEMBIC_VERSION_TABLE,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
If the environment variable `OIDC_ALEMBIC_VERSION_TABLE` is defined, use this as the table that alembic uses to store the alembic versions in. If not defined, use the default `alembic_version`.

Fixes: #76

Allows to use both mlflow-oidc-auth and mlflow in the same (postgres) database, each having its own alembic version table.