### PR TITLE
ci: allow bandit action to upload SARIF report

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -12,6 +12,8 @@ jobs:
   main:
     name: Run bandit
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: PyCQA/bandit-action@v1.0.1
         with:


### PR DESCRIPTION
Forgot to add the required permission; see https://github.com/PyCQA/bandit-action#usage