### PR TITLE
feat: extend Starlette SessionMiddleware config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,15 @@ The plugin uses Starlette's built-in cookie-based sessions:
 - The cookie is signed with `SECRET_KEY` — all replicas **must** share the same key
 - Sessions survive server restarts only if `SECRET_KEY` is explicitly configured
 
+Additional session cookie settings:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SESSION_COOKIE_NAME` | String | `session` | Session cookie name |
+| `SESSION_COOKIE_MAX_AGE_SECONDS` | Integer | `1209600` (2 weeks) | Session expiry time in seconds, if set to `0` then the cookie will last as long as the browser session |
+| `SESSION_COOKIE_SAMESITE` | String | `lax` | SameSite flag prevents the browser from sending session cookie along with cross-site requests |
+| `SESSION_COOKIE_SECURE` | Boolean | `false` | Indicate that the "Secure" flag should be set (can be used with HTTPS only), set this to `true` in production to ensure the session cookie is only sent over HTTPS |
+
 ## MLflow Server Environment Variables
 
 MLflow natively supports environment variables for server configuration. These are not managed by the plugin but are commonly used alongside it:
@@ -148,6 +157,11 @@ OIDC_USERS_DB_URI=postgresql://mlflow:pass@db:5432/mlflow_auth
 
 # Explicit secret key for multi-replica deployments
 SECRET_KEY=your-random-64-char-hex-string
+
+# Secure session cookies
+SESSION_COOKIE_MAX_AGE_SECONDS=0
+SESSION_COOKIE_SAMESITE=strict
+SESSION_COOKIE_SECURE=true
 
 # Auto-redirect to OIDC login
 AUTOMATIC_LOGIN_REDIRECT=true

--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -151,7 +151,7 @@ def _include_mlflow_fastapi_routers(oidc_app: FastAPI) -> None:
         logger.debug("mlflow.server.assistant.api not available — Assistant endpoints disabled")
 
 
-def create_app() -> Any:
+def create_app() -> FastAPI:
     """Create a FastAPI application with OIDC integration.
 
     The app uses a lifespan context manager to ensure OIDC client registration

--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -181,7 +181,14 @@ def create_app() -> Any:
     oidc_app.add_middleware(ProxyHeadersMiddleware)
     oidc_app.add_middleware(AuthMiddleware)
     oidc_app.add_middleware(WorkspaceContextMiddleware)
-    oidc_app.add_middleware(StarletteSessionMiddleware, secret_key=config.SECRET_KEY)
+    oidc_app.add_middleware(
+        StarletteSessionMiddleware,
+        secret_key=config.SECRET_KEY,
+        session_cookie=config.SESSION_COOKIE_NAME,
+        max_age=config.SESSION_COOKIE_MAX_AGE_SECONDS,
+        same_site=config.SESSION_COOKIE_SAMESITE,
+        https_only=config.SESSION_COOKIE_SECURE,
+    )
 
     for router in get_all_routers():
         oidc_app.include_router(router)

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -76,6 +76,15 @@ class AppConfig:
         self.SECRET_KEY = _secret_key
         self.OIDC_CLIENT_SECRET = config_manager.get("OIDC_CLIENT_SECRET")
 
+        # Session cookie settings
+        self.SESSION_COOKIE_NAME = config_manager.get("SESSION_COOKIE_NAME", "session")
+        self.SESSION_COOKIE_MAX_AGE_SECONDS = config_manager.get_int("SESSION_COOKIE_MAX_AGE_SECONDS", default=14 * 24 * 60 * 60) or None
+        _session_cookie_samesite = config_manager.get("SESSION_COOKIE_SAMESITE", "lax").lower()
+        if _session_cookie_samesite not in {"lax", "strict", "none"}:
+            raise ValueError(f"Invalid SESSION_COOKIE_SAMESITE value: '{_session_cookie_samesite}'")
+        self.SESSION_COOKIE_SAMESITE = _session_cookie_samesite
+        self.SESSION_COOKIE_SECURE = config_manager.get_bool("SESSION_COOKIE_SECURE", default=False)
+
         # Database settings (sensitive)
         self.OIDC_USERS_DB_URI = config_manager.get("OIDC_USERS_DB_URI", "sqlite:///auth.db")
 

--- a/mlflow_oidc_auth/tests/test_app.py
+++ b/mlflow_oidc_auth/tests/test_app.py
@@ -9,6 +9,7 @@ error handler registration, and application startup/shutdown procedures.
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware as StarletteSessionMiddleware
 
 from mlflow_oidc_auth.app import create_app
 
@@ -683,3 +684,43 @@ class TestAppConfiguration:
 
                 # Verify secret key is set correctly
                 assert mock_flask_app.secret_key == secret_key
+
+    @patch("mlflow_oidc_auth.app.config")
+    @patch("mlflow_oidc_auth.app.register_exception_handlers")
+    @patch("mlflow_oidc_auth.app.get_all_routers")
+    @patch("mlflow_oidc_auth.app.AuthMiddleware")
+    @patch("mlflow_oidc_auth.app.AuthAwareWSGIMiddleware")
+    @patch("mlflow_oidc_auth.app.app")
+    @patch("mlflow_oidc_auth.app.before_request_hook")
+    @patch("mlflow_oidc_auth.app.after_request_hook")
+    def test_create_app_with_session_middleware_config(
+        self,
+        mock_after,
+        mock_before,
+        mock_flask_app,
+        mock_wsgi,
+        mock_auth,
+        mock_get_all_routers,
+        mock_register,
+        mock_config,
+    ):
+        """Starlette SessionMiddleware should be configured with correct parameters from config."""
+        mock_config.SECRET_KEY = "test-secret"
+        mock_config.EXTEND_MLFLOW_MENU = False
+        mock_config.MLFLOW_ENABLE_WORKSPACES = False
+        mock_config.SESSION_COOKIE_NAME = "my_session"
+        mock_config.SESSION_COOKIE_MAX_AGE_SECONDS = 3600
+        mock_config.SESSION_COOKIE_SAMESITE = "strict"
+        mock_config.SESSION_COOKIE_SECURE = True
+        mock_get_all_routers.return_value = []
+
+        result = create_app()
+        middleware = next(m for m in result.user_middleware if m.cls == StarletteSessionMiddleware)
+        assert middleware is not None, "SessionMiddleware not found in app middleware stack"
+
+        kwargs = middleware.kwargs
+        assert kwargs["secret_key"] == "test-secret"
+        assert kwargs["session_cookie"] == "my_session"
+        assert kwargs["max_age"] == 3600
+        assert kwargs["same_site"] == "strict"
+        assert kwargs["https_only"] is True

--- a/mlflow_oidc_auth/tests/test_config.py
+++ b/mlflow_oidc_auth/tests/test_config.py
@@ -102,6 +102,10 @@ class TestAppConfig(unittest.TestCase):
             "PERMISSION_SOURCE_ORDER",
             "EXTEND_MLFLOW_MENU",
             "DEFAULT_LANDING_PAGE_IS_PERMISSIONS",
+            "SESSION_COOKIE_NAME",
+            "SESSION_COOKIE_MAX_AGE_SECONDS",
+            "SESSION_COOKIE_SAMESITE",
+            "SESSION_COOKIE_SECURE",
         ]
 
         for var in env_vars_to_clear:
@@ -346,6 +350,43 @@ class TestAppConfig(unittest.TestCase):
                 config = AppConfig()
                 mock_logger.warning.assert_not_called()
                 self.assertEqual(config.SECRET_KEY, "my-production-secret")
+
+    def test_session_cookie_defaults(self):
+        """Test that session cookie settings have correct default values."""
+        config = AppConfig()
+        self.assertEqual(config.SESSION_COOKIE_NAME, "session")
+        self.assertEqual(config.SESSION_COOKIE_MAX_AGE_SECONDS, 14 * 24 * 60 * 60)
+        self.assertEqual(config.SESSION_COOKIE_SAMESITE, "lax")
+        self.assertFalse(config.SESSION_COOKIE_SECURE)
+
+    def test_session_cookie_env_overrides(self):
+        """SESSION_COOKIE_* env vars are picked up correctly."""
+        with patch.dict(
+            os.environ,
+            {
+                "SESSION_COOKIE_NAME": "mlflow_auth",
+                "SESSION_COOKIE_MAX_AGE_SECONDS": "3600",
+                "SESSION_COOKIE_SAMESITE": "strict",
+                "SESSION_COOKIE_SECURE": "true",
+            },
+        ):
+            config = AppConfig()
+            self.assertEqual(config.SESSION_COOKIE_NAME, "mlflow_auth")
+            self.assertEqual(config.SESSION_COOKIE_MAX_AGE_SECONDS, 3600)
+            self.assertEqual(config.SESSION_COOKIE_SAMESITE, "strict")
+            self.assertTrue(config.SESSION_COOKIE_SECURE)
+
+    def test_session_cookie_samesite_invalid_raises(self):
+        """An invalid SESSION_COOKIE_SAMESITE value raises ValueError."""
+        with patch.dict(os.environ, {"SESSION_COOKIE_SAMESITE": "invalid"}):
+            with self.assertRaises(ValueError):
+                AppConfig()
+
+    def test_session_cookie_max_age_zero_becomes_none(self):
+        """SESSION_COOKIE_MAX_AGE_SECONDS=0 is treated as no expiry (None)."""
+        with patch.dict(os.environ, {"SESSION_COOKIE_MAX_AGE_SECONDS": "0"}):
+            config = AppConfig()
+            self.assertIsNone(config.SESSION_COOKIE_MAX_AGE_SECONDS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow users to [configure Starlette SessionMiddleware](https://www.starlette.dev/middleware/#sessionmiddleware) cookies. The default values mirror Starlette's default to maintain the existing behavior.