### PR TITLE
feat: add the option disable TLS verification on OIDC provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ The application can be configured through environment variables, dotenv files, o
 | `OIDC_PROVIDER_DISPLAY_NAME` | String | `Login with OIDC` | Display name for the OIDC provider shown on the login page |
 | `OIDC_GROUPS_ATTRIBUTE` | String | `groups` | The attribute name in the ID token that contains user groups |
 | `OIDC_GROUP_DETECTION_PLUGIN` | String | None | Custom plugin for enhanced group detection |
+| `OIDC_VERIFY_SSL` | Boolean | `true` | Disable TLS verification for the OIDC provider |
 | `EXTEND_MLFLOW_MENU` | Boolean | `true` | Extend MLflow UI with OIDC management features |
 | `DEFAULT_LANDING_PAGE_IS_PERMISSIONS` | Boolean | `true` | Use the permissions page as the default landing page |
 

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -4,7 +4,6 @@ from authlib.jose.errors import BadSignatureError
 
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
-from mlflow_oidc_auth.user import create_user, populate_groups, update_user
 
 logger = get_logger()
 
@@ -24,13 +23,13 @@ def _get_oidc_jwks() -> dict:
 
     try:
         logger.debug("Fetching OIDC discovery metadata")
-        metadata = requests.get(config.OIDC_DISCOVERY_URL).json()
+        metadata = requests.get(config.OIDC_DISCOVERY_URL, verify=config.OIDC_VERIFY_SSL).json()
         jwks_uri = metadata.get("jwks_uri")
         if not jwks_uri:
             raise ValueError("No jwks_uri found in OIDC discovery metadata")
 
         logger.debug(f"Fetching JWKS from {jwks_uri}")
-        jwks = requests.get(jwks_uri).json()
+        jwks = requests.get(jwks_uri, verify=config.OIDC_VERIFY_SSL).json()
         return jwks
     except requests.exceptions.RequestException as e:
         logger.error(f"Failed to fetch OIDC JWKS: {e}")

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -74,6 +74,7 @@ class AppConfig:
         # OIDC provider settings
         self.OIDC_DISCOVERY_URL = config_manager.get("OIDC_DISCOVERY_URL")
         self.OIDC_CLIENT_ID = config_manager.get("OIDC_CLIENT_ID")
+        self.OIDC_VERIFY_SSL = config_manager.get_bool("OIDC_VERIFY_SSL", default=True)
         # OIDC_REDIRECT_URI: If not set, will be calculated dynamically based on request headers
         # This enables automatic proxy path detection for OIDC callbacks
         self.OIDC_REDIRECT_URI = config_manager.get("OIDC_REDIRECT_URI")

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -50,7 +50,7 @@ def ensure_oidc_client_registered() -> bool:
             client_id=config.OIDC_CLIENT_ID,
             client_secret=config.OIDC_CLIENT_SECRET,
             server_metadata_url=config.OIDC_DISCOVERY_URL,
-            client_kwargs={"scope": config.OIDC_SCOPE},
+            client_kwargs={"verify": config.OIDC_VERIFY_SSL, "scope": config.OIDC_SCOPE},
         )
         _oidc_client_registered = True
         return True


### PR DESCRIPTION
Optionally disable TLS verification on the OIDC provider. Useful for local development with self-signed certs 