### PR TITLE
fix(packaging): ship hack/reauth.html in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ oidc-auth = "mlflow_oidc_auth.app:app"
 mlflow_oidc_auth = [
   "db/migrations/alembic.ini",
   "hack/menu.html",
+  "hack/reauth.html",
   "ui/**/*",
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #249. The session re-auth feature injects a small fetch/XHR interceptor into MLflow's `index.html` from `mlflow_oidc_auth/hack/reauth.html`, but that file was never listed in `[tool.setuptools.package-data]`. Editable installs (and the test suite) work because the file exists in the source tree, but the published wheel ships only `hack/menu.html` — so on real deployments `_read_snippet(\"reauth.html\")` returns an empty string (with a WARNING log in the server output) and the interceptor never runs.

User-visible symptom on a deployed install: after a session expires, the MLflow SPA shows 401 errors but never auto-redirects to the IdP login flow — the user is stuck on a half-broken page until they force-reload.

## Verification

```
$ python -m build --wheel
$ python -m zipfile -l dist/*.whl | grep hack
mlflow_oidc_auth/hack.py
mlflow_oidc_auth/hack/menu.html
mlflow_oidc_auth/hack/reauth.html    ← now present
```

Confirmed in DevTools that on an install built from this branch, `window.fetch.toString()` returns the patched wrapper (with `origFetch`) instead of `[native code]`.

## Test plan

- [x] Build wheel and confirm `hack/reauth.html` is included
- [x] Manual: deploy → expire session → SPA auto-redirects to `/login?next=<original-path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)