### PR TITLE
feat: add group names delimiter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,8 @@ The application can be configured through environment variables, dotenv files, o
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `OIDC_GROUP_NAME` | String | `mlflow` | Comma-separated list of allowed groups |
+| `OIDC_GROUP_NAME` | String | `mlflow` | List of allowed groups separated by the delimiter |
+| `OIDC_GROUP_NAME_DELIMITER` | String | `,` | Delimiter to separate groups in `OIDC_GROUP_NAME` |
 | `OIDC_ADMIN_GROUP_NAME` | String | `mlflow-admin` | Name of the admin group for full privileges |
 | `DEFAULT_MLFLOW_PERMISSION` | String | `MANAGE` | Default permission level for MLflow objects |
 | `PERMISSION_SOURCE_ORDER` | String | `user,group,regex,group-regex` | Order of precedence for permission resolution |

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -21,7 +21,7 @@ class AppConfig:
         self.DEFAULT_MLFLOW_PERMISSION = os.environ.get("DEFAULT_MLFLOW_PERMISSION", "MANAGE")
         self.SECRET_KEY = os.environ.get("SECRET_KEY", secrets.token_hex(16))
         self.OIDC_USERS_DB_URI = os.environ.get("OIDC_USERS_DB_URI", "sqlite:///auth.db")
-        self.OIDC_GROUP_NAME = [group.strip() for group in os.environ.get("OIDC_GROUP_NAME", "mlflow").split(",")]
+        self.OIDC_GROUP_NAME = [group.strip() for group in os.environ.get("OIDC_GROUP_NAME", "mlflow").split(os.environ.get("OIDC_GROUP_NAME_DELIMITER", ","))]
         self.OIDC_ADMIN_GROUP_NAME = os.environ.get("OIDC_ADMIN_GROUP_NAME", "mlflow-admin")
         self.OIDC_PROVIDER_DISPLAY_NAME = os.environ.get("OIDC_PROVIDER_DISPLAY_NAME", "Login with OIDC")
         self.OIDC_DISCOVERY_URL = os.environ.get("OIDC_DISCOVERY_URL", None)


### PR DESCRIPTION
feat: Have an option to use a custom group delimiter instead of just a comma. In Ping One, group names are returned with commas inside of them. _e.g._ Entire group name: `CN=mygroup1,OU=Groups,OU=Accounts,etc`.