### PR TITLE
fix: use pattern_id kwarg in registered model regex updates

### DIFF
--- a/mlflow_oidc_auth/views/group_registered_model_regex.py
+++ b/mlflow_oidc_auth/views/group_registered_model_regex.py
@@ -38,10 +38,10 @@ def get_group_registered_model_regex_permission(group_name: str, pattern_id: str
 
 @catch_mlflow_exception
 @check_admin_permission
-def update_group_registered_model_regex_permission(group_name: str, id: int):
+def update_group_registered_model_regex_permission(group_name: str, pattern_id: str):
     ep = store.update_group_registered_model_regex_permission(
         group_name=group_name,
-        id=id,
+        id=int(pattern_id),
         regex=get_request_param("regex"),
         priority=int(get_request_param("priority")),
         permission=get_request_param("permission"),
@@ -51,9 +51,9 @@ def update_group_registered_model_regex_permission(group_name: str, id: int):
 
 @catch_mlflow_exception
 @check_admin_permission
-def delete_group_registered_model_regex_permission(group_name: str, id: int):
+def delete_group_registered_model_regex_permission(group_name: str, pattern_id: str):
     store.delete_group_registered_model_regex_permission(
         group_name=group_name,
-        id=id,
+        id=int(pattern_id),
     )
     return jsonify({"status": "success"}), 200


### PR DESCRIPTION
Updating or deleting group regex registered model permissions is broken, raises the following error: 

```
│ app TypeError: update_group_registered_model_regex_permission() got an unexpected keyword argument 'pattern_id'  
```

I've tracked this down to inconsistency in the keyword argument for this function, which expects to receive `id` instead of `pattern_id`. 

`pattern_id` is specified as the appropriate kwarg in [the route](https://github.com/mlflow-oidc/mlflow-oidc-auth/blob/b904ce7642aa4ac6a8c56e1bdefc709964458155/mlflow_oidc_auth/routes.py#L67-L68) and is consistent with other functions that do work correctly like [updating/deleting group_experiment_regex functionality. ](https://github.com/mlflow-oidc/mlflow-oidc-auth/blob/b904ce7642aa4ac6a8c56e1bdefc709964458155/mlflow_oidc_auth/views/group_experiment_regex.py#L41-L62)

Thanks. 

Sam
