### PR TITLE
feat: open telemetry request passthrough

### DIFF
--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -44,6 +44,9 @@ app.add_url_rule(rule=routes.LOGIN, methods=["GET"], view_func=views.login)
 app.add_url_rule(rule=routes.LOGOUT, methods=["GET"], view_func=views.logout)
 app.add_url_rule(rule=routes.CALLBACK, methods=["GET"], view_func=views.callback)
 
+# MLflow Tracing OTLP ingest (machine-to-machine; authenticated via basic/bearer/session)
+app.add_url_rule(rule=routes.OTLP_TRACES, methods=["POST"], view_func=views.ingest_otlp_traces)
+
 # UI routes
 app.add_url_rule(rule=routes.STATIC, methods=["GET"], view_func=views.oidc_static)
 app.add_url_rule(rule=routes.UI, methods=["GET"], view_func=views.oidc_ui)

--- a/mlflow_oidc_auth/routes.py
+++ b/mlflow_oidc_auth/routes.py
@@ -5,6 +5,9 @@ LOGIN = "/login"
 LOGOUT = "/logout"
 CALLBACK = "/callback"
 
+# OTLP ingest endpoints (MLflow Tracing)
+OTLP_TRACES = "/v1/traces"
+
 STATIC = "/oidc/static/<path:filename>"
 UI = "/oidc/ui/<path:filename>"
 UI_ROOT = "/oidc/ui/"

--- a/mlflow_oidc_auth/tests/hooks/test_before_request.py
+++ b/mlflow_oidc_auth/tests/hooks/test_before_request.py
@@ -66,6 +66,16 @@ def test_session_redirect(client):
             assert response.location.endswith("/login")  # type: ignore
 
 
+def test_otlp_ingest_no_auth_returns_401(client):
+    """OTLP ingest endpoints must not redirect or render HTML when auth is missing."""
+    with app.test_request_context(path="/v1/traces", method="POST"):
+        session.clear()
+        with patch("mlflow_oidc_auth.hooks.before_request.config.AUTOMATIC_LOGIN_REDIRECT", True):
+            response = before_request_hook()
+            assert response is not None
+            assert response.status_code == 401  # type: ignore
+
+
 def test_authorization_failure(client):
     with app.test_request_context(path="/protected", method="GET"):
         with patch("mlflow_oidc_auth.hooks.before_request.get_is_admin", return_value=False), patch(

--- a/mlflow_oidc_auth/tests/test_otlp.py
+++ b/mlflow_oidc_auth/tests/test_otlp.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from mlflow_oidc_auth.views.otlp import ingest_otlp_traces
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.secret_key = "test_secret_key"
+    return app
+
+
+def test_ingest_otlp_traces_requires_experiment_header(app):
+    with app.test_request_context(path="/v1/traces", method="POST", data=b""):
+        resp = ingest_otlp_traces()
+        assert resp.status_code == 400
+
+
+@patch("mlflow_oidc_auth.views.otlp._get_tracking_store")
+@patch("mlflow_oidc_auth.views.otlp.Span")
+@patch("mlflow_oidc_auth.views.otlp.ExportTraceServiceRequest")
+@patch("mlflow_oidc_auth.views.otlp.get_username", return_value="user@example.com")
+@patch("mlflow_oidc_auth.views.otlp.effective_experiment_permission")
+def test_ingest_otlp_traces_logs_spans(
+    mock_effective_perm,
+    _mock_get_username,
+    mock_export_req_cls,
+    mock_span_cls,
+    mock_get_store,
+    app,
+):
+    # Permission allows update
+    mock_effective_perm.return_value = MagicMock(permission=MagicMock(can_update=True, can_manage=False))
+
+    # Fake OTLP request containing one span
+    fake_span = MagicMock()
+    fake_scope_spans = MagicMock(spans=[fake_span])
+    fake_resource_spans = MagicMock(scope_spans=[fake_scope_spans])
+
+    mock_export_req = MagicMock()
+    mock_export_req.resource_spans = [fake_resource_spans]
+    mock_export_req_cls.return_value = mock_export_req
+
+    # Span.from_otel_proto returns a "mlflow span" object
+    mlflow_span_obj = MagicMock()
+    mock_span_cls.from_otel_proto.return_value = mlflow_span_obj
+
+    # Tracking store mock
+    store = MagicMock()
+    mock_get_store.return_value = store
+
+    with app.test_request_context(
+        path="/v1/traces",
+        method="POST",
+        headers={"x-mlflow-experiment-id": "23"},
+        data=b"ignored",
+    ):
+        resp = ingest_otlp_traces()
+
+    assert resp.status_code == 200
+    mock_span_cls.from_otel_proto.assert_called_once_with(fake_span, location_id="23")
+    store.log_spans.assert_called_once()
+
+

--- a/mlflow_oidc_auth/tests/test_routes.py
+++ b/mlflow_oidc_auth/tests/test_routes.py
@@ -17,6 +17,8 @@ class TestRoutes:
                 routes.LOGIN,
                 routes.LOGOUT,
                 routes.CALLBACK,
+                # OTLP ingest
+                routes.OTLP_TRACES,
                 routes.STATIC,
                 routes.UI,
                 routes.UI_ROOT,

--- a/mlflow_oidc_auth/views/__init__.py
+++ b/mlflow_oidc_auth/views/__init__.py
@@ -9,6 +9,7 @@ from mlflow_oidc_auth.views.group_prompt import *
 from mlflow_oidc_auth.views.group_prompt_regex import *
 from mlflow_oidc_auth.views.group_registered_model import *
 from mlflow_oidc_auth.views.group_registered_model_regex import *
+from mlflow_oidc_auth.views.otlp import *
 from mlflow_oidc_auth.views.prompt import *
 from mlflow_oidc_auth.views.prompt_regex import *
 from mlflow_oidc_auth.views.registered_model import *

--- a/mlflow_oidc_auth/views/otlp.py
+++ b/mlflow_oidc_auth/views/otlp.py
@@ -1,0 +1,113 @@
+import gzip
+import zlib
+
+from flask import Response, jsonify, request
+
+from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.responses.client_error import make_forbidden_response
+from mlflow_oidc_auth.utils.permissions import effective_experiment_permission
+from mlflow_oidc_auth.utils.request_helpers import get_username
+
+logger = get_logger()
+
+
+def _decompress_otlp_body(raw_body: bytes, content_encoding: str | None) -> bytes:
+    """
+    Decompress an OTLP/HTTP protobuf request body according to Content-Encoding.
+
+    Supported encodings:
+    - gzip
+    - deflate (RFC-compliant and raw deflate)
+    """
+    enc = (content_encoding or "").strip().lower()
+    if not enc:
+        return raw_body
+
+    if enc == "gzip":
+        return gzip.decompress(raw_body)
+    if enc == "deflate":
+        try:
+            return zlib.decompress(raw_body)
+        except Exception:
+            # Try raw DEFLATE stream (some clients send this)
+            return zlib.decompress(raw_body, -zlib.MAX_WBITS)
+
+    raise ValueError(f"Unsupported Content-Encoding: {enc}")
+
+
+def ingest_otlp_traces() -> Response:
+    """
+    OTLP traces ingest endpoint for MLflow Tracing.
+
+    This endpoint is required by MLflow's TracingClient.log_spans(), which posts OTLP protobuf payloads
+    to /v1/traces with an x-mlflow-experiment-id header.
+
+    Auth is handled by the global before_request hook (basic/bearer/session). This handler also enforces
+    per-experiment permissions based on the authenticated user.
+    """
+    try:
+        # Import lazily so environments without full tracing deps still start up (endpoint will 500 if hit).
+        from mlflow.entities.span import Span
+        from mlflow.server.handlers import _get_tracking_store
+        from mlflow.store.tracking.rest_store import ExportTraceServiceRequest, MLFLOW_EXPERIMENT_ID_HEADER
+    except Exception as e:
+        logger.error(f"Failed to import MLflow tracing components: {e}")
+        return Response("Tracing ingest is not available on this server.", status=501, mimetype="text/plain")
+
+    experiment_id = request.headers.get(MLFLOW_EXPERIMENT_ID_HEADER) or request.headers.get("x-mlflow-experiment-id")
+    if not experiment_id:
+        return Response(
+            "Missing required header: x-mlflow-experiment-id",
+            status=400,
+            mimetype="text/plain",
+        )
+
+    # Permission check: require at least update permission on the experiment.
+    try:
+        username = get_username()
+        perm = effective_experiment_permission(str(experiment_id), username).permission
+        if not (perm.can_update or perm.can_manage):
+            return make_forbidden_response({"message": "Permission denied for trace ingestion"})
+    except Exception as e:
+        logger.warning(f"Permission check failed for OTLP ingest: {e}")
+        return make_forbidden_response({"message": "Permission denied for trace ingestion"})
+
+    raw_body = request.get_data(cache=False) or b""
+    try:
+        body = _decompress_otlp_body(raw_body, request.headers.get("Content-Encoding"))
+    except Exception as e:
+        return Response(f"Invalid OTLP payload encoding: {e}", status=400, mimetype="text/plain")
+
+    otlp_req = ExportTraceServiceRequest()
+    try:
+        otlp_req.ParseFromString(body)
+    except Exception as e:
+        return Response(f"Invalid OTLP protobuf payload: {e}", status=400, mimetype="text/plain")
+
+    mlflow_spans = []
+    try:
+        for resource_spans in otlp_req.resource_spans:
+            for scope_spans in resource_spans.scope_spans:
+                for otel_span in scope_spans.spans:
+                    # location_id is used for V4 trace IDs; for OSS it is the experiment_id.
+                    mlflow_spans.append(Span.from_otel_proto(otel_span, location_id=str(experiment_id)))
+    except Exception as e:
+        logger.warning(f"Failed to translate OTLP spans to MLflow spans: {e}")
+        return Response("Failed to parse OTLP spans.", status=400, mimetype="text/plain")
+
+    # Persist spans in MLflow tracking store.
+    try:
+        store = _get_tracking_store()
+        try:
+            store.log_spans(location=str(experiment_id), spans=mlflow_spans, tracking_uri=None)
+        except TypeError:
+            # Older/alternative store implementations may not accept tracking_uri kwarg.
+            store.log_spans(location=str(experiment_id), spans=mlflow_spans)
+    except Exception as e:
+        logger.error(f"Failed to persist OTLP spans: {e}")
+        return Response("Failed to log spans.", status=500, mimetype="text/plain")
+
+    # OTLP ExportTraceServiceResponse is an empty message; clients only require 200.
+    return Response(b"", status=200, content_type="application/x-protobuf")
+
+


### PR DESCRIPTION
I ran into an issue when attempting to implement manual Tracing for my MLFlow 3.7.0 server. I realized that this plugin was not passing through requests to the OTLP server (for `/v1/traces`) which was preventing me from being able to manually log spans to an ongoing trace easily.

This might be helpful to get merged in since I imagine other people might run into this issue in the future as well.

-- Auto generated summary --
This pull request adds support for ingesting OTLP trace data (for MLflow Tracing) via a new authenticated endpoint, along with robust permission checks, decompression handling, and comprehensive testing. It ensures that machine-to-machine OTLP requests are handled securely and do not receive HTML or redirects on authentication failure.

**OTLP Trace Ingest Endpoint Implementation**

* Added a new `/v1/traces` POST endpoint (`OTLP_TRACES`) to receive OTLP trace data, with implementation in `views/otlp.py` and route registration in `app.py` and `routes.py`. [[1]](diffhunk://#diff-0447688e1f8846d9b58aac7ae306a53666c310009ed0650d9460168eb38bee30R1-R113) [[2]](diffhunk://#diff-32158a58b8195d542d9453cac9f927e0f748216fb7c3113681df35a604a9a78bR47-R49) [[3]](diffhunk://#diff-0b31ae5512b5b707fa2dcc85118152eb0e83caa4fef985e774e8f829a6b12092R8-R10) [[4]](diffhunk://#diff-090a37017a8fe609e4dc59ac80b97b01f3d5b6c863420fc03c5ed37c241e848bR12)
* The endpoint decompresses incoming payloads based on `Content-Encoding`, parses OTLP protobuf payloads, checks experiment-level permissions, translates OTLP spans to MLflow spans, and persists them in the MLflow tracking store.
* Returns appropriate status codes for missing headers, permission errors, encoding issues, and internal errors, always responding with plain text or protobuf (never HTML) for machine-to-machine clients.

**Authentication and Authorization Adjustments**

* Updated the `before_request` hook to recognize OTLP ingest endpoints and ensure they never return redirects or HTML on missing authentication, returning plain 401/403 responses instead. [[1]](diffhunk://#diff-6bf1d79849d46580212df0794b2cd48170ea333fb7fd3a523bb3c265e6e7ea5eR100-R103) [[2]](diffhunk://#diff-6bf1d79849d46580212df0794b2cd48170ea333fb7fd3a523bb3c265e6e7ea5eR344-R349)

**Testing Enhancements**

* Added new tests for the OTLP ingest endpoint, including permission checks, header validation, and span logging, as well as tests to ensure correct authentication error handling for OTLP routes. [[1]](diffhunk://#diff-ae289943b1f6010b16997ba5ec7b251c3f4c3c87018f6ea5c995575adac71c85R1-R67) [[2]](diffhunk://#diff-8751961e9a69313669e014d5117405d626860467ca5f3e844b000f11184674e5R69-R78)
* Updated route tests to include the new OTLP endpoint.