### PR TITLE
feat: enforce authorization on CreateExperiment and CreateRegisteredModel

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ The application is configured through environment variables, `.env` files, or pl
 |----------|------|---------|-------------|
 | `DEFAULT_MLFLOW_PERMISSION` | String | `MANAGE` | Default permission level when no explicit permission is found. Options: `READ`, `USE`, `EDIT`, `MANAGE`, `NO_PERMISSIONS`. See [Permissions](permissions) |
 | `PERMISSION_SOURCE_ORDER` | String | `user,group,regex,group-regex` | Comma-separated order for evaluating permission sources. The first source with a matching permission wins. See [Permissions](permissions#permission-source-order) |
+| `RESTRICT_RESOURCE_CREATION` | Boolean | `false` | When enabled, enforce permission checks on experiment and registered model creation. See [Resource Creation Authorization](permissions#resource-creation-authorization) |
 
 ### Database
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -121,6 +121,41 @@ When a user creates a resource, the plugin automatically grants them `MANAGE` pe
 - `CreateGatewayModelDefinition` → MANAGE on the new model definition
 - `CreateWorkspace` → MANAGE workspace permission (when workspaces enabled)
 
+## Resource Creation Authorization
+
+By default, any authenticated user can create experiments and registered models. This matches upstream MLflow behavior.
+
+When `RESTRICT_RESOURCE_CREATION` is set to `true`, the system enforces permission checks on `CreateExperiment` and `CreateRegisteredModel` requests. The user must have at least **EDIT** permission (`can_update`) to create a resource.
+
+### How creation permissions are resolved
+
+Since the resource does not exist yet at creation time, only **name-based** permission sources apply:
+
+1. **`regex`** — user-specific regex patterns matched against the new resource name
+2. **`group-regex`** — group-based regex patterns matched against the new resource name
+3. **Fallback** — `DEFAULT_MLFLOW_PERMISSION` if no regex pattern matches
+
+> **Note:** The `user` and `group` sources are not used for creation checks because they are tied to existing resources (by experiment ID or model name) that don't exist yet.
+
+### Configuration
+
+```bash
+# Enable creation permission checks (opt-in)
+RESTRICT_RESOURCE_CREATION=true
+
+# Combined with deny-by-default, only users with matching regex patterns can create resources
+DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS
+```
+
+### Affected endpoints
+
+| Endpoint | Effect when restricted |
+|----------|----------------------|
+| `CreateExperiment` | Requires EDIT+ permission for the experiment name |
+| `CreateRegisteredModel` | Requires EDIT+ permission for the model name |
+
+Child resources (`CreateRun`, `CreateModelVersion`, etc.) are not affected — they inherit permissions from their parent resource.
+
 ## Search Result Filtering
 
 For non-admin users, search and list results are filtered to only include resources the user can read:
@@ -264,4 +299,29 @@ Sources checked:
   4. group-regex: no matching patterns
   5. Workspace fallback: diana has READ on "data-team"
 Result: READ (from workspace fallback)
+```
+
+### Example 5: Resource Creation with RESTRICT_RESOURCE_CREATION
+```
+Config:
+  RESTRICT_RESOURCE_CREATION=true
+  DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS
+
+User: alice (member of ml-team)
+Action: CreateExperiment with name "ml-team-training"
+Group-regex for ml-team: "^ml-team-.*" -> EDIT
+
+Resolution:
+- regex: No matching user patterns
+- group-regex: Pattern "^ml-team-.*" matches -> EDIT (can_update=true)
+Result: Creation ALLOWED
+
+User: bob (no group regex patterns)
+Action: CreateExperiment with name "my-experiment"
+
+Resolution:
+- regex: No matching patterns
+- group-regex: No matching patterns
+- Fallback: NO_PERMISSIONS (can_update=false)
+Result: Creation DENIED
 ```

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -133,7 +133,9 @@ Since the resource does not exist yet at creation time, only **name-based** perm
 
 1. **`regex`** — user-specific regex patterns matched against the new resource name
 2. **`group-regex`** — group-based regex patterns matched against the new resource name
-3. **Fallback** — `DEFAULT_MLFLOW_PERMISSION` if no regex pattern matches
+3. **Fallback**:
+   - If workspaces enabled → use the user's workspace permission (or deny if the user has no permission on the request workspace)
+   - If workspaces disabled → use `DEFAULT_MLFLOW_PERMISSION`
 
 > **Note:** The `user` and `group` sources are not used for creation checks because they are tied to existing resources (by experiment ID or model name) that don't exist yet.
 

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -63,6 +63,7 @@ class AppConfig:
         # Permission settings
         self.DEFAULT_MLFLOW_PERMISSION = config_manager.get("DEFAULT_MLFLOW_PERMISSION", "MANAGE")
         self.PERMISSION_SOURCE_ORDER = config_manager.get_list("PERMISSION_SOURCE_ORDER", default=["user", "group", "regex", "group-regex"])
+        self.RESTRICT_RESOURCE_CREATION = config_manager.get_bool("RESTRICT_RESOURCE_CREATION", default=False)
 
         # Security settings (secrets - may come from Secrets Manager/Key Vault)
         _secret_key = config_manager.get("SECRET_KEY")

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Optional
 from flask import Request, g, request
 from mlflow.protos.model_registry_pb2 import (
     CreateModelVersion,
+    CreateRegisteredModel,
     DeleteModelVersion,
     DeleteModelVersionTag,
     DeleteRegisteredModel,
@@ -24,6 +25,7 @@ from mlflow.protos.model_registry_pb2 import (
 )
 from mlflow.protos.service_pb2 import (
     AttachModelToGatewayEndpoint,
+    CreateExperiment,
     CreateGatewayEndpoint,
     CreateGatewayEndpointBinding,
     CreateGatewayModelDefinition,
@@ -113,6 +115,8 @@ import mlflow_oidc_auth.responses as responses
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.validators import (
+    validate_can_create_experiment,
+    validate_can_create_registered_model,
     validate_can_delete_experiment,
     validate_can_delete_experiment_artifact_proxy,
     validate_can_delete_logged_model,
@@ -214,6 +218,7 @@ def _get_auth_context() -> tuple[Optional[str], bool]:
 
 BEFORE_REQUEST_HANDLERS = {
     # Routes for experiments
+    CreateExperiment: validate_can_create_experiment,
     GetExperiment: validate_can_read_experiment,
     GetExperimentByName: validate_can_read_experiment_by_name,
     DeleteExperiment: validate_can_delete_experiment,
@@ -236,6 +241,7 @@ BEFORE_REQUEST_HANDLERS = {
     GetMetricHistory: validate_can_read_run,
     ListArtifacts: validate_can_read_run,
     # Routes for model registry
+    CreateRegisteredModel: validate_can_create_registered_model,
     GetRegisteredModel: validate_can_read_registered_model,
     DeleteRegisteredModel: validate_can_delete_registered_model,
     UpdateRegisteredModel: validate_can_update_registered_model,

--- a/mlflow_oidc_auth/tests/hooks/test_before_request.py
+++ b/mlflow_oidc_auth/tests/hooks/test_before_request.py
@@ -9,6 +9,7 @@ from mlflow_oidc_auth.hooks.before_request import (
     _re_compile_path,
     _stash_gateway_context,
     _deny_non_admin,
+    BEFORE_REQUEST_HANDLERS,
     BEFORE_REQUEST_VALIDATORS,
     LOGGED_MODEL_BEFORE_REQUEST_VALIDATORS,
 )
@@ -797,3 +798,21 @@ class TestBudgetPolicyForwardCompat:
             # The handler should deny non-admins (always return False)
             handler = BEFORE_REQUEST_HANDLERS[proto]
             assert handler("any_user") is False
+
+
+def test_create_experiment_has_before_request_handler():
+    """Test that CreateExperiment is registered in BEFORE_REQUEST_HANDLERS (fix for issue #202)."""
+    from mlflow.protos.service_pb2 import CreateExperiment
+    from mlflow_oidc_auth.validators import validate_can_create_experiment
+
+    assert CreateExperiment in BEFORE_REQUEST_HANDLERS, "CreateExperiment must have a before-request handler"
+    assert BEFORE_REQUEST_HANDLERS[CreateExperiment] == validate_can_create_experiment
+
+
+def test_create_registered_model_has_before_request_handler():
+    """Test that CreateRegisteredModel is registered in BEFORE_REQUEST_HANDLERS (fix for issue #202)."""
+    from mlflow.protos.model_registry_pb2 import CreateRegisteredModel
+    from mlflow_oidc_auth.validators import validate_can_create_registered_model
+
+    assert CreateRegisteredModel in BEFORE_REQUEST_HANDLERS, "CreateRegisteredModel must have a before-request handler"
+    assert BEFORE_REQUEST_HANDLERS[CreateRegisteredModel] == validate_can_create_registered_model

--- a/mlflow_oidc_auth/tests/utils/test_permissions.py
+++ b/mlflow_oidc_auth/tests/utils/test_permissions.py
@@ -684,5 +684,135 @@ class TestResolvePermissionWorkspaceFallback(unittest.TestCase):
         self.assertEqual(result.permission, READ)
 
 
+class TestEffectiveNewPermissionWorkspaceFallback(unittest.TestCase):
+    """Workspace-aware fallback for effective_new_*_permission (creation paths)."""
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_experiment_fallback_uses_workspace_permission(self, mock_resolver):
+        """Regex miss + workspaces enabled + workspace perm set → use workspace perm."""
+        from mlflow_oidc_auth.permissions import EDIT, READ
+        from mlflow_oidc_auth.utils.permissions import effective_new_experiment_permission
+
+        mock_resolver.return_value = PermissionResult(READ, "fallback")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = True
+            with patch(
+                "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                return_value="team-ws",
+            ):
+                with patch(
+                    "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                    return_value=EDIT,
+                ):
+                    result = effective_new_experiment_permission("new-exp", "user1")
+
+        self.assertEqual(result.kind, "workspace")
+        self.assertEqual(result.permission, EDIT)
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_experiment_fallback_no_workspace_perm_denies(self, mock_resolver):
+        """Regex miss + workspaces enabled + no workspace perm → NO_PERMISSIONS deny."""
+        from mlflow_oidc_auth.permissions import NO_PERMISSIONS, READ
+        from mlflow_oidc_auth.utils.permissions import effective_new_experiment_permission
+
+        mock_resolver.return_value = PermissionResult(READ, "fallback")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = True
+            with patch(
+                "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                return_value="team-ws",
+            ):
+                with patch(
+                    "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                    return_value=None,
+                ):
+                    result = effective_new_experiment_permission("new-exp", "user1")
+
+        self.assertEqual(result.kind, "workspace-deny")
+        self.assertEqual(result.permission, NO_PERMISSIONS)
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_experiment_regex_match_skips_workspace_check(self, mock_resolver):
+        """Regex match → use that permission, no workspace lookup."""
+        from mlflow_oidc_auth.permissions import MANAGE
+        from mlflow_oidc_auth.utils.permissions import effective_new_experiment_permission
+
+        mock_resolver.return_value = PermissionResult(MANAGE, "regex")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = True
+            with patch(
+                "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            ) as mock_cache:
+                result = effective_new_experiment_permission("new-exp", "user1")
+
+        self.assertEqual(result.kind, "regex")
+        self.assertEqual(result.permission, MANAGE)
+        mock_cache.assert_not_called()
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_experiment_workspaces_disabled_returns_default(self, mock_resolver):
+        """Regex miss + workspaces disabled → existing DEFAULT_MLFLOW_PERMISSION fallback preserved."""
+        from mlflow_oidc_auth.permissions import READ
+        from mlflow_oidc_auth.utils.permissions import effective_new_experiment_permission
+
+        mock_resolver.return_value = PermissionResult(READ, "fallback")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = False
+            result = effective_new_experiment_permission("new-exp", "user1")
+
+        self.assertEqual(result.kind, "fallback")
+        self.assertEqual(result.permission, READ)
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_registered_model_fallback_uses_workspace_permission(self, mock_resolver):
+        """Same workspace-fallback contract for registered model creation."""
+        from mlflow_oidc_auth.permissions import EDIT, READ
+        from mlflow_oidc_auth.utils.permissions import effective_new_registered_model_permission
+
+        mock_resolver.return_value = PermissionResult(READ, "fallback")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = True
+            with patch(
+                "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                return_value="team-ws",
+            ):
+                with patch(
+                    "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                    return_value=EDIT,
+                ):
+                    result = effective_new_registered_model_permission("new-model", "user1")
+
+        self.assertEqual(result.kind, "workspace")
+        self.assertEqual(result.permission, EDIT)
+
+    @patch("mlflow_oidc_auth.utils.permissions.get_permission_from_store_or_default")
+    def test_new_registered_model_fallback_no_workspace_perm_denies(self, mock_resolver):
+        """No workspace perm on a workspace-enabled deployment → deny model creation."""
+        from mlflow_oidc_auth.permissions import NO_PERMISSIONS, READ
+        from mlflow_oidc_auth.utils.permissions import effective_new_registered_model_permission
+
+        mock_resolver.return_value = PermissionResult(READ, "fallback")
+
+        with patch("mlflow_oidc_auth.utils.permissions.config") as mock_config:
+            mock_config.MLFLOW_ENABLE_WORKSPACES = True
+            with patch(
+                "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                return_value="team-ws",
+            ):
+                with patch(
+                    "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                    return_value=None,
+                ):
+                    result = effective_new_registered_model_permission("new-model", "user1")
+
+        self.assertEqual(result.kind, "workspace-deny")
+        self.assertEqual(result.permission, NO_PERMISSIONS)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/mlflow_oidc_auth/tests/validators/test_experiment.py
+++ b/mlflow_oidc_auth/tests/validators/test_experiment.py
@@ -28,6 +28,41 @@ def _patch_permission(**kwargs):
     )
 
 
+def _patch_new_experiment_permission(**kwargs):
+    return patch(
+        "mlflow_oidc_auth.validators.experiment.effective_new_experiment_permission",
+        return_value=MagicMock(permission=DummyPermission(**kwargs)),
+    )
+
+
+def test_validate_can_create_experiment_allowed():
+    """Test that user with update permission can create experiment."""
+    with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
+        with _patch_new_experiment_permission(can_update=True):
+            assert experiment.validate_can_create_experiment("alice") is True
+
+
+def test_validate_can_create_experiment_denied():
+    """Test that user without update permission cannot create experiment."""
+    with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
+        with _patch_new_experiment_permission(can_update=False):
+            assert experiment.validate_can_create_experiment("alice") is False
+
+
+def test_validate_can_create_experiment_read_only():
+    """Test that READ permission is not enough to create experiment."""
+    with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
+        with _patch_new_experiment_permission(can_read=True, can_update=False):
+            assert experiment.validate_can_create_experiment("alice") is False
+
+
+def test_validate_can_create_experiment_manage():
+    """Test that MANAGE permission allows experiment creation."""
+    with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
+        with _patch_new_experiment_permission(can_update=True, can_manage=True):
+            assert experiment.validate_can_create_experiment("alice") is True
+
+
 def test__get_permission_from_experiment_id():
     with (
         patch(

--- a/mlflow_oidc_auth/tests/validators/test_experiment.py
+++ b/mlflow_oidc_auth/tests/validators/test_experiment.py
@@ -35,32 +35,47 @@ def _patch_new_experiment_permission(**kwargs):
     )
 
 
+def test_validate_can_create_experiment_unrestricted():
+    """Test that creation is always allowed when RESTRICT_RESOURCE_CREATION is False."""
+    with patch("mlflow_oidc_auth.validators.experiment.config") as mock_config:
+        mock_config.RESTRICT_RESOURCE_CREATION = False
+        assert experiment.validate_can_create_experiment("alice") is True
+
+
 def test_validate_can_create_experiment_allowed():
     """Test that user with update permission can create experiment."""
     with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
         with _patch_new_experiment_permission(can_update=True):
-            assert experiment.validate_can_create_experiment("alice") is True
+            with patch("mlflow_oidc_auth.validators.experiment.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert experiment.validate_can_create_experiment("alice") is True
 
 
 def test_validate_can_create_experiment_denied():
     """Test that user without update permission cannot create experiment."""
     with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
         with _patch_new_experiment_permission(can_update=False):
-            assert experiment.validate_can_create_experiment("alice") is False
+            with patch("mlflow_oidc_auth.validators.experiment.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert experiment.validate_can_create_experiment("alice") is False
 
 
 def test_validate_can_create_experiment_read_only():
     """Test that READ permission is not enough to create experiment."""
     with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
         with _patch_new_experiment_permission(can_read=True, can_update=False):
-            assert experiment.validate_can_create_experiment("alice") is False
+            with patch("mlflow_oidc_auth.validators.experiment.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert experiment.validate_can_create_experiment("alice") is False
 
 
 def test_validate_can_create_experiment_manage():
     """Test that MANAGE permission allows experiment creation."""
     with patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="my-experiment"):
         with _patch_new_experiment_permission(can_update=True, can_manage=True):
-            assert experiment.validate_can_create_experiment("alice") is True
+            with patch("mlflow_oidc_auth.validators.experiment.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert experiment.validate_can_create_experiment("alice") is True
 
 
 def test__get_permission_from_experiment_id():

--- a/mlflow_oidc_auth/tests/validators/test_registered_model.py
+++ b/mlflow_oidc_auth/tests/validators/test_registered_model.py
@@ -35,32 +35,47 @@ def _patch_new_model_permission(**kwargs):
     )
 
 
+def test_validate_can_create_registered_model_unrestricted():
+    """Test that creation is always allowed when RESTRICT_RESOURCE_CREATION is False."""
+    with patch("mlflow_oidc_auth.validators.registered_model.config") as mock_config:
+        mock_config.RESTRICT_RESOURCE_CREATION = False
+        assert registered_model.validate_can_create_registered_model("alice") is True
+
+
 def test_validate_can_create_registered_model_allowed():
     """Test that user with update permission can create registered model."""
     with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
         with _patch_new_model_permission(can_update=True):
-            assert registered_model.validate_can_create_registered_model("alice") is True
+            with patch("mlflow_oidc_auth.validators.registered_model.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert registered_model.validate_can_create_registered_model("alice") is True
 
 
 def test_validate_can_create_registered_model_denied():
     """Test that user without update permission cannot create registered model."""
     with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
         with _patch_new_model_permission(can_update=False):
-            assert registered_model.validate_can_create_registered_model("alice") is False
+            with patch("mlflow_oidc_auth.validators.registered_model.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert registered_model.validate_can_create_registered_model("alice") is False
 
 
 def test_validate_can_create_registered_model_read_only():
     """Test that READ permission is not enough to create registered model."""
     with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
         with _patch_new_model_permission(can_read=True, can_update=False):
-            assert registered_model.validate_can_create_registered_model("alice") is False
+            with patch("mlflow_oidc_auth.validators.registered_model.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert registered_model.validate_can_create_registered_model("alice") is False
 
 
 def test_validate_can_create_registered_model_manage():
     """Test that MANAGE permission allows registered model creation."""
     with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
         with _patch_new_model_permission(can_update=True, can_manage=True):
-            assert registered_model.validate_can_create_registered_model("alice") is True
+            with patch("mlflow_oidc_auth.validators.registered_model.config") as mock_config:
+                mock_config.RESTRICT_RESOURCE_CREATION = True
+                assert registered_model.validate_can_create_registered_model("alice") is True
 
 
 def test__get_permission_from_registered_model_name():

--- a/mlflow_oidc_auth/tests/validators/test_registered_model.py
+++ b/mlflow_oidc_auth/tests/validators/test_registered_model.py
@@ -28,6 +28,41 @@ def _patch_permission(**kwargs):
     )
 
 
+def _patch_new_model_permission(**kwargs):
+    return patch(
+        "mlflow_oidc_auth.validators.registered_model.effective_new_registered_model_permission",
+        return_value=MagicMock(permission=DummyPermission(**kwargs)),
+    )
+
+
+def test_validate_can_create_registered_model_allowed():
+    """Test that user with update permission can create registered model."""
+    with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
+        with _patch_new_model_permission(can_update=True):
+            assert registered_model.validate_can_create_registered_model("alice") is True
+
+
+def test_validate_can_create_registered_model_denied():
+    """Test that user without update permission cannot create registered model."""
+    with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
+        with _patch_new_model_permission(can_update=False):
+            assert registered_model.validate_can_create_registered_model("alice") is False
+
+
+def test_validate_can_create_registered_model_read_only():
+    """Test that READ permission is not enough to create registered model."""
+    with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
+        with _patch_new_model_permission(can_read=True, can_update=False):
+            assert registered_model.validate_can_create_registered_model("alice") is False
+
+
+def test_validate_can_create_registered_model_manage():
+    """Test that MANAGE permission allows registered model creation."""
+    with patch("mlflow_oidc_auth.validators.registered_model.get_model_name", return_value="my-model"):
+        with _patch_new_model_permission(can_update=True, can_manage=True):
+            assert registered_model.validate_can_create_registered_model("alice") is True
+
+
 def test__get_permission_from_registered_model_name():
     with (
         patch(

--- a/mlflow_oidc_auth/utils/__init__.py
+++ b/mlflow_oidc_auth/utils/__init__.py
@@ -22,7 +22,9 @@ from .data_fetching import (
 
 from .permissions import (
     effective_experiment_permission,
+    effective_new_experiment_permission,
     effective_registered_model_permission,
+    effective_new_registered_model_permission,
     effective_prompt_permission,
     effective_scorer_permission,
     can_read_experiment,
@@ -73,7 +75,9 @@ __all__ = [
     "fetch_all_gateway_model_definitions",
     # Permissions
     "effective_experiment_permission",
+    "effective_new_experiment_permission",
     "effective_registered_model_permission",
+    "effective_new_registered_model_permission",
     "effective_prompt_permission",
     "effective_scorer_permission",
     "can_read_experiment",

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -257,6 +257,30 @@ PERMISSION_REGISTRY: Dict[str, Callable[..., Dict[str, Callable[[], str]]]] = {
 }
 
 
+def _apply_workspace_fallback(result: PermissionResult, username: str) -> PermissionResult:
+    """Replace a generic ``fallback`` result with the user's workspace permission.
+
+    Per WSAUTH-C/WSAUTH-04: when workspaces are enabled, a missing resource-level
+    permission must defer to the user's workspace permission instead of
+    ``DEFAULT_MLFLOW_PERMISSION``. If the user has no permission on the request
+    workspace, deny by returning ``NO_PERMISSIONS`` with kind ``workspace-deny``.
+    """
+    if result.kind != "fallback" or not config.MLFLOW_ENABLE_WORKSPACES:
+        return result
+
+    from mlflow_oidc_auth.bridge.user import get_request_workspace
+    from mlflow_oidc_auth.utils.workspace_cache import get_workspace_permission_cached
+
+    workspace = get_request_workspace()
+    if workspace is None:
+        return result
+
+    ws_perm = get_workspace_permission_cached(username, workspace)
+    if ws_perm is not None:
+        return PermissionResult(ws_perm, "workspace")
+    return PermissionResult(NO_PERMISSIONS, "workspace-deny")
+
+
 def resolve_permission(resource_type: str, resource_id: str, username: str, **kwargs) -> PermissionResult:
     """Single entry point for all permission resolution. Per D-01 (REFAC-01).
 
@@ -273,21 +297,7 @@ def resolve_permission(resource_type: str, resource_id: str, username: str, **kw
     builder = PERMISSION_REGISTRY[resource_type]
     sources_config = builder(resource_id, username, **kwargs)
     result = get_permission_from_store_or_default(sources_config)
-
-    # Workspace fallback: when no resource-level permission found (per WSAUTH-C/WSAUTH-04)
-    if result.kind == "fallback" and config.MLFLOW_ENABLE_WORKSPACES:
-        from mlflow_oidc_auth.bridge.user import get_request_workspace
-        from mlflow_oidc_auth.utils.workspace_cache import (
-            get_workspace_permission_cached,
-        )
-
-        workspace = get_request_workspace()
-        if workspace:
-            ws_perm = get_workspace_permission_cached(username, workspace)
-            if ws_perm is not None:
-                result = PermissionResult(ws_perm, "workspace")
-            else:
-                result = PermissionResult(NO_PERMISSIONS, "workspace-deny")
+    result = _apply_workspace_fallback(result, username)
 
     cache.set(cache_key, result)
     return result
@@ -331,13 +341,25 @@ def _permission_new_registered_model_sources_config(model_name: str, username: s
 
 
 def effective_new_experiment_permission(experiment_name: str, user: str) -> PermissionResult:
-    """Resolve permission for creating a new experiment by name."""
-    return get_permission_from_store_or_default(_permission_new_experiment_sources_config(experiment_name, user))
+    """Resolve permission for creating a new experiment by name.
+
+    When workspaces are enabled, a regex/group-regex miss falls back to the
+    user's workspace permission (or NO_PERMISSIONS if absent), matching the
+    contract enforced by ``resolve_permission`` for existing resources.
+    """
+    result = get_permission_from_store_or_default(_permission_new_experiment_sources_config(experiment_name, user))
+    return _apply_workspace_fallback(result, user)
 
 
 def effective_new_registered_model_permission(model_name: str, user: str) -> PermissionResult:
-    """Resolve permission for creating a new registered model by name."""
-    return get_permission_from_store_or_default(_permission_new_registered_model_sources_config(model_name, user))
+    """Resolve permission for creating a new registered model by name.
+
+    When workspaces are enabled, a regex/group-regex miss falls back to the
+    user's workspace permission (or NO_PERMISSIONS if absent), matching the
+    contract enforced by ``resolve_permission`` for existing resources.
+    """
+    result = get_permission_from_store_or_default(_permission_new_registered_model_sources_config(model_name, user))
+    return _apply_workspace_fallback(result, user)
 
 
 def effective_experiment_permission(experiment_id: str, user: str) -> PermissionResult:

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -298,6 +298,48 @@ def resolve_permission(resource_type: str, resource_id: str, username: str, **kw
 # ---------------------------------------------------------------------------
 
 
+def _permission_new_experiment_sources_config(experiment_name: str, username: str) -> Dict[str, Callable[[], str]]:
+    """Permission sources for experiment creation (by name, no experiment_id yet).
+
+    Only regex-based sources are used because "user" and "group" sources
+    require a per-resource-ID permission record which doesn't exist yet.
+    """
+    return {
+        "regex": lambda experiment_name=experiment_name, user=username: _match_regex_permission(
+            store.list_experiment_regex_permissions(user), experiment_name, "experiment name"
+        ),
+        "group-regex": lambda experiment_name=experiment_name, user=username: _match_regex_permission(
+            store.list_group_experiment_regex_permissions_for_groups_ids(store.get_groups_ids_for_user(user)), experiment_name, "experiment name"
+        ),
+    }
+
+
+def _permission_new_registered_model_sources_config(model_name: str, username: str) -> Dict[str, Callable[[], str]]:
+    """Permission sources for registered model creation (by name, no permission record yet).
+
+    Only regex-based sources are used because "user" and "group" sources
+    require a per-resource permission record which doesn't exist yet.
+    """
+    return {
+        "regex": lambda model_name=model_name, user=username: _match_regex_permission(
+            store.list_registered_model_regex_permissions(user), model_name, "model name"
+        ),
+        "group-regex": lambda model_name=model_name, user=username: _match_regex_permission(
+            store.list_group_registered_model_regex_permissions_for_groups_ids(store.get_groups_ids_for_user(user)), model_name, "model name"
+        ),
+    }
+
+
+def effective_new_experiment_permission(experiment_name: str, user: str) -> PermissionResult:
+    """Resolve permission for creating a new experiment by name."""
+    return get_permission_from_store_or_default(_permission_new_experiment_sources_config(experiment_name, user))
+
+
+def effective_new_registered_model_permission(model_name: str, user: str) -> PermissionResult:
+    """Resolve permission for creating a new registered model by name."""
+    return get_permission_from_store_or_default(_permission_new_registered_model_sources_config(model_name, user))
+
+
 def effective_experiment_permission(experiment_id: str, user: str) -> PermissionResult:
     """
     Attempts to get permission from store based on configured sources,

--- a/mlflow_oidc_auth/validators/__init__.py
+++ b/mlflow_oidc_auth/validators/__init__.py
@@ -1,4 +1,5 @@
 from mlflow_oidc_auth.validators.experiment import (
+    validate_can_create_experiment,
     validate_can_delete_experiment,
     validate_can_delete_experiment_artifact_proxy,
     validate_can_manage_experiment,
@@ -11,6 +12,7 @@ from mlflow_oidc_auth.validators.experiment import (
     validate_can_update_experiment_from_experiment_id,
 )
 from mlflow_oidc_auth.validators.registered_model import (
+    validate_can_create_registered_model,
     validate_can_delete_logged_model,
     validate_can_delete_registered_model,
     validate_can_read_logged_model,
@@ -83,6 +85,7 @@ from mlflow_oidc_auth.validators.workspace import (
 )
 
 __all__ = [
+    "validate_can_create_experiment",
     "validate_can_read_experiment",
     "validate_can_read_experiment_by_name",
     "validate_can_update_experiment",
@@ -93,6 +96,7 @@ __all__ = [
     "validate_can_delete_experiment_artifact_proxy",
     "validate_can_read_experiments_from_experiment_ids",
     "validate_can_update_experiment_from_experiment_id",
+    "validate_can_create_registered_model",
     "validate_can_read_registered_model",
     "validate_can_update_registered_model",
     "validate_can_manage_registered_model",

--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -7,6 +7,7 @@ from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.permissions import Permission, get_permission
 from mlflow_oidc_auth.utils import (
     effective_experiment_permission,
+    effective_new_experiment_permission,
     get_experiment_id,
     get_request_param,
 )
@@ -52,6 +53,11 @@ def _get_permission_from_experiment_id_artifact_proxy(username: str) -> Permissi
     if experiment_id := _get_experiment_id_from_view_args():
         return effective_experiment_permission(experiment_id, username).permission
     return get_permission(config.DEFAULT_MLFLOW_PERMISSION)
+
+
+def validate_can_create_experiment(username: str) -> bool:
+    experiment_name = get_request_param("name")
+    return effective_new_experiment_permission(experiment_name, username).permission.can_update
 
 
 def validate_can_read_experiment(username: str) -> bool:

--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -56,6 +56,8 @@ def _get_permission_from_experiment_id_artifact_proxy(username: str) -> Permissi
 
 
 def validate_can_create_experiment(username: str) -> bool:
+    if not config.RESTRICT_RESOURCE_CREATION:
+        return True
     experiment_name = get_request_param("name")
     return effective_new_experiment_permission(experiment_name, username).permission.can_update
 

--- a/mlflow_oidc_auth/validators/registered_model.py
+++ b/mlflow_oidc_auth/validators/registered_model.py
@@ -1,6 +1,7 @@
 from mlflow_oidc_auth.permissions import Permission
 from mlflow_oidc_auth.utils import (
     effective_registered_model_permission,
+    effective_new_registered_model_permission,
     effective_experiment_permission,
     get_model_name,
     get_model_id,
@@ -41,6 +42,11 @@ def _get_permission_from_trace_request_id(username: str) -> Permission:
     experiment_id = trace.experiment_id
 
     return effective_experiment_permission(experiment_id, username).permission
+
+
+def validate_can_create_registered_model(username: str) -> bool:
+    model_name = get_model_name()
+    return effective_new_registered_model_permission(model_name, username).permission.can_update
 
 
 def validate_can_read_registered_model(username: str) -> bool:

--- a/mlflow_oidc_auth/validators/registered_model.py
+++ b/mlflow_oidc_auth/validators/registered_model.py
@@ -1,3 +1,4 @@
+from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.permissions import Permission
 from mlflow_oidc_auth.utils import (
     effective_registered_model_permission,
@@ -45,6 +46,8 @@ def _get_permission_from_trace_request_id(username: str) -> Permission:
 
 
 def validate_can_create_registered_model(username: str) -> bool:
+    if not config.RESTRICT_RESOURCE_CREATION:
+        return True
     model_name = get_model_name()
     return effective_new_registered_model_permission(model_name, username).permission.can_update
 


### PR DESCRIPTION
## Summary

Resurrects @nitaibezerra's original work from #195/#202, rebased onto current `main` and made workspace-aware.

Currently any authenticated user can create experiments and registered models regardless of `DEFAULT_MLFLOW_PERMISSION` or group/regex permissions — there's no before-request validator on `CreateExperiment`/`CreateRegisteredModel`, only an after-request handler that grants `MANAGE` to the creator after the resource already exists.

This PR adds opt-in creation enforcement gated by a new `RESTRICT_RESOURCE_CREATION` config flag (default: `false`), so existing deployments see no behaviour change unless they enable it.

Fixes #202.

## Changes

Three rebased commits from @nitaibezerra plus one workspace-correctness fix:

1. **`fix: enforce authorization on CreateExperiment and CreateRegisteredModel`** — adds `validate_can_create_experiment` and `validate_can_create_registered_model` validators wired into `BEFORE_REQUEST_HANDLERS`. Resolves permission by **resource name** (the resource ID doesn't exist yet at creation time) using regex/group-regex sources only.
2. **`feat: add RESTRICT_RESOURCE_CREATION flag for backward compatibility`** — gates the new validators behind an opt-in config flag (default `false`).
3. **`docs: add resource creation authorization documentation`** — documents the flag and the resolution order.
4. **`fix(auth): respect workspace permissions for resource creation`** *(new in this rebase)* — extracts the existing workspace-fallback logic from `resolve_permission` into a small helper and applies it on the creation paths. Without this, with `MLFLOW_ENABLE_WORKSPACES=true` a user with no workspace permission would fall through to `DEFAULT_MLFLOW_PERMISSION` and could still create resources.

## Behaviour

When `RESTRICT_RESOURCE_CREATION=false` (default): no change — anyone authenticated can create.

When `RESTRICT_RESOURCE_CREATION=true`:

| Scenario | Result |
|---|---|
| User has matching regex / group-regex granting EDIT+ on the requested name | Allow |
| Workspaces disabled, no regex match | Falls back to `DEFAULT_MLFLOW_PERMISSION` |
| Workspaces enabled, no regex match, user has EDIT+ on request workspace | Allow |
| Workspaces enabled, no regex match, no workspace permission | **Deny** |

## Test plan

- [x] `pytest mlflow_oidc_auth/tests/validators/test_experiment.py mlflow_oidc_auth/tests/validators/test_registered_model.py mlflow_oidc_auth/tests/hooks/test_before_request.py mlflow_oidc_auth/tests/utils/test_permissions.py` — 158/158 passing locally
- [x] New tests cover: regex match, regex miss with workspaces enabled and a workspace permission, regex miss with workspaces enabled and no workspace permission (deny), regex miss with workspaces disabled
- [ ] Maintainer review

## Notes

@nitaibezerra is preserved as the original author on commits 1-3. Happy to squash on merge if maintainers prefer a single-commit PR — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)