### PR TITLE
fix: uri-encode group names

### DIFF
--- a/web-react/src/core/configs/api-endpoints.ts
+++ b/web-react/src/core/configs/api-endpoints.ts
@@ -58,31 +58,31 @@ export const DYNAMIC_API_ENDPOINTS = {
 
   // Group permissions for resources
   GROUP_EXPERIMENT_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/experiments`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/experiments`,
   GROUP_EXPERIMENT_PERMISSION: (groupName: string, experimentId: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/experiments/${experimentId}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/experiments/${experimentId}`,
   GROUP_MODEL_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/registered-models`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/registered-models`,
   GROUP_MODEL_PERMISSION: (groupName: string, modelName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/registered-models/${modelName}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/registered-models/${modelName}`,
   GROUP_PROMPT_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/prompts`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/prompts`,
   GROUP_PROMPT_PERMISSION: (groupName: string, promptName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/prompts/${promptName}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/prompts/${promptName}`,
 
   // Group pattern permissions
   GROUP_EXPERIMENT_PATTERN_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/experiment-patterns`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/experiment-patterns`,
   GROUP_EXPERIMENT_PATTERN_PERMISSION: (groupName: string, patternId: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/experiment-patterns/${patternId}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/experiment-patterns/${patternId}`,
   GROUP_MODEL_PATTERN_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/registered-models-patterns`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/registered-models-patterns`,
   GROUP_MODEL_PATTERN_PERMISSION: (groupName: string, patternId: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/registered-models-patterns/${patternId}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/registered-models-patterns/${patternId}`,
   GROUP_PROMPT_PATTERN_PERMISSIONS: (groupName: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/prompts-patterns`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/prompts-patterns`,
   GROUP_PROMPT_PATTERN_PERMISSION: (groupName: string, patternId: string) =>
-    `/api/2.0/mlflow/permissions/groups/${groupName}/prompts-patterns/${patternId}`,
+    `/api/2.0/mlflow/permissions/groups/${encodeURIComponent(groupName)}/prompts-patterns/${patternId}`,
 
   // Resource group permissions
   EXPERIMENT_GROUP_PERMISSIONS: (experimentId: string) =>

--- a/web-react/src/features/groups/groups-page.tsx
+++ b/web-react/src/features/groups/groups-page.tsx
@@ -32,7 +32,7 @@ export default function GroupsPage() {
   const renderPermissionsButton = (groupName: string) => (
     <div className="invisible group-hover:visible">
       <RowActionButton
-        entityId={`${groupName}/experiments`}
+        entityId={`${encodeURIComponent(groupName)}/experiments`}
         route="/groups"
         buttonText="Manage permissions"
       />

--- a/web-react/src/features/permissions/shared-permissions-page.tsx
+++ b/web-react/src/features/permissions/shared-permissions-page.tsx
@@ -84,7 +84,7 @@ export const SharedPermissionsPage = ({
           {tabs.map((tab) => (
             <Link
               key={tab.id}
-              to={`${baseRoute}/${entityName}/${tab.id}`}
+              to={`${baseRoute}/${encodeURIComponent(entityName)}/${tab.id}`}
               className={`py-2 px-4 border-b-2 font-medium text-sm transition-colors duration-200 ${
                 type === tab.id
                   ? "border-btn-primary text-btn-primary dark:border-btn-primary-dark dark:text-btn-primary-dark"


### PR DESCRIPTION
In our deployment (rel.: #187), we determine groups based on a roles that contain '#', which is a reserved URL characer (anchor). The frontend inserts group names directly into the frontend/API URLs, causing it to fail. This fix ensures they are encoded first.