### PR TITLE
ci: migrate to PyCQA/bandit-action

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -11,10 +11,7 @@ jobs:
     name: Run bandit
     runs-on: ubuntu-latest
     steps:
-      - uses: mdegis/bandit-action@v1.0
+      - uses: PyCQA/bandit-action@v1.0.1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          path: "."
-          level: high
+          severity: high
           confidence: high
-          exit_zero: true


### PR DESCRIPTION
Closes #142

We would lose the PR comment feature, but this action uploads the SARIF report to CodeQL.