### PR TITLE
fix: improve auth-failure diagnostics

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -83,7 +83,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             else:
                 return False, None, "Invalid basic auth credentials"
         except Exception as e:
-            logger.error("Basic auth error: %s", type(e).__name__)
+            logger.error("Basic auth error: %s: %s", type(e).__name__, e, exc_info=True)
             return False, None, "Invalid basic auth format"
 
     async def _authenticate_bearer_token(self, auth_header: str) -> Tuple[bool, Optional[str], str]:
@@ -107,7 +107,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             else:
                 return False, None, "Invalid token payload"
         except Exception as e:
-            logger.error("Bearer auth error: %s", type(e).__name__)
+            logger.error("Bearer auth error: %s: %s", type(e).__name__, e, exc_info=True)
             return False, None, "Invalid token"
 
     async def _authenticate_session(self, request: Request) -> Tuple[bool, Optional[str], str]:

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -83,7 +83,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             else:
                 return False, None, "Invalid basic auth credentials"
         except Exception as e:
-            logger.error("Basic auth error: %s: %s", type(e).__name__, e, exc_info=True)
+            logger.warning("Basic auth error: %s: %s", type(e).__name__, e)
+            logger.debug("Basic auth error traceback", exc_info=True)
             return False, None, "Invalid basic auth format"
 
     async def _authenticate_bearer_token(self, auth_header: str) -> Tuple[bool, Optional[str], str]:
@@ -107,7 +108,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             else:
                 return False, None, "Invalid token payload"
         except Exception as e:
-            logger.error("Bearer auth error: %s: %s", type(e).__name__, e, exc_info=True)
+            logger.warning("Bearer auth error: %s: %s", type(e).__name__, e)
+            logger.debug("Bearer auth error traceback", exc_info=True)
             return False, None, "Invalid token"
 
     async def _authenticate_session(self, request: Request) -> Tuple[bool, Optional[str], str]:


### PR DESCRIPTION
When token validation fails, the bearer/basic auth handlers log only the exception class name with no message, traceback, URL, or token claim. Operators investigating intermittent 401s cannot tell apart token expiry, JWKS network errors, signature mismatch, or claim issues — all collapse to the same opaque "Invalid token" log line.

<del>JWKS fetch in `_get_oidc_jwks` calls `requests.get` without a timeout. A slow or hung IdP can block request threads until the OS-level TCP timeout (~2 minutes), turning a brief upstream blip into a wave of authentication failures.<del>

Changes:
- `auth_middleware.py`: log exception message and traceback on basic/bearer auth failure, while keeping the returned error string stable so existing tests and callers are unaffected.
- <del>`auth.py`: add a 10s timeout on the OIDC discovery and JWKS HTTP calls.<del>