### PR TITLE
feat: add fortawesome css to package

### DIFF
--- a/web-ui/angular.json
+++ b/web-ui/angular.json
@@ -24,7 +24,7 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["./node_modules/@angular/material/prebuilt-themes/indigo-pink.css", "src/styles.scss"],
+            "styles": ["./node_modules/@angular/material/prebuilt-themes/indigo-pink.css", "src/styles.scss", "./node_modules/@fortawesome/fontawesome-svg-core/styles.css"],
             "scripts": []
           },
           "configurations": {


### PR DESCRIPTION
Because the fortawesome css is not included in the built package, web ui fetches it from the internet which is not possible for airgap installations. This change request adds the css to package itself so even with no internet access, the web ui works properly. 