### PR TITLE
fix: get experiment-id for workspace enabled paths

### DIFF
--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -31,6 +31,7 @@ _EXPERIMENT_ID_PATTERN = re.compile(r"^(\d+)/")
 # where the workspace name can be alphanumeric with an optional single hyphen.
 _WORKSPACES_EXPERIMENT_ID_PATTERN = re.compile(r"^(workspaces)/([\w-]+)/(\d+)/")
 
+
 def _get_experiment_id_from_view_args():
     # The artifact proxy routes encode experiment_id as the first path segment
     # of the artifact_path (e.g. "123/artifacts/model.pkl").  This cannot be
@@ -41,7 +42,7 @@ def _get_experiment_id_from_view_args():
     if view_args is not None and (artifact_path := view_args.get("artifact_path")):
         if m := _EXPERIMENT_ID_PATTERN.match(artifact_path):
             return m.group(1)
-        if m:= _WORKSPACES_EXPERIMENT_ID_PATTERN.match(artifact_path):
+        if m := _WORKSPACES_EXPERIMENT_ID_PATTERN.match(artifact_path):
             # Group 1: workspace, Group 2: {workspace_name}, Group 3: experiment-id
             return m.group(3)
     return None

--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -27,7 +27,9 @@ def _get_permission_from_experiment_name(username: str) -> Permission:
 
 
 _EXPERIMENT_ID_PATTERN = re.compile(r"^(\d+)/")
-
+# Workspace paths are structured: workspaces/{workspace-name}/{experiment-id}/...
+# where the workspace name can be alphanumeric with an optional single hyphen.
+_WORKSPACES_EXPERIMENT_ID_PATTERN = re.compile(r"^(workspaces)/([\w-]+)/(\d+)/")
 
 def _get_experiment_id_from_view_args():
     # The artifact proxy routes encode experiment_id as the first path segment
@@ -39,6 +41,9 @@ def _get_experiment_id_from_view_args():
     if view_args is not None and (artifact_path := view_args.get("artifact_path")):
         if m := _EXPERIMENT_ID_PATTERN.match(artifact_path):
             return m.group(1)
+        if m:= _WORKSPACES_EXPERIMENT_ID_PATTERN.match(artifact_path):
+            # Group 1: workspace, Group 2: {workspace_name}, Group 3: experiment-id
+            return m.group(3)
     return None
 
 


### PR DESCRIPTION
I ran into this same issue - https://github.com/mlflow-oidc/mlflow-oidc-auth/issues/236.

The original regex expects the experiment-id to be the first value in the artifact path e.g.

```
{experiment-id}/{other information}...
```
When workspaces are enabled the path changes to 
```
workspaces/{workspace-name}/{experiment-id}/..
```