### PR TITLE
feat: support running behind reverse proxy with path based routing

### DIFF
--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -1,5 +1,7 @@
 import os
 
+from werkzeug.middleware.proxy_fix import ProxyFix
+
 from mlflow.server import app
 from flask_session import Session
 
@@ -86,6 +88,8 @@ app.add_url_rule(rule=routes.UPDATE_GROUP_MODEL_PERMISSION, methods=["PATCH"], v
 # Add new hooks
 app.before_request(before_request_hook)
 app.after_request(after_request_hook)
+
+app.wsgi_app = ProxyFix(app.wsgi_app, x_prefix=1)
 
 # Set up session
 Session(app)

--- a/mlflow_oidc_auth/hack/menu.html
+++ b/mlflow_oidc_auth/hack/menu.html
@@ -45,8 +45,8 @@
                 return;
             }
             var username = response.display_name;
-            var oidcLink = "/oidc/ui/";
-            var logoutLink = "/logout";
+            var oidcLink = "oidc/ui/";
+            var logoutLink = "logout";
             addLinks(username, oidcLink, logoutLink);
         });
     });

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -85,7 +85,7 @@ def _is_unprotected_route(path: str) -> bool:
             "/callback",
             "/oidc/static",
             "/metrics",
-        )
+        ) or path == '/'
     )
 
 
@@ -197,7 +197,7 @@ def before_request_hook():
             session.clear()
 
             if config.AUTOMATIC_LOGIN_REDIRECT:
-                return redirect(url_for("login", _external=True))
+                return redirect(url_for("login"), _external=True)
             return render_template(
                 "auth.html",
                 username=None,

--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -8,7 +8,6 @@ from mlflow_oidc_auth.app import app
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.user import create_user, populate_groups, update_user
 
-
 def login():
     state = secrets.token_urlsafe(16)
     session["oauth_state"] = state

--- a/web-ui/src/app/app.module.ts
+++ b/web-ui/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SharedModule } from './shared/shared.module';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { ErrorHandlerInterceptor } from './shared/interceptors/error-handler.interceptor';
+import { BasePrefixInterceptor } from './shared/interceptors/base-prefix.interceptor';
 
 @NgModule({
   declarations: [
@@ -19,7 +20,8 @@ import { ErrorHandlerInterceptor } from './shared/interceptors/error-handler.int
     SharedModule,
   ],
   providers: [
-    { provide: HTTP_INTERCEPTORS, useClass: ErrorHandlerInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: ErrorHandlerInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: BasePrefixInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/web-ui/src/app/features/home-page/components/home-page/home-page.component.ts
+++ b/web-ui/src/app/features/home-page/components/home-page/home-page.component.ts
@@ -65,7 +65,11 @@ export class HomePageComponent implements OnInit, AfterViewInit {
   }
 
   redirectToMLFlow() {
-    window.location.href = '/';
+    // /models/oidc/ui -> /models
+    // /oidc/ui -> /
+    const paths = location.pathname.split("/").filter(function(f) {return f != ''})
+    const basePath = paths.splice(0, paths.indexOf("oidc")).join("/")
+    window.location.href = '/'+ basePath
   }
 
   handleTabSelection(index: number) {

--- a/web-ui/src/app/shared/interceptors/base-prefix.interceptor.spec.ts
+++ b/web-ui/src/app/shared/interceptors/base-prefix.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BasePrefixInterceptor } from './base-prefix.interceptor';
+
+describe('BasePrefixInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      BasePrefixInterceptor
+      ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: BasePrefixInterceptor = TestBed.inject(BasePrefixInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/web-ui/src/app/shared/interceptors/base-prefix.interceptor.ts
+++ b/web-ui/src/app/shared/interceptors/base-prefix.interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+@Injectable()
+export class BasePrefixInterceptor implements HttpInterceptor {
+
+  constructor() {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    let baseUrl = environment.basePrefix;
+
+    const clonedRequest = request.clone({
+      url: baseUrl + request.url,
+    });
+
+    return next.handle(clonedRequest);
+  }
+}

--- a/web-ui/src/environments/environment.prod.ts
+++ b/web-ui/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  basePrefix: ""
 };

--- a/web-ui/src/environments/environment.ts
+++ b/web-ui/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  basePrefix: ""
 };
 
 /*

--- a/web-ui/src/index.html
+++ b/web-ui/src/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <title>MLFlow Permissions Management</title>
-  <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
Fix #https://github.com/mlflow-oidc/mlflow-oidc-auth/issues/90

# Feature
This feature will enable to run MlFlow together with this plugin to run behind a reverse proxy that routes traffic based on the path, e.g. `/models`. This requires some changes in the backend and frontend to use the prefix path. Ideally this prefix path should not be hardcoded or configured.

## URL generation in the backend
We can use Werkzeugs `ProxyFix` (https://werkzeug.palletsprojects.com/en/stable/middleware/proxy_fix/) to use `X-Forwarded-Prefix` from the reverse proxy. This will enable `url_for` to generate the correct URL with the prefix

## URL generation in the frontend
The UI needs to be configurable to use a base prefix. This could is done via en environment setting which per default is empty. 

# How to use the feature
The user has to properly configure their reverse proxy as well as override the base prefix in the UI code.
 
## Required changes at Reverse Proxy
In order to work one needs to adjust his reverse proxy to set the needed header. Also at the moment accessing `/models` does not work as the requests for the static mlflow files as well as for the current username (https://github.com/mlflow-oidc/mlflow-oidc-auth/blob/main/mlflow_oidc_auth/hack/menu.html#L42) will ignore the path. I did not want to introduce a new config variable to add the base path here manually so the quick fix is to redirect requests to `/models` to `/models/`. Then the relative paths will work again.
```
proxy_set_header X-Forwarded-Prefix /models;
location /models {
    return 301 /models/;
}
```

## Required changes during build time
As the UI is part of the package, there is no easy way to set the `basePrefix` in the angular configuration without hardcoding it. Therefore, I am overriding it before building the UI. I have not find a way yet to set it dynamically. I tried overriding the compiled javascript in the pip package but was not successful as the production js code gets optimized 
```dockerfile
RUN git clone https://github.com/mlflow-oidc/mlflow-oidc-auth
RUN find '.' -name '*.ts' -exec sed -i -e 's@basePrefix: ""@basePrefix:"/models"@g' {} \;
RUN yarn install
RUN yarn release 
RUN python -m pip install .
```