### PR TITLE
fix: permission denied for non-admins

### DIFF
--- a/mlflow_oidc_auth/validators/stuff.py
+++ b/mlflow_oidc_auth/validators/stuff.py
@@ -128,13 +128,13 @@ def validate_gateway_proxy(username: str) -> bool:
     def _extract_gateway_name():
         # Try query params first
         if request.args:
-            for key in ("gateway_name", "gateway", "name", "target"):
+            for key in ("gateway_name", "gateway", "name", "target", "gateway_path"):
                 if key in request.args:
                     return request.args.get(key)
         # Try JSON body
         if request.is_json:
             data = request.get_json(silent=True) or {}
-            for key in ("gateway_name", "gateway", "name", "target"):
+            for key in ("gateway_name", "gateway", "name", "target", "gateway_path"):
                 if key in data:
                     return data.get(key)
         return None


### PR DESCRIPTION
For non-admin users, workspace enabled I am seeing the following "Permission Denied" message in the UI that does not seem relevant to anything. I believe it comes from incorrectly extracting the gateway name.

<img width="1233" height="975" alt="image" src="https://github.com/user-attachments/assets/47c5f2f2-338d-4a9e-a997-c648535b0946" />
