### PR TITLE
ci: configure CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '18 4 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+        
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mlflow-oidc-auth
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI Downloads](https://static.pepy.tech/badge/mlflow-oidc-auth/month)](https://pepy.tech/projects/mlflow-oidc-auth)
-[![CodeQL](https://github.com/felipeolifre/mlflow-oidc-auth/actions/workflows/codeql.yml/badge.svg)](https://github.com/felipeolifre/mlflow-oidc-auth/actions/workflows/codeql.yml)
+[![CodeQL](https://github.com/mlflow-oidc/mlflow-oidc-auth/actions/workflows/codeql.yml/badge.svg)](https://github.com/mlflow-oidc/mlflow-oidc-auth/actions/workflows/codeql.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mlflow-oidc/mlflow-oidc-auth)
 
 MLflow auth plugin to use OpenID Connect (OIDC) as authentication and authorization provider.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mlflow-oidc-auth
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PyPI Downloads](https://static.pepy.tech/badge/mlflow-oidc-auth/month)](https://pepy.tech/projects/mlflow-oidc-auth)
+[![CodeQL](https://github.com/felipeolifre/mlflow-oidc-auth/actions/workflows/codeql.yml/badge.svg)](https://github.com/felipeolifre/mlflow-oidc-auth/actions/workflows/codeql.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mlflow-oidc/mlflow-oidc-auth)
 
 MLflow auth plugin to use OpenID Connect (OIDC) as authentication and authorization provider.


### PR DESCRIPTION
Since this is a public project, I suggest onboarding GitHub's native CodeQL scans and making their status visible as a banner in `README.md`

To see what the banner would look like, you can check my fork's readme: https://github.com/felipeolifre/mlflow-oidc-auth