### PR TITLE
fix: handle string OIDC attributes like Google hd (hosted domain)

### DIFF
--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -149,6 +149,9 @@ def handle_user_and_group_management(token) -> list[str]:
             user_groups = importlib.import_module(config.OIDC_GROUP_DETECTION_PLUGIN).get_user_groups(token["access_token"])
         else:
             user_groups = token["userinfo"][config.OIDC_GROUPS_ATTRIBUTE]
+        # Ensure user_groups is always a list (handles string attributes like 'hd')
+        if isinstance(user_groups, str):
+            user_groups = [user_groups]
     except Exception as e:
         logger.error(f"Group detection error: {str(e)}")
         errors.append("Group detection error: Failed to get user groups")


### PR DESCRIPTION
## Problem

When using `OIDC_GROUPS_ATTRIBUTE` with attributes that return a **string** instead of a list (e.g., Google's `hd` attribute for hosted domain), the code was iterating over each character of the string, creating individual group entries for each character.

For example, with `OIDC_GROUPS_ATTRIBUTE=hd` and domain `gupy.com.br`, the groups table would be populated with:
| id | group_name |
|----|------------|
| 1  | c          |
| 2  | o          |
| 3  | m          |
| 4  | p          |
| 5  | a          |
| 6  | n          |
| 7  | y          |
| ...| ...        |

## Solution

This fix ensures `user_groups` is always converted to a list before being passed to `populate_groups()` and `update_user()`, preventing the character-by-character iteration issue.

## Changes

- Added type check in `auth.py` to convert string attributes to a single-element list

## Testing

Tested with Google OIDC provider using `hd` (hosted domain) as the groups attribute.