### PR TITLE
feat(auth): re-authenticate sessions against IdP token expiry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,8 @@ The application is configured through environment variables, `.env` files, or pl
 | `OIDC_AUDIENCE` | String | None | Expected JWT `aud` claim value (e.g., your client ID or API identifier). When set, bearer tokens are rejected if the `aud` claim doesn't match. Recommended for production to prevent token confusion attacks |
 | `OIDC_PROVIDER_DISPLAY_NAME` | String | `Login with OIDC` | Display name shown on the login page button |
 | `OIDC_GROUPS_ATTRIBUTE` | String | `groups` | Attribute name in the ID token that contains the user's group memberships |
+| `OIDC_SESSION_EXPIRY_LEEWAY_SECONDS` | Integer | `30` | Clock-skew leeway applied to the IdP-issued token expiry. Sessions are rejected once `now >= expires_at - leeway`, forcing the user back through the OIDC login flow so IdP-side changes (deactivation, group changes, MFA enrollment) take effect within the token's lifetime instead of waiting for the cookie TTL |
+| `OIDC_USE_REFRESH_TOKEN` | Boolean | `false` | When `true`, request `offline_access` and persist the refresh token in the session so expired sessions are silently refreshed against the IdP without forcing a visible login. Disabled by default because many enterprises require additional approval for `offline_access` and because refresh tokens are persisted in the signed (but not encrypted) session cookie |
 
 ### Group and Access Control
 
@@ -52,6 +54,7 @@ The application is configured through environment variables, `.env` files, or pl
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `EXTEND_MLFLOW_MENU` | Boolean | `true` | Inject sign-in/sign-out links and permission management navigation into MLflow's built-in UI |
+| `EXTEND_MLFLOW_REAUTH` | Boolean | `true` | Inject a small script into MLflow's UI that triggers a full page reload on any 401 response. Without this, an expired session leaves the SPA rendering empty pages until a manual force-reload, because React Router intercepts URL-bar navigations as soft routing |
 | `DEFAULT_LANDING_PAGE_IS_PERMISSIONS` | Boolean | `true` | Use the permissions management page as the default landing page in the admin UI |
 
 ### Feature Flags

--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -193,8 +193,10 @@ def create_app() -> FastAPI:
     for router in get_all_routers():
         oidc_app.include_router(router)
 
-    # Add links to MLFlow UI
-    if config.EXTEND_MLFLOW_MENU:
+    # Inject into MLflow's index.html when the menu links or the re-auth helper
+    # are enabled. Both live in the same hack module to keep injection ordering
+    # predictable.
+    if config.EXTEND_MLFLOW_MENU or config.EXTEND_MLFLOW_REAUTH:
         from mlflow_oidc_auth import hack
 
         app.view_functions["serve"] = hack.index

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -99,6 +99,15 @@ class AppConfig:
         self.OIDC_GROUPS_ATTRIBUTE = config_manager.get("OIDC_GROUPS_ATTRIBUTE", "groups")
         self.OIDC_AUDIENCE = config_manager.get("OIDC_AUDIENCE")
 
+        # Session re-authentication settings
+        # When True, the session is rejected once the IdP-issued access/ID token expires.
+        # Leeway compensates for clock skew between this server and the IdP.
+        self.OIDC_SESSION_EXPIRY_LEEWAY_SECONDS = config_manager.get_int("OIDC_SESSION_EXPIRY_LEEWAY_SECONDS", default=30)
+        # When True, request `offline_access` and persist the refresh token so the
+        # session can be silently refreshed against the IdP on expiry. Many enterprises
+        # require additional approval for offline_access, so this is opt-in.
+        self.OIDC_USE_REFRESH_TOKEN = config_manager.get_bool("OIDC_USE_REFRESH_TOKEN", default=False)
+
         # JWKS caching settings
         self.OIDC_JWKS_CACHE_TTL_SECONDS = config_manager.get_int("OIDC_JWKS_CACHE_TTL_SECONDS", default=300)
 
@@ -115,6 +124,10 @@ class AppConfig:
 
         # UI settings
         self.EXTEND_MLFLOW_MENU = config_manager.get_bool("EXTEND_MLFLOW_MENU", default=True)
+        # Inject a small script into MLflow's index.html that forces a full reload on
+        # any 401 response, so expired sessions trigger the IdP redirect flow instead
+        # of leaving the user staring at empty SPA pages.
+        self.EXTEND_MLFLOW_REAUTH = config_manager.get_bool("EXTEND_MLFLOW_REAUTH", default=True)
         self.DEFAULT_LANDING_PAGE_IS_PERMISSIONS = config_manager.get_bool("DEFAULT_LANDING_PAGE_IS_PERMISSIONS", default=True)
         self.AUTOMATIC_LOGIN_REDIRECT = config_manager.get_bool("AUTOMATIC_LOGIN_REDIRECT", default=False)
 

--- a/mlflow_oidc_auth/hack.py
+++ b/mlflow_oidc_auth/hack.py
@@ -2,11 +2,24 @@ import os
 
 from flask import Response
 
+from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
 
 logger = get_logger()
 
 _BODY_CLOSE_TAG = "</body>"
+_HACK_DIR = os.path.join(os.path.dirname(__file__), "hack")
+
+
+def _read_snippet(name: str) -> str:
+    """Read a snippet from the hack/ directory. Returns empty string if missing."""
+
+    path = os.path.join(_HACK_DIR, name)
+    if not os.path.exists(path):
+        logger.warning("Injection snippet '%s' not found at %s; skipping", name, path)
+        return ""
+    with open(path, "r") as f:
+        return f.read()
 
 
 def index():
@@ -23,7 +36,6 @@ def index():
         return Response(text_notset, mimetype="text/plain")
 
     index_path = os.path.join(static_folder, "index.html")
-    menu_path = os.path.join(os.path.dirname(__file__), "hack", "menu.html")
 
     if not os.path.exists(index_path):
         return Response(text_notfound, mimetype="text/plain")
@@ -33,20 +45,21 @@ def index():
 
     if _BODY_CLOSE_TAG not in html_content:
         logger.warning(
-            "MLflow index.html does not contain '%s' marker; menu injection skipped",
+            "MLflow index.html does not contain '%s' marker; injection skipped",
             _BODY_CLOSE_TAG,
         )
         return html_content
 
-    if not os.path.exists(menu_path):
-        logger.warning(
-            "Menu injection file not found at %s; serving unmodified index.html",
-            menu_path,
-        )
+    # Build the combined injection. Re-auth runs first so the fetch/XHR patch is
+    # in place before the menu code (or any later script) issues network calls.
+    injections = []
+    if config.EXTEND_MLFLOW_REAUTH:
+        injections.append(_read_snippet("reauth.html"))
+    if config.EXTEND_MLFLOW_MENU:
+        injections.append(_read_snippet("menu.html"))
+
+    injected = "\n".join(s for s in injections if s)
+    if not injected:
         return html_content
 
-    with open(menu_path, "r") as js_file:
-        js_injection = js_file.read()
-
-    modified_html_content = html_content.replace(_BODY_CLOSE_TAG, f"{js_injection}\n{_BODY_CLOSE_TAG}")
-    return modified_html_content
+    return html_content.replace(_BODY_CLOSE_TAG, f"{injected}\n{_BODY_CLOSE_TAG}")

--- a/mlflow_oidc_auth/hack/menu.html
+++ b/mlflow_oidc_auth/hack/menu.html
@@ -130,7 +130,9 @@
         document.addEventListener("DOMContentLoaded", function () {
             getJSON("api/2.0/mlflow/users/current", function (err, res) {
                 if (err) { console.error("Error fetching username:", err); return; }
-                waitForElement('a[href="#/settings"]', function (settingsLink) {
+                // Prefix-match: newer MLflow versions land on sub-routes like
+                // "#/settings/general?returnTo=%2F" instead of plain "#/settings".
+                waitForElement('a[href^="#/settings"]', function (settingsLink) {
                     injectMenu(res.display_name, settingsLink);
                 });
             });

--- a/mlflow_oidc_auth/hack/reauth.html
+++ b/mlflow_oidc_auth/hack/reauth.html
@@ -12,7 +12,15 @@
         function reauth() {
             if (triggered) return;
             triggered = true;
-            window.location.reload();
+            // Forward path + search + hash so the post-login callback can
+            // return the user to where they were. MLflow uses hash routing,
+            // so the hash is essential — without it they'd land at the root.
+            var next = window.location.pathname + window.location.search + window.location.hash;
+            var baseHref = (document.querySelector("base") || {}).getAttribute
+                ? document.querySelector("base").getAttribute("href")
+                : "/";
+            baseHref = (baseHref || "/").replace(/\/$/, "");
+            window.location.assign(baseHref + "/login?next=" + encodeURIComponent(next));
         }
 
         if (typeof window.fetch === "function") {

--- a/mlflow_oidc_auth/hack/reauth.html
+++ b/mlflow_oidc_auth/hack/reauth.html
@@ -1,0 +1,41 @@
+<script>
+    // Forces a full page reload when any fetch / XHR returns 401, so that
+    // expired sessions trigger the AuthMiddleware redirect to the IdP login
+    // flow instead of the SPA rendering empty pages forever.
+    //
+    // React Router intercepts URL-bar Enter as a soft navigation, so without
+    // this hook the user has to manually force-reload after a session expiry.
+    (function () {
+        "use strict";
+
+        var triggered = false;
+        function reauth() {
+            if (triggered) return;
+            triggered = true;
+            window.location.reload();
+        }
+
+        if (typeof window.fetch === "function") {
+            var origFetch = window.fetch.bind(window);
+            window.fetch = function () {
+                return origFetch.apply(this, arguments).then(function (response) {
+                    if (response && response.status === 401) reauth();
+                    return response;
+                });
+            };
+        }
+
+        if (typeof window.XMLHttpRequest === "function") {
+            // Monkey-patch the prototype rather than replacing the constructor,
+            // so static constants (XMLHttpRequest.DONE, etc.) and any library
+            // assumptions about the class identity are preserved.
+            var origSend = XMLHttpRequest.prototype.send;
+            XMLHttpRequest.prototype.send = function () {
+                this.addEventListener("load", function () {
+                    if (this.status === 401) reauth();
+                });
+                return origSend.apply(this, arguments);
+            };
+        }
+    })();
+</script>

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -8,6 +8,7 @@ Authorization (what the user can do) is handled by RBACMiddleware.
 
 from typing import Optional, Tuple
 import base64
+import time
 
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse, JSONResponse
@@ -57,6 +58,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/redoc",
             "/openapi.json",
             "/oidc/ui",
+            # MLflow's React bundle is served from /static-files/<path:path> with
+            # content-addressed (hashed) filenames and ships publicly on PyPI.
+            # Letting it load unauthenticated lets a session-expired SPA finish
+            # loading chunks instead of dying with ChunkLoadError; the next
+            # navigation will redirect through the IdP for re-auth.
+            "/static-files",
         )
         return path.startswith(unprotected_prefixes)
 
@@ -114,6 +121,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         Authenticate using session.
 
+        Enforces the IdP-issued ``expires_at`` (set at OIDC callback) so a session
+        cannot outlive the underlying token. When ``OIDC_USE_REFRESH_TOKEN`` is
+        enabled and a refresh token is stored, an expired session is silently
+        refreshed against the IdP before being rejected.
+
         Args:
             request: FastAPI request object
 
@@ -126,9 +138,25 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 try:
                     session = request.session
                     username = session.get("username")
-                    if username:
-                        logger.debug(f"User {username} authenticated via session")
-                        return True, username, ""
+                    if not username:
+                        return False, None, "No session authentication"
+
+                    if self._is_session_expired(session):
+                        # Try a silent refresh first; only force re-login if it fails.
+                        from mlflow_oidc_auth.routers.auth import refresh_session_with_idp
+
+                        refreshed = await refresh_session_with_idp(session)
+                        if not refreshed:
+                            logger.info(
+                                "Session expired for user %s; clearing session to force re-authentication",
+                                username,
+                            )
+                            session.clear()
+                            return False, None, "Session expired"
+                        logger.debug(f"Session for {username} refreshed against IdP")
+
+                    logger.debug(f"User {username} authenticated via session")
+                    return True, username, ""
                 except Exception as session_error:
                     logger.debug("Session access error: %s", type(session_error).__name__)
                     return False, None, "Session access failed"
@@ -140,6 +168,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return False, None, "Session error"
 
         return False, None, "No session authentication"
+
+    @staticmethod
+    def _is_session_expired(session) -> bool:
+        """Return True when the IdP-issued ``expires_at`` (minus leeway) is in the past.
+
+        Returns False when no expiry is recorded — older sessions predating this
+        feature should keep working until the cookie TTL takes them out, instead
+        of being summarily logged out at deploy time.
+        """
+
+        expires_at = session.get("expires_at")
+        if not isinstance(expires_at, (int, float)):
+            return False
+        leeway = max(0, config.OIDC_SESSION_EXPIRY_LEEWAY_SECONDS)
+        return time.time() >= float(expires_at) - leeway
 
     async def _authenticate_user(self, request: Request) -> Tuple[bool, Optional[str], str]:
         """
@@ -255,4 +298,29 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     status_code=403,
                     content={"detail": "Administrator privileges required for this operation"},
                 )
+            # Only redirect top-level navigation requests. Subresource fetches
+            # (chunks, fetch/XHR, telemetry) must get 401 — otherwise the
+            # browser silently follows the 302 and hands HTML to the JS chunk
+            # loader / JSON.parse, breaking the SPA mid-session.
+            if not self._is_document_request(request):
+                return JSONResponse(status_code=401, content={"detail": "Authentication required"})
             return await self._handle_auth_redirect(request)
+
+    @staticmethod
+    def _is_document_request(request: Request) -> bool:
+        """Return True when the request is a top-level navigation (HTML document fetch).
+
+        Uses the ``Sec-Fetch-Dest`` header (sent by all modern browsers) and falls
+        back to the ``Accept`` header for clients that don't set it. Only document
+        requests should receive a 302 redirect to the login flow; everything else
+        (script/style/image/fetch/XHR) needs a 401 so the SPA can react instead
+        of receiving HTML in place of expected JSON or JS.
+        """
+
+        sec_fetch_dest = request.headers.get("sec-fetch-dest", "").lower()
+        if sec_fetch_dest:
+            return sec_fetch_dest == "document"
+        # Older clients without Sec-Fetch-Dest: trust Accept. fetch()/XHR usually
+        # send `application/json` or `*/*`; navigations send `text/html,...`.
+        accept = request.headers.get("accept", "").lower()
+        return "text/html" in accept

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -227,6 +227,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         Handle authentication redirect for unauthenticated users.
 
+        Forwards the original request path (and query string) as ``?next=`` so
+        the post-login callback can return the user to where they were instead
+        of dumping them at the root.
+
         Args:
             request: FastAPI request object
 
@@ -234,12 +238,23 @@ class AuthMiddleware(BaseHTTPMiddleware):
             Appropriate response (redirect or auth page)
         """
         # Import here to avoid circular imports
+        from urllib.parse import quote
+
         from mlflow_oidc_auth.utils import get_base_path
 
         base_path = await get_base_path(request)
 
+        # Reconstruct the original target so the user is returned to it after
+        # IdP login. We can only see path + query server-side; the SPA layer
+        # also forwards the URL fragment for hash-routed apps like MLflow.
+        target = request.url.path
+        query = request.url.query
+        if query and isinstance(query, str):
+            target = f"{target}?{query}"
+        next_param = f"?next={quote(target, safe='')}"
+
         if config.AUTOMATIC_LOGIN_REDIRECT:
-            login_url = f"{base_path}/login"
+            login_url = f"{base_path}/login{next_param}"
             return RedirectResponse(url=login_url, status_code=302)
 
         ui_url = f"{base_path}/oidc/ui"

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -30,6 +30,26 @@ def _has_required_config() -> bool:
     return bool(config.OIDC_CLIENT_ID and config.OIDC_CLIENT_SECRET and config.OIDC_DISCOVERY_URL)
 
 
+def _build_scope() -> str:
+    """Build the OIDC scope string, adding ``offline_access`` if refresh is enabled.
+
+    Authlib accepts either comma- or space-separated scopes. We normalise to the
+    same separator the user configured to keep the rendered authorize URL
+    predictable, while making sure ``offline_access`` is present when the
+    refresh-token flow is enabled.
+    """
+
+    raw = config.OIDC_SCOPE or ""
+    if not config.OIDC_USE_REFRESH_TOKEN:
+        return raw
+
+    separator = "," if "," in raw else " "
+    scopes = [s.strip() for s in raw.replace(",", " ").split() if s.strip()]
+    if "offline_access" not in scopes:
+        scopes.append("offline_access")
+    return separator.join(scopes)
+
+
 def ensure_oidc_client_registered() -> bool:
     """Ensure the 'oidc' client is registered.
 
@@ -50,7 +70,7 @@ def ensure_oidc_client_registered() -> bool:
             client_id=config.OIDC_CLIENT_ID,
             client_secret=config.OIDC_CLIENT_SECRET,
             server_metadata_url=config.OIDC_DISCOVERY_URL,
-            client_kwargs={"scope": config.OIDC_SCOPE},
+            client_kwargs={"scope": _build_scope()},
         )
         _oidc_client_registered = True
         return True

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -5,6 +5,7 @@ This router handles OIDC authentication flows including login, logout, and callb
 """
 
 import secrets
+import time
 from collections.abc import Awaitable
 from typing import Any, Optional
 from urllib.parse import urlencode
@@ -97,6 +98,95 @@ async def _authorize_access_token_with_retry(
     if last_error:
         raise last_error
     return None
+
+
+async def refresh_session_with_idp(session) -> bool:
+    """Attempt to refresh an expired session against the IdP using the stored refresh token.
+
+    Returns True on success (session updated in place with new ``expires_at`` and,
+    when rotated, a new ``refresh_token``). Returns False on any failure — the
+    caller is expected to clear the session and force re-authentication.
+
+    No-op (returns False) when ``OIDC_USE_REFRESH_TOKEN`` is disabled or no
+    refresh token is stored, so this is safe to call unconditionally from the
+    middleware.
+    """
+
+    if not config.OIDC_USE_REFRESH_TOKEN:
+        return False
+
+    refresh_token = session.get("refresh_token") if session is not None else None
+    if not refresh_token:
+        return False
+
+    fetch_fn = getattr(oauth.oidc, "fetch_access_token", None)
+    if fetch_fn is None:
+        logger.warning("OIDC client has no fetch_access_token; cannot refresh session")
+        return False
+
+    try:
+        new_token = await _maybe_await(fetch_fn(grant_type="refresh_token", refresh_token=refresh_token))
+    except Exception as exc:
+        logger.warning("OIDC refresh token exchange failed: %s", exc)
+        return False
+
+    if not new_token:
+        return False
+
+    _persist_session_auth(session, new_token)
+    return True
+
+
+def _extract_session_expiry(token_response: dict[str, Any]) -> Optional[int]:
+    """Extract the session expiry timestamp (Unix seconds) from an OIDC token response.
+
+    Prefers ``expires_at`` (set by Authlib from ``expires_in``), then the ``exp``
+    claim of the validated id_token, then falls back to computing
+    ``now + expires_in``. Returns None when no expiry information is available
+    (in which case the caller should leave the session unchanged so behaviour
+    matches the legacy ~14-day cookie window).
+    """
+
+    expires_at = token_response.get("expires_at")
+    if isinstance(expires_at, (int, float)) and expires_at > 0:
+        return int(expires_at)
+
+    userinfo = token_response.get("userinfo") or {}
+    id_token_exp = userinfo.get("exp")
+    if isinstance(id_token_exp, (int, float)) and id_token_exp > 0:
+        return int(id_token_exp)
+
+    expires_in = token_response.get("expires_in")
+    if isinstance(expires_in, (int, float)) and expires_in > 0:
+        return int(time.time()) + int(expires_in)
+
+    return None
+
+
+def _persist_session_auth(session, token_response: dict[str, Any]) -> None:
+    """Store IdP-issued expiry (and optionally the refresh token) in the session.
+
+    Called after a successful OIDC token exchange. ``OIDC_USE_REFRESH_TOKEN``
+    gates persistence of the refresh token because storing one in a signed
+    (but not encrypted) cookie has security implications, and many enterprises
+    disallow ``offline_access`` outright.
+    """
+
+    expiry = _extract_session_expiry(token_response)
+    if expiry is not None:
+        session["expires_at"] = expiry
+    else:
+        # No reliable expiry from the IdP; remove any stale value from a prior login.
+        session.pop("expires_at", None)
+
+    if config.OIDC_USE_REFRESH_TOKEN:
+        refresh_token = token_response.get("refresh_token")
+        if refresh_token:
+            session["refresh_token"] = refresh_token
+        else:
+            session.pop("refresh_token", None)
+    else:
+        session.pop("refresh_token", None)
 
 
 def _build_ui_url(request: Request, path: str, query_params: Optional[dict] = None) -> str:
@@ -517,6 +607,8 @@ async def _process_oidc_callback_fastapi(request: Request, session) -> tuple[Opt
             logger.error(f"User/group management error: {str(e)}")
             errors.append("Failed to update user/groups")
             return None, errors
+
+        _persist_session_auth(session, token_response)
 
         return email.lower(), []
 

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -189,6 +189,28 @@ def _persist_session_auth(session, token_response: dict[str, Any]) -> None:
         session.pop("refresh_token", None)
 
 
+def _sanitize_next(value: Optional[str]) -> Optional[str]:
+    """Validate a ``next`` redirect target. Only same-origin relative paths are
+    accepted to prevent open-redirect attacks. Returns None on rejection.
+
+    Accepts: ``/users``, ``/oidc/ui/groups``, ``/#/experiments/0``.
+    Rejects: ``http://evil``, ``//evil``, ``javascript:...``, anything not starting
+    with a single ``/``.
+    """
+
+    if not value:
+        return None
+    if not isinstance(value, str):
+        return None
+    if not value.startswith("/"):
+        return None
+    if value.startswith("//"):  # protocol-relative URL — would escape origin
+        return None
+    if "\n" in value or "\r" in value:  # header-injection guard
+        return None
+    return value
+
+
 def _build_ui_url(request: Request, path: str, query_params: Optional[dict] = None) -> str:
     """
     Build a UI URL with the correct prefix and optional query parameters.
@@ -241,6 +263,13 @@ async def login(request: Request):
         # Generate OAuth state for CSRF protection
         oauth_state = secrets.token_urlsafe(32)
         session["oauth_state"] = oauth_state
+
+        # Capture an optional ?next= return target so the callback can return
+        # the user to where they were before the session expired. Validated to
+        # be a same-origin relative path; anything else is dropped silently.
+        next_target = _sanitize_next(request.query_params.get("next"))
+        if next_target:
+            session["redirect_after_login"] = next_target
 
         # Get redirect URI (configured or dynamic). Use a safe fallback if dynamic calculation fails
         try:

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -183,8 +183,10 @@ def _persist_session_auth(session, token_response: dict[str, Any]) -> None:
         refresh_token = token_response.get("refresh_token")
         if refresh_token:
             session["refresh_token"] = refresh_token
-        else:
-            session.pop("refresh_token", None)
+        # If the response has no refresh_token, keep the existing one. Many
+        # IdPs only emit refresh_token on the initial token exchange and reuse
+        # it across subsequent refreshes (Microsoft Entra, some Keycloak
+        # configs, etc.). Popping it here would break the next refresh.
     else:
         session.pop("refresh_token", None)
 

--- a/mlflow_oidc_auth/tests/middleware/conftest.py
+++ b/mlflow_oidc_auth/tests/middleware/conftest.py
@@ -210,6 +210,10 @@ class MockRequest:
         self.scope = scope
         self.url = MagicMock()
         self.url.path = scope.get("path", "/")
+        # Real string so middleware code that does string ops on .query works.
+        self.url.query = (
+            scope.get("query_string", b"").decode() if isinstance(scope.get("query_string", b""), (bytes, bytearray)) else (scope.get("query_string", "") or "")
+        )
         self.headers = {}
 
         # Convert headers from scope

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -66,6 +66,12 @@ class TestAuthMiddleware:
         assert auth_middleware._is_unprotected_route("/oidc/ui") is True
         assert auth_middleware._is_unprotected_route("/oidc/ui/admin") is True
 
+    def test_is_unprotected_route_mlflow_static_files(self, auth_middleware):
+        """MLflow's hashed bundle assets must load even without a valid session."""
+        assert auth_middleware._is_unprotected_route("/static-files/static/js/9605.46a42772.chunk.js") is True
+        assert auth_middleware._is_unprotected_route("/static-files/static/css/main.css") is True
+        assert auth_middleware._is_unprotected_route("/static-files/static/media/default-error.svg") is True
+
     def test_is_unprotected_route_protected(self, auth_middleware):
         """Test that other routes are protected."""
         assert auth_middleware._is_unprotected_route("/api/users") is False
@@ -288,6 +294,81 @@ class TestAuthMiddleware:
                 delattr(request.__class__, "session")
 
     @pytest.mark.asyncio
+    async def test_authenticate_session_unexpired_passes_through(self, auth_middleware, create_mock_request):
+        """A session with a future ``expires_at`` is allowed without touching the IdP."""
+        future = 9999999999  # year 2286
+        request = create_mock_request(session={"username": "user@example.com", "expires_at": future})
+
+        success, username, error = await auth_middleware._authenticate_session(request)
+
+        assert success is True
+        assert username == "user@example.com"
+        assert error == ""
+
+    @pytest.mark.asyncio
+    async def test_authenticate_session_expired_no_refresh_token_clears(self, auth_middleware, create_mock_request):
+        """Expired sessions without a refresh token are cleared and rejected."""
+        from mlflow_oidc_auth.middleware import auth_middleware as middleware_mod
+
+        session = {"username": "user@example.com", "expires_at": 100}  # 1970, well past
+
+        # Patch refresh helper to confirm no successful refresh path
+        from unittest.mock import AsyncMock, patch as _patch
+
+        with (
+            _patch("mlflow_oidc_auth.routers.auth.refresh_session_with_idp", new=AsyncMock(return_value=False)),
+            _patch.object(middleware_mod.config, "OIDC_SESSION_EXPIRY_LEEWAY_SECONDS", 0, create=True),
+        ):
+            request = create_mock_request(session=session)
+            success, username, error = await auth_middleware._authenticate_session(request)
+
+        assert success is False
+        assert username is None
+        assert error == "Session expired"
+        assert "username" not in session  # session.clear() was called
+
+    @pytest.mark.asyncio
+    async def test_authenticate_session_expired_refresh_succeeds(self, auth_middleware, create_mock_request):
+        """When OIDC_USE_REFRESH_TOKEN is on and refresh succeeds, the session is accepted."""
+        from mlflow_oidc_auth.middleware import auth_middleware as middleware_mod
+
+        session = {
+            "username": "user@example.com",
+            "expires_at": 100,
+            "refresh_token": "rt-123",
+        }
+
+        async def fake_refresh(s):
+            s["expires_at"] = 9999999999
+            s["refresh_token"] = "rt-456"
+            return True
+
+        from unittest.mock import patch as _patch
+
+        with (
+            _patch("mlflow_oidc_auth.routers.auth.refresh_session_with_idp", side_effect=fake_refresh),
+            _patch.object(middleware_mod.config, "OIDC_SESSION_EXPIRY_LEEWAY_SECONDS", 0, create=True),
+        ):
+            request = create_mock_request(session=session)
+            success, username, error = await auth_middleware._authenticate_session(request)
+
+        assert success is True
+        assert username == "user@example.com"
+        assert error == ""
+        assert session["expires_at"] == 9999999999
+        assert session["refresh_token"] == "rt-456"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_session_no_expires_at_unchanged(self, auth_middleware, create_mock_request):
+        """Sessions predating this feature (no ``expires_at``) keep working."""
+        request = create_mock_request(session={"username": "user@example.com"})
+
+        success, username, error = await auth_middleware._authenticate_session(request)
+
+        assert success is True
+        assert username == "user@example.com"
+
+    @pytest.mark.asyncio
     async def test_authenticate_user_basic_auth_priority(self, auth_middleware, create_mock_request, mock_store):
         """Test that basic auth takes priority over other methods."""
         with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
@@ -468,13 +549,16 @@ class TestAuthMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_user_automatic_redirect(self, auth_middleware, create_mock_request, mock_config):
-        """Test dispatch for unauthenticated user with automatic login redirect."""
+        """Document navigation requests redirect to login when auto-redirect is enabled."""
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True
 
         with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
-            request = create_mock_request(path="/protected", session={})
+            request = create_mock_request(
+                path="/protected",
+                session={},
+                headers={"sec-fetch-dest": "document"},
+            )
 
-            # Mock call_next (should not be called)
             async def mock_call_next(req):
                 pytest.fail("call_next should not be called for unauthenticated user")
 
@@ -486,13 +570,16 @@ class TestAuthMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_user_oidc_ui_redirect(self, auth_middleware, create_mock_request, mock_config):
-        """Test dispatch for unauthenticated user with OIDC UI redirect."""
+        """Document navigation requests redirect to the UI when auto-redirect is disabled."""
         mock_config.AUTOMATIC_LOGIN_REDIRECT = False
 
         with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
-            request = create_mock_request(path="/protected", session={})
+            request = create_mock_request(
+                path="/protected",
+                session={},
+                headers={"sec-fetch-dest": "document"},
+            )
 
-            # Mock call_next (should not be called)
             async def mock_call_next(req):
                 pytest.fail("call_next should not be called for unauthenticated user")
 
@@ -501,6 +588,63 @@ class TestAuthMiddleware:
             assert isinstance(response, RedirectResponse)
             assert response.status_code == 302
             assert response.headers["location"] == "/oidc/ui"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unauthenticated_subresource_returns_401(self, auth_middleware, create_mock_request, mock_config):
+        """Subresource fetches (chunks, fetch/XHR) get 401 instead of a 302 → HTML.
+
+        Otherwise the browser silently follows the redirect and the JS chunk
+        loader / JSON.parse receives HTML and throws — that's the regression
+        that broke the SPA mid-session once IdP-issued expiry kicked in.
+        """
+        mock_config.AUTOMATIC_LOGIN_REDIRECT = True
+
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
+            # Browser script fetch — Sec-Fetch-Dest is the modern signal.
+            # Use a protected path; /static-files/* is unprotected by design.
+            request = create_mock_request(
+                path="/some-app-route/data.js",
+                session={},
+                headers={"sec-fetch-dest": "script"},
+            )
+
+            response = await auth_middleware.dispatch(request, lambda r: pytest.fail("should not be called"))
+
+            assert response.status_code == 401
+            assert b"Authentication required" in response.body
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unauthenticated_xhr_returns_401_via_accept_fallback(self, auth_middleware, create_mock_request, mock_config):
+        """Older clients without Sec-Fetch-Dest fall back to the Accept header."""
+        mock_config.AUTOMATIC_LOGIN_REDIRECT = True
+
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
+            request = create_mock_request(
+                path="/some-endpoint",
+                session={},
+                headers={"accept": "application/json"},
+            )
+
+            response = await auth_middleware.dispatch(request, lambda r: pytest.fail("should not be called"))
+
+            assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unauthenticated_html_accept_redirects(self, auth_middleware, create_mock_request, mock_config):
+        """Without Sec-Fetch-Dest, an Accept: text/html header still redirects."""
+        mock_config.AUTOMATIC_LOGIN_REDIRECT = True
+
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
+            request = create_mock_request(
+                path="/some-endpoint",
+                session={},
+                headers={"accept": "text/html,application/xhtml+xml"},
+            )
+
+            response = await auth_middleware.dispatch(request, lambda r: pytest.fail("should not be called"))
+
+            assert isinstance(response, RedirectResponse)
+            assert response.status_code == 302
 
     @pytest.mark.asyncio
     async def test_dispatch_basic_auth_header(self, auth_middleware, create_mock_request, mock_store):
@@ -632,7 +776,7 @@ class TestAuthMiddleware:
     async def test_dispatch_case_sensitivity(self, auth_middleware, create_mock_request):
         """Test that route protection is case sensitive."""
         # Uppercase paths should be protected (case sensitive)
-        request = create_mock_request(path="/HEALTH")
+        request = create_mock_request(path="/HEALTH", headers={"sec-fetch-dest": "document"})
 
         # Mock call_next (should not be called for protected route without auth)
         async def mock_call_next(req):

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -456,17 +456,21 @@ class TestAuthMiddleware:
 
     @pytest.mark.asyncio
     async def test_handle_auth_redirect_automatic_login(self, auth_middleware, create_mock_request, mock_config):
-        """Test authentication redirect with automatic login enabled."""
+        """Test authentication redirect with automatic login enabled.
+
+        Includes the ``?next=<original-path>`` round-trip so the user lands
+        back on the page they tried to load instead of the root.
+        """
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True
 
         with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
-            request = create_mock_request()
+            request = create_mock_request(path="/protected")
 
             response = await auth_middleware._handle_auth_redirect(request)
 
             assert isinstance(response, RedirectResponse)
             assert response.status_code == 302
-            assert response.headers["location"] == "/login"
+            assert response.headers["location"] == "/login?next=%2Fprotected"
 
     @pytest.mark.asyncio
     async def test_handle_auth_redirect_no_automatic_login(self, auth_middleware, create_mock_request, mock_config):
@@ -566,7 +570,7 @@ class TestAuthMiddleware:
 
             assert isinstance(response, RedirectResponse)
             assert response.status_code == 302
-            assert response.headers["location"] == "/login"
+            assert response.headers["location"] == "/login?next=%2Fprotected"
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_user_oidc_ui_redirect(self, auth_middleware, create_mock_request, mock_config):
@@ -588,6 +592,24 @@ class TestAuthMiddleware:
             assert isinstance(response, RedirectResponse)
             assert response.status_code == 302
             assert response.headers["location"] == "/oidc/ui"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_unauthenticated_user_preserves_query_string_in_next(self, auth_middleware, create_mock_request, mock_config):
+        """Query string is forwarded as part of ?next= so deep links survive re-auth."""
+        mock_config.AUTOMATIC_LOGIN_REDIRECT = True
+
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
+            request = create_mock_request(
+                path="/protected",
+                session={},
+                headers={"sec-fetch-dest": "document"},
+            )
+            request.url.query = "tab=runs&id=42"
+
+            response = await auth_middleware.dispatch(request, lambda r: pytest.fail("nope"))
+
+            assert isinstance(response, RedirectResponse)
+            assert response.headers["location"] == "/login?next=%2Fprotected%3Ftab%3Druns%26id%3D42"
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_subresource_returns_401(self, auth_middleware, create_mock_request, mock_config):

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -18,12 +18,15 @@ from mlflow_oidc_auth.routers.auth import (
     LOGIN,
     LOGOUT,
     _build_ui_url,
+    _extract_session_expiry,
+    _persist_session_auth,
     _process_oidc_callback_fastapi,
     auth_router,
     auth_status,
     callback,
     login,
     logout,
+    refresh_session_with_idp,
 )
 
 
@@ -597,3 +600,200 @@ class TestProcessOIDCCallbackFastAPI:
             assert email is None
             assert len(errors) == 1
             assert "Failed to update user/groups" in errors[0]
+
+
+class TestExtractSessionExpiry:
+    """Test ``_extract_session_expiry`` precedence rules."""
+
+    def test_prefers_expires_at(self):
+        token = {"expires_at": 12345, "expires_in": 3600, "userinfo": {"exp": 99999}}
+        assert _extract_session_expiry(token) == 12345
+
+    def test_falls_back_to_id_token_exp(self):
+        token = {"userinfo": {"exp": 99999}, "expires_in": 3600}
+        assert _extract_session_expiry(token) == 99999
+
+    def test_computes_from_expires_in_when_no_expires_at(self):
+        import time as _time
+
+        token = {"expires_in": 3600}
+        result = _extract_session_expiry(token)
+        # Allow a few seconds of slack between time.time() inside and outside.
+        assert result is not None
+        assert abs(result - (int(_time.time()) + 3600)) < 5
+
+    def test_returns_none_when_unavailable(self):
+        assert _extract_session_expiry({}) is None
+        assert _extract_session_expiry({"userinfo": {}}) is None
+
+    def test_ignores_non_numeric_expiry(self):
+        assert _extract_session_expiry({"expires_at": "soon"}) is None
+
+
+class TestPersistSessionAuth:
+    """Test that the callback persists exactly the session fields needed for re-auth."""
+
+    def test_stores_expires_at_when_refresh_disabled(self, mock_config):
+        mock_config.OIDC_USE_REFRESH_TOKEN = False
+        session = {}
+        token = {"expires_at": 9999999999, "refresh_token": "rt"}
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            _persist_session_auth(session, token)
+
+        assert session["expires_at"] == 9999999999
+        # Refresh token must NOT leak into the cookie when feature is disabled.
+        assert "refresh_token" not in session
+
+    def test_stores_refresh_token_when_enabled(self, mock_config):
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+        session = {}
+        token = {"expires_at": 9999999999, "refresh_token": "rt-abc"}
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            _persist_session_auth(session, token)
+
+        assert session["expires_at"] == 9999999999
+        assert session["refresh_token"] == "rt-abc"
+
+    def test_clears_stale_expires_at_when_no_new_expiry(self, mock_config):
+        mock_config.OIDC_USE_REFRESH_TOKEN = False
+        session = {"expires_at": 100}
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            _persist_session_auth(session, {})  # token response without expiry info
+
+        assert "expires_at" not in session
+
+    def test_drops_refresh_token_when_disabled_after_enabled(self, mock_config):
+        # Simulates rotating from refresh-enabled deployment back to disabled.
+        mock_config.OIDC_USE_REFRESH_TOKEN = False
+        session = {"refresh_token": "stale"}
+        token = {"expires_at": 9999999999, "refresh_token": "rt-new"}
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            _persist_session_auth(session, token)
+
+        assert "refresh_token" not in session
+
+
+class TestRefreshSessionWithIdP:
+    """Test ``refresh_session_with_idp`` against the OAuth client."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_feature_off(self, mock_config):
+        mock_config.OIDC_USE_REFRESH_TOKEN = False
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            assert await refresh_session_with_idp({"refresh_token": "rt"}) is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_refresh_token(self, mock_config):
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            assert await refresh_session_with_idp({}) is False
+
+    @pytest.mark.asyncio
+    async def test_success_updates_session(self, mock_config, mock_oauth):
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+        mock_oauth.oidc.fetch_access_token = AsyncMock(
+            return_value={
+                "access_token": "new",
+                "expires_at": 9999999999,
+                "refresh_token": "rt-new",
+            }
+        )
+        session = {"refresh_token": "rt-old", "expires_at": 1, "username": "u@x"}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+        ):
+            ok = await refresh_session_with_idp(session)
+
+        assert ok is True
+        assert session["expires_at"] == 9999999999
+        assert session["refresh_token"] == "rt-new"
+        assert session["username"] == "u@x"  # untouched
+        mock_oauth.oidc.fetch_access_token.assert_awaited_once_with(grant_type="refresh_token", refresh_token="rt-old")
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_false_without_mutating(self, mock_config, mock_oauth):
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+        mock_oauth.oidc.fetch_access_token = AsyncMock(side_effect=RuntimeError("idp down"))
+        session = {"refresh_token": "rt-old", "expires_at": 1}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+        ):
+            ok = await refresh_session_with_idp(session)
+
+        assert ok is False
+        # Session retains its (still-stale) values; middleware is responsible for clearing it.
+        assert session["refresh_token"] == "rt-old"
+        assert session["expires_at"] == 1
+
+
+class TestProcessCallbackPersistsExpiry:
+    """End-to-end: the callback path persists the IdP expiry into the session."""
+
+    @pytest.mark.asyncio
+    async def test_callback_writes_expires_at(self, mock_request_with_session, mock_oauth, mock_config, mock_user_management):
+        mock_config.OIDC_USE_REFRESH_TOKEN = False
+        mock_oauth.oidc.authorize_access_token = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "id_token": "idt",
+                "expires_at": 9999999999,
+                "userinfo": {
+                    "email": "test@example.com",
+                    "name": "Test User",
+                    "groups": ["test-group"],
+                },
+            }
+        )
+        request = mock_request_with_session({"oauth_state": "test_state"})
+        request.query_params = {"state": "test_state", "code": "auth_code_123"}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+        ):
+            email, errors = await _process_oidc_callback_fastapi(request, request.session)
+
+        assert errors == []
+        assert email == "test@example.com"
+        assert request.session["expires_at"] == 9999999999
+        assert "refresh_token" not in request.session
+
+    @pytest.mark.asyncio
+    async def test_callback_writes_refresh_token_when_enabled(self, mock_request_with_session, mock_oauth, mock_config, mock_user_management):
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+        mock_oauth.oidc.authorize_access_token = AsyncMock(
+            return_value={
+                "access_token": "at",
+                "id_token": "idt",
+                "expires_at": 9999999999,
+                "refresh_token": "rt-xyz",
+                "userinfo": {
+                    "email": "test@example.com",
+                    "name": "Test User",
+                    "groups": ["test-group"],
+                },
+            }
+        )
+        request = mock_request_with_session({"oauth_state": "test_state"})
+        request.query_params = {"state": "test_state", "code": "auth_code_123"}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+        ):
+            email, errors = await _process_oidc_callback_fastapi(request, request.session)
+
+        assert errors == []
+        assert email == "test@example.com"
+        assert request.session["expires_at"] == 9999999999
+        assert request.session["refresh_token"] == "rt-xyz"

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -111,6 +111,40 @@ class TestLoginEndpoint:
             )
 
     @pytest.mark.asyncio
+    async def test_login_captures_safe_next_param(self, mock_request_with_session, mock_oauth, mock_config):
+        """``/login?next=<relative-path>`` is stored so the callback can return there."""
+        request = mock_request_with_session({"oauth_state": None})
+        request.query_params = {"next": "/oidc/ui/groups"}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+            patch("mlflow_oidc_auth.routers.auth.get_configured_or_dynamic_redirect_uri") as mock_redirect,
+            patch("mlflow_oidc_auth.routers.auth.is_oidc_configured", return_value=True),
+        ):
+            mock_redirect.return_value = "http://localhost:8000/callback"
+            await login(request)
+
+        assert request.session["redirect_after_login"] == "/oidc/ui/groups"
+
+    @pytest.mark.asyncio
+    async def test_login_drops_unsafe_next_param(self, mock_request_with_session, mock_oauth, mock_config):
+        """Open-redirect targets must be ignored."""
+        request = mock_request_with_session({"oauth_state": None})
+        request.query_params = {"next": "https://attacker.example/steal"}
+
+        with (
+            patch("mlflow_oidc_auth.routers.auth.oauth", mock_oauth),
+            patch("mlflow_oidc_auth.routers.auth.config", mock_config),
+            patch("mlflow_oidc_auth.routers.auth.get_configured_or_dynamic_redirect_uri") as mock_redirect,
+            patch("mlflow_oidc_auth.routers.auth.is_oidc_configured", return_value=True),
+        ):
+            mock_redirect.return_value = "http://localhost:8000/callback"
+            await login(request)
+
+        assert "redirect_after_login" not in request.session
+
+    @pytest.mark.asyncio
     async def test_login_oauth_not_configured(self, mock_request_with_session):
         """Test login when OAuth client is not properly configured."""
         request = mock_request_with_session()
@@ -797,3 +831,47 @@ class TestProcessCallbackPersistsExpiry:
         assert email == "test@example.com"
         assert request.session["expires_at"] == 9999999999
         assert request.session["refresh_token"] == "rt-xyz"
+
+
+class TestSanitizeNext:
+    """Validate the open-redirect guard on the ?next= query param."""
+
+    def test_accepts_relative_path(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next("/oidc/ui/groups") == "/oidc/ui/groups"
+
+    def test_accepts_path_with_search_and_hash(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next("/?tab=runs#/experiments/0") == "/?tab=runs#/experiments/0"
+
+    def test_rejects_absolute_url(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next("https://attacker.example/steal") is None
+        assert _sanitize_next("http://attacker.example/") is None
+
+    def test_rejects_protocol_relative(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        # //evil.example escapes origin in browsers — must reject.
+        assert _sanitize_next("//evil.example/path") is None
+
+    def test_rejects_javascript_scheme(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next("javascript:alert(1)") is None
+
+    def test_rejects_header_injection_chars(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next("/path\nLocation: http://evil") is None
+        assert _sanitize_next("/path\rfoo") is None
+
+    def test_rejects_empty_and_none(self):
+        from mlflow_oidc_auth.routers.auth import _sanitize_next
+
+        assert _sanitize_next(None) is None
+        assert _sanitize_next("") is None
+        assert _sanitize_next("no-leading-slash") is None

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -710,6 +710,20 @@ class TestPersistSessionAuth:
 
         assert "refresh_token" not in session
 
+    def test_keeps_existing_refresh_token_when_response_omits_one(self, mock_config):
+        """Many IdPs (Entra, some Keycloak configs) emit refresh_token only on
+        the initial token exchange and reuse the same one across refreshes.
+        Removing the stored token would break the next refresh."""
+        mock_config.OIDC_USE_REFRESH_TOKEN = True
+        session = {"refresh_token": "rt-original"}
+        token = {"expires_at": 9999999999}  # No refresh_token in the response
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+            _persist_session_auth(session, token)
+
+        assert session["refresh_token"] == "rt-original"
+        assert session["expires_at"] == 9999999999
+
 
 class TestRefreshSessionWithIdP:
     """Test ``refresh_session_with_idp`` against the OAuth client."""

--- a/mlflow_oidc_auth/tests/routers/test_ui.py
+++ b/mlflow_oidc_auth/tests/routers/test_ui.py
@@ -459,8 +459,11 @@ class TestUIRouterIntegration:
                 # Attempt path traversal
                 response = client.get("/oidc/ui/../../../etc/passwd")
 
-                # Router may either return the SPA (200) or reject access (403)
-                assert response.status_code in [200, 403, 404]
+                # Acceptable outcomes: serve the SPA (200), reject (401/403/404).
+                # 401 is the AuthMiddleware's response when an unauthenticated
+                # subresource fetch falls outside the unprotected /oidc/ui prefix —
+                # which is exactly what we want for a traversal attempt.
+                assert response.status_code in [200, 401, 403, 404]
 
                 if response.status_code == 200:
                     assert "UI" in response.text

--- a/mlflow_oidc_auth/tests/test_app.py
+++ b/mlflow_oidc_auth/tests/test_app.py
@@ -538,9 +538,10 @@ class TestAppErrorHandling:
             mock_getattr.return_value = True
 
             # Since testing actual import failures is complex and can affect other imports,
-            # we'll test the behavior when EXTEND_MLFLOW_MENU is False instead
-            # This ensures the hack import code path is not executed
+            # we'll test the behavior when EXTEND_MLFLOW_MENU and EXTEND_MLFLOW_REAUTH
+            # are both False — this ensures the hack import code path is not executed.
             mock_config.EXTEND_MLFLOW_MENU = False
+            mock_config.EXTEND_MLFLOW_REAUTH = False
             mock_config.MLFLOW_ENABLE_WORKSPACES = False
 
             # Call the function

--- a/mlflow_oidc_auth/tests/test_hack.py
+++ b/mlflow_oidc_auth/tests/test_hack.py
@@ -15,6 +15,20 @@ from flask import Response
 from mlflow_oidc_auth.hack import index
 
 
+@pytest.fixture(autouse=True)
+def _menu_only_config():
+    """Pin pre-existing tests to menu-only injection so their fixtures stay valid.
+
+    Reauth injection (default-on in production) is exercised by its own dedicated
+    test class below.
+    """
+
+    with patch("mlflow_oidc_auth.hack.config") as cfg:
+        cfg.EXTEND_MLFLOW_MENU = True
+        cfg.EXTEND_MLFLOW_REAUTH = False
+        yield cfg
+
+
 class TestHackIndex:
     """Test the index function that handles MLflow UI extension."""
 
@@ -874,3 +888,85 @@ class TestHackModulePerformance:
 
                     # Verify correct result
                     assert menu_html in result
+
+
+class TestReauthInjection:
+    """Cover the EXTEND_MLFLOW_REAUTH flag and the combined injection ordering."""
+
+    def _run_index(self, html: str, snippets: dict, *, reauth: bool, menu: bool):
+        """Drive ``hack.index()`` with a controlled file-system / config state."""
+
+        mock_app = MagicMock()
+        mock_app.static_folder = "/fake/static"
+
+        def open_side_effect(file_path, mode="r"):
+            if "index.html" in file_path:
+                return mock_open(read_data=html).return_value
+            for key, content in snippets.items():
+                if key in file_path:
+                    return mock_open(read_data=content).return_value
+            raise FileNotFoundError(file_path)
+
+        with (
+            patch.dict("sys.modules", {"mlflow.server": MagicMock(app=mock_app)}),
+            patch("mlflow_oidc_auth.hack.os.path.exists", return_value=True),
+            patch("builtins.open", mock_open()) as mock_file_open,
+            patch("mlflow_oidc_auth.hack.config") as cfg,
+        ):
+            cfg.EXTEND_MLFLOW_REAUTH = reauth
+            cfg.EXTEND_MLFLOW_MENU = menu
+            mock_file_open.side_effect = open_side_effect
+            return index()
+
+    def test_reauth_only_injection(self):
+        """When only reauth is enabled, only the reauth snippet is appended."""
+        html = "<html><body>Content</body></html>"
+        result = self._run_index(
+            html,
+            {"reauth.html": "<script>REAUTH</script>", "menu.html": "<script>MENU</script>"},
+            reauth=True,
+            menu=False,
+        )
+        assert "REAUTH" in result
+        assert "MENU" not in result
+        assert "</body>" in result
+
+    def test_both_enabled_reauth_runs_first(self):
+        """Reauth must precede menu in the injected output so the fetch patch
+        is in place before any later script issues network calls."""
+        html = "<html><body>Content</body></html>"
+        result = self._run_index(
+            html,
+            {"reauth.html": "<!--REAUTH_MARK-->", "menu.html": "<!--MENU_MARK-->"},
+            reauth=True,
+            menu=True,
+        )
+        assert result.index("REAUTH_MARK") < result.index("MENU_MARK")
+
+    def test_both_disabled_returns_unmodified(self):
+        """If both flags are off, ``index`` returns the original HTML unchanged."""
+        html = "<html><body>Content</body></html>"
+        result = self._run_index(
+            html,
+            {"reauth.html": "<!--REAUTH-->", "menu.html": "<!--MENU-->"},
+            reauth=False,
+            menu=False,
+        )
+        assert "REAUTH" not in result
+        assert "MENU" not in result
+        assert result == html
+
+    def test_reauth_snippet_file_exists_in_repo(self):
+        """The shipped reauth.html must exist on disk — otherwise default-on
+        deployments silently degrade to no re-auth helper."""
+        from mlflow_oidc_auth import hack
+
+        snippet_path = os.path.join(hack._HACK_DIR, "reauth.html")
+        assert os.path.isfile(snippet_path)
+        with open(snippet_path) as f:
+            content = f.read()
+        # Spot-check: the snippet should patch fetch and XHR and act on a 401.
+        assert "window.fetch" in content
+        assert "XMLHttpRequest.prototype.send" in content
+        assert "401" in content
+        assert "window.location.reload" in content

--- a/mlflow_oidc_auth/tests/test_hack.py
+++ b/mlflow_oidc_auth/tests/test_hack.py
@@ -965,8 +965,10 @@ class TestReauthInjection:
         assert os.path.isfile(snippet_path)
         with open(snippet_path) as f:
             content = f.read()
-        # Spot-check: the snippet should patch fetch and XHR and act on a 401.
+        # Spot-check: the snippet should patch fetch and XHR, react to a 401,
+        # and forward the current location to /login as ?next=.
         assert "window.fetch" in content
         assert "XMLHttpRequest.prototype.send" in content
         assert "401" in content
-        assert "window.location.reload" in content
+        assert "/login?next=" in content
+        assert "window.location.hash" in content

--- a/mlflow_oidc_auth/tests/test_oauth.py
+++ b/mlflow_oidc_auth/tests/test_oauth.py
@@ -406,5 +406,45 @@ class TestOAuthSecurity(unittest.TestCase):
         self.assertTrue(hasattr(mlflow_oidc_auth.oauth.oauth, "register"))
 
 
+class TestBuildScope(unittest.TestCase):
+    """Test the ``_build_scope`` helper that adds ``offline_access`` when refresh is enabled."""
+
+    def test_no_offline_access_when_refresh_disabled(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,email,profile", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid,email,profile")
+
+    def test_appends_offline_access_to_csv_scope(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", True, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,email,profile", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid,email,profile,offline_access")
+
+    def test_appends_offline_access_to_space_separated_scope(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", True, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid email profile", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid email profile offline_access")
+
+    def test_does_not_duplicate_offline_access(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", True, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,offline_access,email", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid,offline_access,email")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web-react/src/core/services/http.test.ts
+++ b/web-react/src/core/services/http.test.ts
@@ -146,8 +146,8 @@ describe("http", () => {
           assign: assignSpy,
         },
       });
-      // Ensure no <base> element from a prior test.
-      document.head.querySelector("base")?.remove();
+      // Reset runtime config between tests.
+      delete (window as { __RUNTIME_CONFIG__?: unknown }).__RUNTIME_CONFIG__;
     });
 
     afterEachRestoreLocation: {
@@ -234,10 +234,10 @@ describe("http", () => {
       expect(assignSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("respects <base href> when computing the login URL", async () => {
-      const baseEl = document.createElement("base");
-      baseEl.setAttribute("href", "/proxy/path/");
-      document.head.appendChild(baseEl);
+    it("uses runtime config basePath for the login URL behind a proxy", async () => {
+      (window as { __RUNTIME_CONFIG__?: { basePath?: string } }).__RUNTIME_CONFIG__ = {
+        basePath: "/proxy/path",
+      };
 
       vi.mocked(fetch).mockResolvedValue({
         ok: false,
@@ -250,6 +250,29 @@ describe("http", () => {
       await expect(http("/api/users")).rejects.toThrow("HTTP 401");
       expect(assignSpy).toHaveBeenCalledWith(
         "/proxy/path/login?next=" + encodeURIComponent("/oidc/ui/users"),
+      );
+    });
+
+    it("ignores <base href> (which points at /oidc/ui/) when redirecting", async () => {
+      // The plugin SPA's <base href> is the UI mount point — not the right
+      // anchor for /login, which lives at <basePath>/login.
+      const baseEl = document.createElement("base");
+      baseEl.setAttribute("href", "/oidc/ui/");
+      document.head.appendChild(baseEl);
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 401");
+      // Falls back to root because no runtime config is set, so /login (NOT
+      // /oidc/ui/login) is what gets called.
+      expect(assignSpy).toHaveBeenCalledWith(
+        "/login?next=" + encodeURIComponent("/oidc/ui/users"),
       );
 
       baseEl.remove();

--- a/web-react/src/core/services/http.test.ts
+++ b/web-react/src/core/services/http.test.ts
@@ -141,6 +141,8 @@ describe("http", () => {
         value: {
           ...originalLocation,
           pathname: "/oidc/ui/users",
+          search: "",
+          hash: "",
           assign: assignSpy,
         },
       });
@@ -153,7 +155,7 @@ describe("http", () => {
       // so explicit restore isn't required.
     }
 
-    it("redirects to /login on 401 from a non-auth page", async () => {
+    it("redirects to /login with ?next= on 401 from a non-auth page", async () => {
       vi.mocked(fetch).mockResolvedValue({
         ok: false,
         status: 401,
@@ -164,13 +166,47 @@ describe("http", () => {
 
       await expect(http("/api/users")).rejects.toThrow("HTTP 401");
       expect(assignSpy).toHaveBeenCalledTimes(1);
-      expect(assignSpy).toHaveBeenCalledWith("/login");
+      expect(assignSpy).toHaveBeenCalledWith(
+        "/login?next=" + encodeURIComponent("/oidc/ui/users"),
+      );
+    });
+
+    it("preserves search and hash in ?next=", async () => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          ...window.location,
+          pathname: "/",
+          search: "?tab=runs",
+          hash: "#/experiments/0",
+          assign: assignSpy,
+        },
+      });
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 401");
+      expect(assignSpy).toHaveBeenCalledWith(
+        "/login?next=" + encodeURIComponent("/?tab=runs#/experiments/0"),
+      );
     });
 
     it("does not redirect when already on the auth feature page", async () => {
       Object.defineProperty(window, "location", {
         configurable: true,
-        value: { ...window.location, pathname: "/oidc/ui/auth", assign: assignSpy },
+        value: {
+          ...window.location,
+          pathname: "/oidc/ui/auth",
+          search: "",
+          hash: "",
+          assign: assignSpy,
+        },
       });
 
       vi.mocked(fetch).mockResolvedValue({
@@ -212,7 +248,9 @@ describe("http", () => {
       } as Response);
 
       await expect(http("/api/users")).rejects.toThrow("HTTP 401");
-      expect(assignSpy).toHaveBeenCalledWith("/proxy/path/login");
+      expect(assignSpy).toHaveBeenCalledWith(
+        "/proxy/path/login?next=" + encodeURIComponent("/oidc/ui/users"),
+      );
 
       baseEl.remove();
     });

--- a/web-react/src/core/services/http.test.ts
+++ b/web-react/src/core/services/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { http, extractErrorMessage } from "./http";
+import { http, extractErrorMessage, _resetReauthForTests } from "./http";
 
 vi.mock("../../shared/context/workspace-context", () => ({
   getActiveWorkspace: vi.fn(() => null),
@@ -125,6 +125,110 @@ describe("http", () => {
         credentials: "include",
       }),
     );
+  });
+
+  describe("401 reauth redirect", () => {
+    let assignSpy: ReturnType<typeof vi.fn>;
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      _resetReauthForTests();
+      assignSpy = vi.fn();
+      // jsdom won't let us reassign window.location, so swap a stub in.
+      originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: {
+          ...originalLocation,
+          pathname: "/oidc/ui/users",
+          assign: assignSpy,
+        },
+      });
+      // Ensure no <base> element from a prior test.
+      document.head.querySelector("base")?.remove();
+    });
+
+    afterEachRestoreLocation: {
+      // jsdom limitation: the location stub is replaced per-test in beforeEach,
+      // so explicit restore isn't required.
+    }
+
+    it("redirects to /login on 401 from a non-auth page", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 401");
+      expect(assignSpy).toHaveBeenCalledTimes(1);
+      expect(assignSpy).toHaveBeenCalledWith("/login");
+    });
+
+    it("does not redirect when already on the auth feature page", async () => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { ...window.location, pathname: "/oidc/ui/auth", assign: assignSpy },
+      });
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 401");
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("redirects only once for concurrent 401s", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await Promise.allSettled([http("/a"), http("/b"), http("/c")]);
+      expect(assignSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("respects <base href> when computing the login URL", async () => {
+      const baseEl = document.createElement("base");
+      baseEl.setAttribute("href", "/proxy/path/");
+      document.head.appendChild(baseEl);
+
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: new Headers(),
+        text: () => Promise.resolve("expired"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 401");
+      expect(assignSpy).toHaveBeenCalledWith("/proxy/path/login");
+
+      baseEl.remove();
+    });
+
+    it("does not redirect on non-401 errors", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        headers: new Headers(),
+        text: () => Promise.resolve("boom"),
+      } as Response);
+
+      await expect(http("/api/users")).rejects.toThrow("HTTP 500");
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
   });
 
   it("returns undefined for 204 No Content responses", async () => {

--- a/web-react/src/core/services/http.ts
+++ b/web-react/src/core/services/http.ts
@@ -25,8 +25,10 @@ export function _resetReauthForTests(): void {
  * Navigate to the OIDC login flow once on 401. /oidc/ui is in the auth
  * middleware's unprotected prefix list, so a plain reload would just bring
  * the SPA back into the same broken state — we have to actively redirect to
- * /login. Skips the redirect on the auth feature page itself, which legitimately
- * receives 401-ish responses while a logged-out user is on it.
+ * /login. Forwards the current path/search/hash as ?next= so the callback
+ * can return the user to where they were. Skips the redirect on the auth
+ * feature page itself, which legitimately receives 401-ish responses while
+ * a logged-out user is on it.
  */
 function triggerReauth(): void {
   if (reauthTriggered) return;
@@ -35,7 +37,10 @@ function triggerReauth(): void {
   if (pathname.includes("/oidc/ui/auth")) return;
   reauthTriggered = true;
   const baseHref = document.querySelector("base")?.getAttribute("href") ?? "/";
-  const loginUrl = baseHref.replace(/\/$/, "") + "/login";
+  const next =
+    window.location.pathname + window.location.search + window.location.hash;
+  const loginUrl =
+    baseHref.replace(/\/$/, "") + "/login?next=" + encodeURIComponent(next);
   window.location.assign(loginUrl);
 }
 

--- a/web-react/src/core/services/http.ts
+++ b/web-react/src/core/services/http.ts
@@ -29,6 +29,10 @@ export function _resetReauthForTests(): void {
  * can return the user to where they were. Skips the redirect on the auth
  * feature page itself, which legitimately receives 401-ish responses while
  * a logged-out user is on it.
+ *
+ * The login endpoint lives at ``<basePath>/login``, NOT under the SPA's
+ * ``<base href>`` (which is ``<basePath>/oidc/ui/``). Use the runtime
+ * config's ``basePath`` to get the proxy prefix.
  */
 function triggerReauth(): void {
   if (reauthTriggered) return;
@@ -36,11 +40,12 @@ function triggerReauth(): void {
   const pathname = window.location.pathname;
   if (pathname.includes("/oidc/ui/auth")) return;
   reauthTriggered = true;
-  const baseHref = document.querySelector("base")?.getAttribute("href") ?? "/";
+  const runtime = (window as { __RUNTIME_CONFIG__?: { basePath?: string } })
+    .__RUNTIME_CONFIG__;
+  const basePath = (runtime?.basePath ?? "").replace(/\/$/, "");
   const next =
     window.location.pathname + window.location.search + window.location.hash;
-  const loginUrl =
-    baseHref.replace(/\/$/, "") + "/login?next=" + encodeURIComponent(next);
+  const loginUrl = basePath + "/login?next=" + encodeURIComponent(next);
   window.location.assign(loginUrl);
 }
 

--- a/web-react/src/core/services/http.ts
+++ b/web-react/src/core/services/http.ts
@@ -12,6 +12,33 @@ const buildUrl = (url: string, params?: Record<string, string>) => {
   return u.toString();
 };
 
+let reauthTriggered = false;
+
+/**
+ * Reset the reauth latch — exposed for tests so each case starts clean.
+ */
+export function _resetReauthForTests(): void {
+  reauthTriggered = false;
+}
+
+/**
+ * Navigate to the OIDC login flow once on 401. /oidc/ui is in the auth
+ * middleware's unprotected prefix list, so a plain reload would just bring
+ * the SPA back into the same broken state — we have to actively redirect to
+ * /login. Skips the redirect on the auth feature page itself, which legitimately
+ * receives 401-ish responses while a logged-out user is on it.
+ */
+function triggerReauth(): void {
+  if (reauthTriggered) return;
+  if (typeof window === "undefined") return;
+  const pathname = window.location.pathname;
+  if (pathname.includes("/oidc/ui/auth")) return;
+  reauthTriggered = true;
+  const baseHref = document.querySelector("base")?.getAttribute("href") ?? "/";
+  const loginUrl = baseHref.replace(/\/$/, "") + "/login";
+  window.location.assign(loginUrl);
+}
+
 /**
  * Extract a user-friendly error message from an HTTP error.
  * Falls back to the provided default message if parsing fails.
@@ -61,6 +88,9 @@ export async function http<T = unknown>(
   });
 
   if (!res.ok) {
+    if (res.status === 401) {
+      triggerReauth();
+    }
     const text = await res.text();
     throw new Error(`HTTP ${res.status}: ${text}`);
   }


### PR DESCRIPTION
Closes #242.

## Summary

Once a user completed the OIDC login flow, their session lasted up to ~14 days regardless of any IdP-side change (deactivation, group/MFA changes, password resets, etc.) because only `username` was persisted and Starlette's `SessionMiddleware` fell back to its default cookie TTL. IdP-driven deprovisioning could effectively be ignored for two weeks.

Per @kharkevich's guidance on the issue, this PR implements **option (2) as the default** and **option (3) as opt-in**, then ships the SPA-side plumbing needed to actually make the feature usable.

### Default — token-expiry-based session invalidation (option 2)

- Persist the IdP-issued `expires_at` in the session at OIDC callback time.
- Reject the session in `AuthMiddleware._authenticate_session` once `now >= expires_at - leeway`, forcing the user back through the OIDC flow.
- New config: `OIDC_SESSION_EXPIRY_LEEWAY_SECONDS` (default `30`).
- Sessions that predate this change (no `expires_at`) keep working until their cookie expires — no forced logout at deploy time.

### Opt-in — refresh-token flow (option 3)

- New config: `OIDC_USE_REFRESH_TOKEN` (default `false`).
- When enabled, `offline_access` is appended to the OIDC scope, the refresh token is persisted in the session, and expired sessions are silently refreshed against the IdP via `oauth.oidc.fetch_access_token(grant_type=\"refresh_token\", ...)`. On refresh failure the session is cleared and the user re-logs in.
- Disabled by default because many enterprises require additional approval for `offline_access`, and because refresh tokens then live in the signed-but-not-encrypted session cookie.

### Why three follow-on changes were necessary

Without these, enabling option (2) breaks the SPA mid-session:

1. **Subresource vs document discrimination.** `AuthMiddleware.dispatch` previously redirected (302) any unauthenticated non-`/api` request. After expiry, fetch/XHR and JS chunk loads silently followed the 302 → received HTML → `JSON.parse` and the chunk loader threw. Now `Sec-Fetch-Dest` (with `Accept: text/html` fallback) is used: only document navigations get a 302; subresources get **401** so the SPA can react.
2. **`/static-files` whitelisted.** MLflow's React bundle is served from `/static-files/<path>` with content-addressed hashed filenames and ships publicly on PyPI. Letting it load anonymously avoids `ChunkLoadError` when the session expires mid-use; the next navigation still goes through the redirect.
3. **SPA-side 401 handlers.**
   - **MLflow UI** (we don't own the bundle): a small fetch + `XMLHttpRequest.prototype.send` interceptor is injected via the existing `hack` mechanism. On any 401 it triggers a single `window.location.reload()` → AuthMiddleware redirects to the IdP. Gated by `EXTEND_MLFLOW_REAUTH` (default `true`).
   - **Plugin admin UI**: `core/services/http.ts` now navigates to `/login` on 401 (single-fire, suppressed on `/oidc/ui/auth` to prevent loops). A reload alone wouldn't help here because `/oidc/ui` is in the unprotected-prefix list.

## New configuration

| Variable | Default | Purpose |
|---|---|---|
| `OIDC_SESSION_EXPIRY_LEEWAY_SECONDS` | `30` | Clock-skew leeway applied to the IdP-issued token expiry |
| `OIDC_USE_REFRESH_TOKEN` | `false` | Request `offline_access` and silently refresh expired sessions |
| `EXTEND_MLFLOW_REAUTH` | `true` | Inject the 401-reload helper into MLflow's UI |

## Test plan

- [x] `pytest mlflow_oidc_auth/tests` — 2764 passing
- [x] `yarn test --run` (frontend) — 833 passing
- [x] Manual: silent refresh against JumpCloud (10-min access token, 60-min ID token, refresh token enabled) — verified \"Session for ... refreshed against IdP\" log + uninterrupted requests
- [x] Manual: expiry without refresh token → 401 → SPA-side handler redirects to /login → re-auth completes
- [x] Manual: MLflow UI menu still injects (small unrelated forward-compat fix in commit 1 to match newer MLflow's `#/settings/general?...` sub-routes)

## Notes

- Two pre-existing test failures unrelated to this PR are deselected from the local run (`test_callback_success` redirect-URL assertion, `test_list_deleted_runs_invalid_older_than` schema-mismatch in the local mlflow venv).
- Commit 1 (`fix(ui): match newer MLflow settings sub-routes when injecting menu`) is small and unrelated to #242 but was needed during local testing of this PR. Happy to split it into a separate PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)