### PR TITLE
fix(hack): ui menu injection target querySelector

### DIFF
--- a/mlflow_oidc_auth/hack/menu.html
+++ b/mlflow_oidc_auth/hack/menu.html
@@ -130,7 +130,7 @@
         document.addEventListener("DOMContentLoaded", function () {
             getJSON("api/2.0/mlflow/users/current", function (err, res) {
                 if (err) { console.error("Error fetching username:", err); return; }
-                waitForElement('a[href="#/settings"]', function (settingsLink) {
+                waitForElement('a[href^="#/settings"]', function (settingsLink) {
                     injectMenu(res.display_name, settingsLink);
                 });
             });


### PR DESCRIPTION
The UI menu extension hack no longer works in MLflow 3.12 as the menu settings item [may now include the `returnTo` param](https://github.com/mlflow/mlflow/commit/2cbec19cbfc0d08bda938a0e78d69f99c47fb02a#diff-02d811c72b19398826777e15c8c2818b2fd26c55357a3623091fc556a7b93a62R30-R33) and breaks the selection query.