### PR TITLE
feat(security): allow cookie config override

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -52,6 +52,10 @@ class AppConfig:
         self.SESSION_PERMANENT = get_bool_env_variable("SESSION_PERMANENT", False)
         self.SESSION_KEY_PREFIX = os.environ.get("SESSION_KEY_PREFIX", "mlflow_oidc:")
         self.PERMANENT_SESSION_LIFETIME = os.environ.get("PERMANENT_SESSION_LIFETIME", 86400)
+        self.SESSION_COOKIE_NAME = os.environ.get("SESSION_COOKIE_NAME", "session")
+        self.SESSION_COOKIE_SECURE = get_bool_env_variable("SESSION_COOKIE_SECURE", False)
+        self.SESSION_COOKIE_SAMESITE = os.environ.get("SESSION_COOKIE_SAMESITE", None)
+        self.SESSION_COOKIE_PARTITIONED = get_bool_env_variable("SESSION_COOKIE_PARTITIONED", False)
         if self.SESSION_TYPE:
             try:
                 session_module = importlib.import_module(f"mlflow_oidc_auth.session.{(self.SESSION_TYPE).lower()}")


### PR DESCRIPTION
Add additional Flask [cookie configuration overrides](https://flask.palletsprojects.com/en/stable/config/#SESSION_COOKIE_NAME). The default values mirror Flask's defaults to maintain backward compatibility.