### PR TITLE
feat: rewrite permission logic to no permissions having lowest priority

### DIFF
--- a/mlflow_oidc_auth/permissions.py
+++ b/mlflow_oidc_auth/permissions.py
@@ -43,7 +43,7 @@ MANAGE = Permission(
 
 NO_PERMISSIONS = Permission(
     name="NO_PERMISSIONS",
-    priority=100,
+    priority=0,
     can_read=False,
     can_update=False,
     can_delete=False,

--- a/mlflow_oidc_auth/permissions.py
+++ b/mlflow_oidc_auth/permissions.py
@@ -70,7 +70,7 @@ def _validate_permission(permission: str):
         )
 
 
-def compare_permissions(permission1: str, permission2: str) -> bool:
+def compare_permissions(permission1: str, permission2: str, strict: bool=False) -> bool:
     _validate_permission(permission1)
     _validate_permission(permission2)
     return ALL_PERMISSIONS[permission1].priority <= ALL_PERMISSIONS[permission2].priority

--- a/mlflow_oidc_auth/permissions.py
+++ b/mlflow_oidc_auth/permissions.py
@@ -73,4 +73,8 @@ def _validate_permission(permission: str):
 def compare_permissions(permission1: str, permission2: str, strict: bool=False) -> bool:
     _validate_permission(permission1)
     _validate_permission(permission2)
-    return ALL_PERMISSIONS[permission1].priority <= ALL_PERMISSIONS[permission2].priority
+
+    if strict:
+        return ALL_PERMISSIONS[permission1].priority < ALL_PERMISSIONS[permission2].priority
+    else:
+        return ALL_PERMISSIONS[permission1].priority <= ALL_PERMISSIONS[permission2].priority

--- a/mlflow_oidc_auth/permissions.py
+++ b/mlflow_oidc_auth/permissions.py
@@ -71,6 +71,20 @@ def _validate_permission(permission: str):
 
 
 def compare_permissions(permission1: str, permission2: str, strict: bool=False) -> bool:
+    """Compare two permissions permission1 and permission2
+
+    If permission1 has a lower priorty than permission2, the return value will be True. In case the argument
+    strict has the non-default value of True, the priority of permission1 must be strictly lower than the
+    priority of permission2
+
+    Args:
+        permission1: The string representation of the first permission
+        permission2: The string representation of the second permission
+        strict: Boolean indicating whether the comparison should be exected in strictly lower or not
+
+    Returns:
+        True if permission1 is having (strictly) lower priority than permission2
+    """
     _validate_permission(permission1)
     _validate_permission(permission2)
 

--- a/mlflow_oidc_auth/utils.py
+++ b/mlflow_oidc_auth/utils.py
@@ -9,7 +9,7 @@ from mlflow.server.handlers import _get_tracking_store
 from mlflow_oidc_auth.app import app
 from mlflow_oidc_auth.auth import validate_token
 from mlflow_oidc_auth.config import config
-from mlflow_oidc_auth.permissions import Permission, get_permission
+from mlflow_oidc_auth.permissions import Permission, compare_permissions, get_permission
 from mlflow_oidc_auth.store import store
 
 


### PR DESCRIPTION
Instead of giving `NO_PERMISSIONS` a higher priority than all the other priorities, which allows for weird blocking of access if you have both MANAGE PERMISSIONS as well as NO_PERMISSIONS, this PR will modify the permission logic to be giving you the access of the highest allowed permissions based on the default permission, your user permissions, as well as each of your groups permissions.

In order to check what the type is that gave you access, we start with type fallback, then if the user permission prioerity is strictly higher than the fallback one, we change the type to user and if after that any of the group permissions have a strictly higher priority, we consider the group to be the type that granted this access.

For example, if the default permission is READ and your user also has explicit READ permissions, we consider the type to still be fallback (the fact that the user has read access does not grant anything additional above the defaults).

By using this logic and assigning NO_PERMISSIONS the lowest priority, you automatically solve the problem that if you are a member of two groups and one group gives you MANAGE access and the other one NO PERMISSIONS, you end up with no permissions in the current state (in the state with this pr, you would end up with MANAGE).


Because of the changes in this PR, this also Implements #80

This also might address #83, though without the use of an extra config variable