### PR TITLE
feat: support pagination for Entra ID group

### DIFF
--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -129,7 +129,7 @@ def handle_token_validation(oauth_instance: OAuth):
 def handle_user_and_group_management(token) -> list[str]:
     """Handle user and group management based on the token. Returns list of error messages or empty list."""
     errors = []
-    email = token["userinfo"].get("email")
+    email = token["userinfo"].get("email")  or token["userinfo"].get("preferred_username")
     display_name = token["userinfo"].get("name")
     if not email:
         errors.append("User profile error: No email provided in OIDC userinfo.")
@@ -220,7 +220,7 @@ def process_oidc_callback(request, session) -> tuple[Optional[str], list[str]]:
     if not isinstance(userinfo, dict):
         errors.append("OIDC token error: 'userinfo' is missing or not a dictionary.")
         return None, errors
-    email = userinfo.get("email")
+    email = userinfo.get("email") or userinfo.get("preferred_username")
     if email is None:
         errors.append("OIDC token error: 'email' is missing in userinfo.")
         return None, errors

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -129,7 +129,7 @@ def handle_token_validation(oauth_instance: OAuth):
 def handle_user_and_group_management(token) -> list[str]:
     """Handle user and group management based on the token. Returns list of error messages or empty list."""
     errors = []
-    email = token["userinfo"] token["userinfo"].get("preferred_username")
+    email = token["userinfo"].get("email") or token["userinfo"].get("preferred_username")
     display_name = token["userinfo"].get("name")
     if not email:
         errors.append("User profile error: No email provided in OIDC userinfo.")

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -129,7 +129,7 @@ def handle_token_validation(oauth_instance: OAuth):
 def handle_user_and_group_management(token) -> list[str]:
     """Handle user and group management based on the token. Returns list of error messages or empty list."""
     errors = []
-    email = token["userinfo"].get("email")  or token["userinfo"].get("preferred_username")
+    email = token["userinfo"] token["userinfo"].get("preferred_username")
     display_name = token["userinfo"].get("name")
     if not email:
         errors.append("User profile error: No email provided in OIDC userinfo.")

--- a/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
+++ b/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
@@ -1,15 +1,11 @@
 import requests
-from mlflow_oidc_auth.config import config
 
 def get_user_groups(access_token):
     graph_url="https://graph.microsoft.com/v1.0/me/memberOf"
     headers={
-        "Authorization":f"Bearer{access_token}",
+        "Authorization":f"Bearer {access_token}",
         "Content-Type":"application/json",
     }
-
-    # Initialize an empty list to hold all groups
-    all_groups=[]
 
     while graph_url:
         # Make the request to get the user's groups

--- a/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
+++ b/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
@@ -1,24 +1,28 @@
 import requests
 
+
 def get_user_groups(access_token):
-    graph_url="https://graph.microsoft.com/v1.0/me/memberOf"
-    headers={
-        "Authorization":f"Bearer {access_token}",
-        "Content-Type":"application/json",
+    graph_url = "https://graph.microsoft.com/v1.0/me/memberOf"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
     }
+    all_groups = []
 
     while graph_url:
-        # Make the request to get the user's groups
-        group_response=requests.get(graph_url,headers=headers)
+        # Make the request to get the user's groups
+        group_response = requests.get(graph_url, headers=headers)
 
-        # Check if the response is successful
+        # Check if the response is successful
         if not group_response.ok:
             raise Exception(f"Error retrieving user groups: {group_response.status_code}-{group_response.text}")
 
-        # Parse the response JSON
-        group_data=group_response.json()
+        # Parse the response JSON
+        group_data = group_response.json()
 
-        # Check for more pages of results
-        graph_url=group_data.get('@odata.nextLink')
+        # accumulate group_data["value"] from each page in the loop and the dedupe before returning
+        all_groups.extend(group_data["value"])
+        # Check for more pages of results
+        graph_url = group_data.get("@odata.nextLink")
 
-    return list(dict.fromkeys([group["displayName"] for group in group_data["value"] if group.get("displayName") is not None]))
+    return list(dict.fromkeys([group["displayName"] for group in all_groups if group.get("displayName") is not None]))

--- a/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
+++ b/mlflow_oidc_auth/plugins/group_detection_microsoft_entra_id/__init__.py
@@ -1,14 +1,28 @@
 import requests
-
+from mlflow_oidc_auth.config import config
 
 def get_user_groups(access_token):
-    graph_url = "https://graph.microsoft.com/v1.0/me/memberOf"
-    group_response = requests.get(
-        graph_url,
-        headers={
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json",
-        },
-    )
-    group_data = group_response.json()
+    graph_url="https://graph.microsoft.com/v1.0/me/memberOf"
+    headers={
+        "Authorization":f"Bearer{access_token}",
+        "Content-Type":"application/json",
+    }
+
+    # Initialize an empty list to hold all groups
+    all_groups=[]
+
+    while graph_url:
+        # Make the request to get the user's groups
+        group_response=requests.get(graph_url,headers=headers)
+
+        # Check if the response is successful
+        if not group_response.ok:
+            raise Exception(f"Error retrieving user groups: {group_response.status_code}-{group_response.text}")
+
+        # Parse the response JSON
+        group_data=group_response.json()
+
+        # Check for more pages of results
+        graph_url=group_data.get('@odata.nextLink')
+
     return list(dict.fromkeys([group["displayName"] for group in group_data["value"] if group.get("displayName") is not None]))

--- a/mlflow_oidc_auth/tests/test_auth.py
+++ b/mlflow_oidc_auth/tests/test_auth.py
@@ -255,10 +255,10 @@ class TestAuth:
         assert "No email provided" in str(errors)
         assert "No display name provided" in str(errors)
 
-    def test_handle_userinfo_missing_field_email_but_has_prefered_username_success(self):
+    def test_handle_userinfo_missing_field_email_but_has_preferred_username_success(self):
         from mlflow_oidc_auth.auth import handle_user_and_group_management
 
-        token = {"userinfo": {"name": "Test Tes", "preferred_username": "techaccount@example.net"}, "access_token": "token"}
+        token = {"userinfo": {"name": "Test Tes", "preferred_username": "techaccount@example.net", "groups": ["users"]}, "access_token": "token"}
         config = importlib.import_module("mlflow_oidc_auth.config").config
         config.OIDC_GROUP_DETECTION_PLUGIN = None
         config.OIDC_GROUPS_ATTRIBUTE = "groups"

--- a/mlflow_oidc_auth/tests/test_auth.py
+++ b/mlflow_oidc_auth/tests/test_auth.py
@@ -255,6 +255,25 @@ class TestAuth:
         assert "No email provided" in str(errors)
         assert "No display name provided" in str(errors)
 
+    def test_handle_userinfo_missing_field_email_but_has_prefered_username_success(self):
+        from mlflow_oidc_auth.auth import handle_user_and_group_management
+
+        token = {"userinfo": {"name": "Test Tes", "preferred_username": "techaccount@example.net"}, "access_token": "token"}
+        config = importlib.import_module("mlflow_oidc_auth.config").config
+        config.OIDC_GROUP_DETECTION_PLUGIN = None
+        config.OIDC_GROUPS_ATTRIBUTE = "groups"
+        config.OIDC_ADMIN_GROUP_NAME = "admin"
+        config.OIDC_GROUP_NAME = ["users"]
+
+        with patch("mlflow_oidc_auth.auth.create_user") as mock_create, patch("mlflow_oidc_auth.auth.populate_groups") as mock_populate, patch(
+            "mlflow_oidc_auth.auth.update_user"
+        ) as mock_update, patch("mlflow_oidc_auth.auth.app"):
+            errors = handle_user_and_group_management(token)
+            assert errors == []
+            mock_create.assert_called_once()
+            mock_populate.assert_called_once()
+            mock_update.assert_called_once()
+
     def test_handle_user_and_group_management_unauthorized(self):
         from mlflow_oidc_auth.auth import handle_user_and_group_management
 


### PR DESCRIPTION
2 issue are identified when we test oidc-auth :
Issue when user from EntraID has a lot of group, we need browse all page with '@odata.nextLink'

Issue when user in EntraID with tech account from Onpremise AD, email is also retrieve from  "prefered_username" when email field is not setup from TechAccount in AD

This PR is to resolve them.

We test all use case locally with real ad , tenant etc and user and is okay