### PR TITLE
feat: use patterns to filter all groups to only relevant groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OIDC_CLIENT_SECRET ='<super_secret>'
 OIDC_CLIENT_ID ='<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Okta"
 OIDC_SCOPE = "openid,profile,email,groups"
-OIDC_GROUP_NAME = "mlflow-users-group-name"
+OIDC_GROUP_FILTER_PATTERN = "mlflow-users-group-name"
 OIDC_ADMIN_GROUP_NAME = "mlflow-admin-group-name"
 ```
 
@@ -75,7 +75,20 @@ OIDC_CLIENT_ID = '<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Microsoft"
 OIDC_GROUP_DETECTION_PLUGIN = 'mlflow_oidc_auth.plugins.group_detection_microsoft_entra_id'
 OIDC_SCOPE = "openid,profile,email"
-OIDC_GROUP_NAME = "mlflow_users_group_name"
+OIDC_GROUP_FILTER_PATTERN = "mlflow_users_group_name"
+OIDC_ADMIN_GROUP_NAME = "mlflow_admins_group_name"
+```
+
+Alternatively, if you want to give access to every group starting with `mlflow_users_` or `mlflow_viewers_` you can use the following configuration:
+
+```bash
+OIDC_DISCOVERY_URL = 'https://login.microsoftonline.com/<tenant_id>/v2.0/.well-known/openid-configuration'
+OIDC_CLIENT_SECRET = '<super_secret>'
+OIDC_CLIENT_ID = '<client_id>'
+OIDC_PROVIDER_DISPLAY_NAME = "Login with Microsoft"
+OIDC_GROUP_DETECTION_PLUGIN = 'mlflow_oidc_auth.plugins.group_detection_microsoft_entra_id'
+OIDC_SCOPE = "openid,profile,email"
+OIDC_GROUP_FILTER_PATTERN = "mlflow_users_* mlflow_viewers_*"
 OIDC_ADMIN_GROUP_NAME = "mlflow_admins_group_name"
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The plugin required the following environment variables but also supported `.env
 | OIDC_GROUP_DETECTION_PLUGIN | OIDC plugin to detect groups |
 | OIDC_PROVIDER_DISPLAY_NAME | any text to display |
 | OIDC_SCOPE | OIDC scope |
-| OIDC_GROUP_PATTERN_FILTER | List of fnmatch patterns that will be considered relevant to login to MLFlow. Any groups coming from the currently supported groups in OIDC claims and Microsoft Entra ID groups not matching any of the patterns will be ignored. Will default to `*` to not filter out any groups |
+| OIDC_GROUP_FILTER_PATTERNS | List of fnmatch patterns that will be considered relevant to login to MLFlow. Any groups coming from the currently supported groups in OIDC claims and Microsoft Entra ID groups not matching any of the patterns will be ignored. Will default to `*` to not filter out any groups |
 | OIDC_AUTHORIZATION_URL | OIDC Auth URL (if discovery URL is not defined) |
 | OIDC_TOKEN_URL         | OIDC Token URL (if discovery URL is not defined) |
 | OIDC_USER_URL          | OIDC User info URL (if discovery URL is not defined) |
@@ -61,7 +61,7 @@ OIDC_CLIENT_SECRET ='<super_secret>'
 OIDC_CLIENT_ID ='<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Okta"
 OIDC_SCOPE = "openid,profile,email,groups"
-OIDC_GROUP_FILTER_PATTERN = "mlflow-users-group-name"
+OIDC_GROUP_FILTER_PATTERNS = "mlflow-users-group-name"
 OIDC_ADMIN_GROUP_NAME = "mlflow-admin-group-name"
 ```
 
@@ -74,7 +74,7 @@ OIDC_CLIENT_ID = '<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Microsoft"
 OIDC_GROUP_DETECTION_PLUGIN = 'mlflow_oidc_auth.plugins.group_detection_microsoft_entra_id'
 OIDC_SCOPE = "openid,profile,email"
-OIDC_GROUP_FILTER_PATTERN = "mlflow_users_group_name"
+OIDC_GROUP_FILTER_PATTERNS = "mlflow_users_group_name"
 OIDC_ADMIN_GROUP_NAME = "mlflow_admins_group_name"
 ```
 
@@ -87,7 +87,7 @@ OIDC_CLIENT_ID = '<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Microsoft"
 OIDC_GROUP_DETECTION_PLUGIN = 'mlflow_oidc_auth.plugins.group_detection_microsoft_entra_id'
 OIDC_SCOPE = "openid,profile,email"
-OIDC_GROUP_FILTER_PATTERN = "mlflow_users_* mlflow_viewers_*"
+OIDC_GROUP_FILTER_PATTERNS = "mlflow_users_* mlflow_viewers_*"
 OIDC_ADMIN_GROUP_NAME = "mlflow_admins_group_name"
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The plugin required the following environment variables but also supported `.env
 | OIDC_PROVIDER_DISPLAY_NAME | any text to display |
 | OIDC_SCOPE | OIDC scope |
 | OIDC_GROUP_NAME | User group name to be allowed login to MLFlow, currently supported groups in OIDC claims and Microsoft Entra ID groups |
-| OIDC_ADMIN_GROUP_NAME | User group name to be allowed login to MLFlow manage and define permissions, currently supported groups in OIDC claims and Microsoft Entra ID groups |
+| OIDC_GROUP_PATTERN_FILTER | List of fnmatch patterns that will be considered relevant to login to MLFlow. Any groups coming from the currently supported groups in OIDC claims and Microsoft Entra ID groups not matching any of the patterns will be ignored |
 | OIDC_AUTHORIZATION_URL | OIDC Auth URL (if discovery URL is not defined) |
 | OIDC_TOKEN_URL         | OIDC Token URL (if discovery URL is not defined) |
 | OIDC_USER_URL          | OIDC User info URL (if discovery URL is not defined) |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ The plugin required the following environment variables but also supported `.env
 | OIDC_GROUP_DETECTION_PLUGIN | OIDC plugin to detect groups |
 | OIDC_PROVIDER_DISPLAY_NAME | any text to display |
 | OIDC_SCOPE | OIDC scope |
-| OIDC_GROUP_NAME | User group name to be allowed login to MLFlow, currently supported groups in OIDC claims and Microsoft Entra ID groups |
-| OIDC_GROUP_PATTERN_FILTER | List of fnmatch patterns that will be considered relevant to login to MLFlow. Any groups coming from the currently supported groups in OIDC claims and Microsoft Entra ID groups not matching any of the patterns will be ignored |
+| OIDC_GROUP_PATTERN_FILTER | List of fnmatch patterns that will be considered relevant to login to MLFlow. Any groups coming from the currently supported groups in OIDC claims and Microsoft Entra ID groups not matching any of the patterns will be ignored. Will default to `*` to not filter out any groups |
 | OIDC_AUTHORIZATION_URL | OIDC Auth URL (if discovery URL is not defined) |
 | OIDC_TOKEN_URL         | OIDC Token URL (if discovery URL is not defined) |
 | OIDC_USER_URL          | OIDC User info URL (if discovery URL is not defined) |

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -19,7 +19,9 @@ class AppConfig:
         self.DEFAULT_MLFLOW_PERMISSION = os.environ.get("DEFAULT_MLFLOW_PERMISSION", "MANAGE")
         self.SECRET_KEY = os.environ.get("SECRET_KEY", secrets.token_hex(16))
         self.OIDC_USERS_DB_URI = os.environ.get("OIDC_USERS_DB_URI", "sqlite:///auth.db")
-        self.OIDC_GROUP_FILTER_PATTERNS = [pattern.strip() for pattern in os.environ.get("OIDC_GROUP_FILTER_PATTERNS", "*").split(",")]
+        self.OIDC_GROUP_FILTER_PATTERNS = [
+            pattern.strip() for pattern in os.environ.get("OIDC_GROUP_FILTER_PATTERNS", "*").split(",")
+        ]
         self.OIDC_ADMIN_GROUP_NAME = os.environ.get("OIDC_ADMIN_GROUP_NAME", "mlflow-admin")
         self.OIDC_PROVIDER_DISPLAY_NAME = os.environ.get("OIDC_PROVIDER_DISPLAY_NAME", "Login with OIDC")
         self.OIDC_DISCOVERY_URL = os.environ.get("OIDC_DISCOVERY_URL", None)

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -19,7 +19,7 @@ class AppConfig:
         self.DEFAULT_MLFLOW_PERMISSION = os.environ.get("DEFAULT_MLFLOW_PERMISSION", "MANAGE")
         self.SECRET_KEY = os.environ.get("SECRET_KEY", secrets.token_hex(16))
         self.OIDC_USERS_DB_URI = os.environ.get("OIDC_USERS_DB_URI", "sqlite:///auth.db")
-        self.OIDC_GROUP_NAME = [group.strip() for group in os.environ.get("OIDC_GROUP_NAME", "mlflow").split(",")]
+        self.OIDC_GROUP_FILTER_PATTERNS = [pattern.strip() for pattern in os.environ.get("OIDC_GROUP_FILTER_PATTERNS", "*").split(",")]
         self.OIDC_ADMIN_GROUP_NAME = os.environ.get("OIDC_ADMIN_GROUP_NAME", "mlflow-admin")
         self.OIDC_PROVIDER_DISPLAY_NAME = os.environ.get("OIDC_PROVIDER_DISPLAY_NAME", "Login with OIDC")
         self.OIDC_DISCOVERY_URL = os.environ.get("OIDC_DISCOVERY_URL", None)

--- a/mlflow_oidc_auth/tests/test_group_memberships_and_admin.py
+++ b/mlflow_oidc_auth/tests/test_group_memberships_and_admin.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+from mlflow_oidc_auth.token_utils import token_get_user_groups, token_get_user_is_admin
+from mlflow_oidc_auth.config import config
+
+
+@patch("mlflow_oidc_auth.token_utils.config.OIDC_GROUP_FILTER_PATTERNS", new=["mlflow-*"])
+@patch("mlflow_oidc_auth.token_utils.config.OIDC_ADMIN_GROUP_NAME", new="admin-mlflow")
+class TestGroupMemberships(unittest.TestCase):
+
+    def test_user_in_all_groups_and_admin_group(self):
+
+        token = {
+            "userinfo": {
+                config.OIDC_GROUPS_ATTRIBUTE: [
+                    "mlflow-user-team1",
+                    "mlflow-user-team2",
+                    config.OIDC_ADMIN_GROUP_NAME,
+                ]
+            }
+        }
+
+        user_groups = token_get_user_groups(token)
+        is_admin = token_get_user_is_admin(user_groups)
+
+        self.assertEqual(len(user_groups), len(token["userinfo"][config.OIDC_GROUPS_ATTRIBUTE]))
+        self.assertTrue(is_admin)
+
+    def test_user_in_no_groups_but_in_admin_group(self):
+
+        token = {
+            "userinfo": {
+                config.OIDC_GROUPS_ATTRIBUTE: [
+                    "otherapp-team1",
+                    "otherapp-team2",
+                    config.OIDC_ADMIN_GROUP_NAME,
+                ]
+            }
+        }
+
+        user_groups = token_get_user_groups(token)
+        is_admin = token_get_user_is_admin(user_groups)
+
+        self.assertEqual(len(user_groups), 1)
+        self.assertTrue(is_admin)
+
+    def test_user_in_no_groups_not_in_admin_group(self):
+
+        token = {
+            "userinfo": {
+                config.OIDC_GROUPS_ATTRIBUTE: [
+                    "otherapp-team1",
+                    "otherapp-team2",
+                ]
+            }
+        }
+
+        user_groups = token_get_user_groups(token)
+        is_admin = token_get_user_is_admin(user_groups)
+
+        self.assertEqual(len(user_groups), 0)
+        self.assertFalse(is_admin)
+
+    def test_user_in_groups_not_in_admin_group(self):
+
+        token = {
+            "userinfo": {
+                config.OIDC_GROUPS_ATTRIBUTE: [
+                    "otherapp-team1",
+                    "otherapp-team2",
+                    "mlflow-user-team1",
+                    "mlflow-user-team2",
+                ]
+            }
+        }
+
+        user_groups = token_get_user_groups(token)
+        is_admin = token_get_user_is_admin(user_groups)
+
+        self.assertEqual(len(user_groups), 2)
+        self.assertFalse(is_admin)

--- a/mlflow_oidc_auth/token_utils.py
+++ b/mlflow_oidc_auth/token_utils.py
@@ -1,0 +1,54 @@
+import fnmatch
+
+from mlflow_oidc_auth.config import config
+
+
+def token_get_user_groups(token: dict) -> list[str]:
+    """Retrieve the list of groups this user (based on the provided token) is a member of
+
+    Args:
+        token: dictionary holding the oidc token information
+
+    Returns:
+        list of all the groups this user is a member of
+    """
+    user_groups = []
+
+    if config.OIDC_GROUP_DETECTION_PLUGIN:
+        import importlib
+
+        user_groups = importlib.import_module(config.OIDC_GROUP_DETECTION_PLUGIN).get_user_groups(token["access_token"])
+    else:
+        user_groups = token["userinfo"][config.OIDC_GROUPS_ATTRIBUTE]
+
+    # Now filter the user groups to keep only those matching the pattern or the ADMIN group
+    user_groups = sorted(
+        set(
+            [
+                g
+                for g in user_groups
+                if (g == config.OIDC_ADMIN_GROUP_NAME) or any(fnmatch.fnmatch(g, p) for p in config.OIDC_GROUP_FILTER_PATTERNS)
+            ]
+        )
+    )
+
+    return user_groups
+
+
+def token_get_user_is_admin(user_groups: list[str]):
+    """Check if the admin group is included in the user_groups. In that case
+    it means that the user is an admin user
+
+    Args:
+        user_groups (list[str]): list of the groups the current user belongs to
+
+    Returns:
+        True if the admin group is in the list of the groups of the current user, False otherwise
+
+    """
+    is_admin = False
+
+    if config.OIDC_ADMIN_GROUP_NAME in user_groups:
+        is_admin = True
+
+    return is_admin

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -1,3 +1,4 @@
+import fnmatch
 import secrets
 
 from flask import redirect, render_template, session, url_for

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -63,7 +63,15 @@ def callback():
 
     if config.OIDC_ADMIN_GROUP_NAME in user_groups:
         is_admin = True
-    elif not any(group in user_groups for group in config.OIDC_GROUP_NAME):
+
+    # Now filter the user groups to keep only those matching the pattern
+    user_groups = sorted(
+        set([x for p in config.OIDC_GROUP_FILTER_PATTERNS for x in [g for g in user_groups if fnmatch.fnmatch(g, p)]])
+    )
+
+    app.logger.debug(f"Filtered user groups: {user_groups}")
+
+    if not len(user_groups):
         return "User is not allowed to login", 401
 
     create_user(username=email.lower(), display_name=display_name, is_admin=is_admin)

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -61,9 +61,6 @@ def callback():
 
     app.logger.debug(f"All user groups: {user_groups}")
 
-    if config.OIDC_ADMIN_GROUP_NAME in user_groups:
-        is_admin = True
-
     # Now filter the user groups to keep only those matching the pattern
     user_groups = sorted(
         set([x for p in config.OIDC_GROUP_FILTER_PATTERNS for x in [g for g in user_groups if fnmatch.fnmatch(g, p)]])
@@ -71,7 +68,10 @@ def callback():
 
     app.logger.debug(f"Filtered user groups: {user_groups}")
 
-    if not len(user_groups):
+    if config.OIDC_ADMIN_GROUP_NAME in user_groups:
+        app.logger.debug(f"User is in admin group {config.OIDC_ADMIN_GROUP_NAME}")
+        is_admin = True
+    elif not len(user_groups):
         return "User is not allowed to login", 401
 
     create_user(username=email.lower(), display_name=display_name, is_admin=is_admin)

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -67,6 +67,26 @@ def get_user_groups(token: dict) -> list[str]:
     return user_groups
 
 
+def get_is_admin(user_groups: list[str]):
+    """Check if the admin group is included in the user_groups. In that case
+    it means that the user is an admin user
+
+    Args:
+        user_groups (list[str]): list of the groups the current user belongs to
+
+    Returns:
+        True if the admin group is in the list of the groups of the current user, False otherwise
+
+    """
+    is_admin = False
+
+    if config.OIDC_ADMIN_GROUP_NAME in user_groups:
+        app.logger.debug(f"User is in admin group {config.OIDC_ADMIN_GROUP_NAME}")
+        is_admin = True
+
+    return is_admin
+
+
 def callback():
     """Validate the state to protect against CSRF"""
 

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -59,7 +59,7 @@ def callback():
     else:
         user_groups = token["userinfo"][config.OIDC_GROUPS_ATTRIBUTE]
 
-    app.logger.debug(f"User groups: {user_groups}")
+    app.logger.debug(f"All user groups: {user_groups}")
 
     if config.OIDC_ADMIN_GROUP_NAME in user_groups:
         is_admin = True


### PR DESCRIPTION
In the original setup you have a configuration option `OIDC_GROUP_NAME` which provides a comma separated list of groups that are considered relevant. 

Every new group that is added to AD that would allow access to MLFlow would require a restart of the mlflow server with an updated configuration.

Instead, if we use patterns like mlflow-users-* as an allowed pattern, it would indicate that any group starting withmlflow-users- would be a group that gives access to mlflow.

One additional benefit is that if the okta function returns a large number of groups (e.g. 300 different groups that a user is a member of), only the groups considered relevant based on the patterns are added to the permission databases, the rest is ignored.

This PR modifies the code to not work with a hardcoded list of full names, but with a list of patterns instead. 

Decided to not use full regular expressions here, but simple file-system like matching using the `fnmatch` library in python.

Implements: #78 