### PR TITLE
fix: convert `PERMANENT_SESSION_LIFETIME` to int

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -51,7 +51,7 @@ class AppConfig:
         self.SESSION_TYPE = os.environ.get("SESSION_TYPE", "cachelib")
         self.SESSION_PERMANENT = get_bool_env_variable("SESSION_PERMANENT", False)
         self.SESSION_KEY_PREFIX = os.environ.get("SESSION_KEY_PREFIX", "mlflow_oidc:")
-        self.PERMANENT_SESSION_LIFETIME = os.environ.get("PERMANENT_SESSION_LIFETIME", 86400)
+        self.PERMANENT_SESSION_LIFETIME = int(os.environ.get("PERMANENT_SESSION_LIFETIME", "86400"))
         if self.SESSION_TYPE:
             try:
                 session_module = importlib.import_module(f"mlflow_oidc_auth.session.{(self.SESSION_TYPE).lower()}")


### PR DESCRIPTION
Flask passes the `PERMANENT_SESSION_LIFETIME` value directly to `timedelta`, which needs to be an integer.

```
Traceback (most recent call last):
  File "/mlflow/.venv/lib/python3.12/site-packages/flask/app.py", line 941, in finalize_request
    response = self.process_response(response)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mlflow/.venv/lib/python3.12/site-packages/flask/app.py", line 1322, in process_response
    self.session_interface.save_session(self, ctx.session, response)
  File "/mlflow/.venv/lib/python3.12/site-packages/flask_session/base.py", line 305, in save_session
    self._upsert_session(app.permanent_session_lifetime, session, store_id)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mlflow/.venv/lib/python3.12/site-packages/flask/config.py", line 42, in __get__
    rv = self.get_converter(rv)
         ^^^^^^^^^^^^^^^^^^^^^^
  File "/mlflow/.venv/lib/python3.12/site-packages/flask/sansio/app.py", line 56, in _make_timedelta
    return timedelta(seconds=value)
           ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported type for timedelta seconds component: str
```