### PR TITLE
fix: preserve URL fragment through AUTOMATIC_LOGIN_REDIRECT

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -13,6 +13,7 @@ import time
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import HTMLResponse
 from starlette.types import ASGIApp
 
 from mlflow_oidc_auth.config import config
@@ -233,22 +234,32 @@ class AuthMiddleware(BaseHTTPMiddleware):
         the post-login callback can return the user to where they were instead
         of dumping them at the root.
 
+        When ``AUTOMATIC_LOGIN_REDIRECT`` is enabled, the response is a tiny
+        HTML page with inline JavaScript instead of a bare 302.  This gives the
+        browser a chance to capture ``window.location.hash`` — which is never
+        sent to the server (RFC 3986 §3.5) — and include it in the ``?next=``
+        parameter.  Without this, deep links that rely on hash-based routing
+        (e.g. ``/#/experiments/0``) lose the fragment during the redirect chain
+        and the user lands on the root page after login.
+
+        Browsers without JavaScript fall back to a ``<noscript>`` meta-refresh
+        that behaves identically to the previous 302 (the fragment is still
+        lost, but the login flow works).
+
         Args:
             request: FastAPI request object
 
         Returns:
             Appropriate response (redirect or auth page)
         """
-        # Import here to avoid circular imports
+        import json
+
         from urllib.parse import quote
 
         from mlflow_oidc_auth.utils import get_base_path
 
         base_path = await get_base_path(request)
 
-        # Reconstruct the original target so the user is returned to it after
-        # IdP login. We can only see path + query server-side; the SPA layer
-        # also forwards the URL fragment for hash-routed apps like MLflow.
         target = request.url.path
         query = request.url.query
         if query and isinstance(query, str):
@@ -256,8 +267,24 @@ class AuthMiddleware(BaseHTTPMiddleware):
         next_param = f"?next={quote(target, safe='')}"
 
         if config.AUTOMATIC_LOGIN_REDIRECT:
-            login_url = f"{base_path}/login{next_param}"
-            return RedirectResponse(url=login_url, status_code=302)
+            login_path = f"{base_path}/login"
+            fallback_url = f"{login_path}{next_param}"
+            html = (
+                "<!DOCTYPE html><html><head>"
+                "<script>"
+                "(function(){"
+                f"var t={json.dumps(target)};"
+                "var h=window.location.hash;"
+                "if(h)t+=h;"
+                f"window.location.replace({json.dumps(login_path)}"
+                '+"?next="+encodeURIComponent(t));'
+                "})();"
+                "</script>"
+                f'<noscript><meta http-equiv="refresh" content="0;url={fallback_url}"></noscript>'
+                "</head>"
+                "<body>Redirecting\u2026</body></html>"
+            )
+            return HTMLResponse(content=html, status_code=200, headers={"Cache-Control": "no-store"})
 
         ui_url = f"{base_path}/oidc/ui"
         return RedirectResponse(url=ui_url, status_code=302)

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -458,8 +458,10 @@ class TestAuthMiddleware:
     async def test_handle_auth_redirect_automatic_login(self, auth_middleware, create_mock_request, mock_config):
         """Test authentication redirect with automatic login enabled.
 
-        Includes the ``?next=<original-path>`` round-trip so the user lands
-        back on the page they tried to load instead of the root.
+        Returns an HTML page with JavaScript that captures the URL fragment
+        before redirecting, so hash-routed deep links survive the login flow.
+        A ``<noscript>`` fallback provides the same ``?next=`` redirect for
+        clients without JavaScript.
         """
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True
 
@@ -468,9 +470,14 @@ class TestAuthMiddleware:
 
             response = await auth_middleware._handle_auth_redirect(request)
 
-            assert isinstance(response, RedirectResponse)
-            assert response.status_code == 302
-            assert response.headers["location"] == "/login?next=%2Fprotected"
+            assert response.status_code == 200
+            assert response.headers["cache-control"] == "no-store"
+            body = response.body.decode()
+            assert "<script>" in body
+            assert "window.location.hash" in body
+            assert '"/login"' in body
+            assert "encodeURIComponent" in body
+            assert "/login?next=%2Fprotected" in body
 
     @pytest.mark.asyncio
     async def test_handle_auth_redirect_no_automatic_login(self, auth_middleware, create_mock_request, mock_config):
@@ -553,7 +560,7 @@ class TestAuthMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_user_automatic_redirect(self, auth_middleware, create_mock_request, mock_config):
-        """Document navigation requests redirect to login when auto-redirect is enabled."""
+        """Document navigation requests return an HTML fragment-capture page when auto-redirect is enabled."""
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True
 
         with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
@@ -568,9 +575,10 @@ class TestAuthMiddleware:
 
             response = await auth_middleware.dispatch(request, mock_call_next)
 
-            assert isinstance(response, RedirectResponse)
-            assert response.status_code == 302
-            assert response.headers["location"] == "/login?next=%2Fprotected"
+            assert response.status_code == 200
+            body = response.body.decode()
+            assert "window.location.hash" in body
+            assert "/login?next=%2Fprotected" in body
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_user_oidc_ui_redirect(self, auth_middleware, create_mock_request, mock_config):
@@ -608,8 +616,10 @@ class TestAuthMiddleware:
 
             response = await auth_middleware.dispatch(request, lambda r: pytest.fail("nope"))
 
-            assert isinstance(response, RedirectResponse)
-            assert response.headers["location"] == "/login?next=%2Fprotected%3Ftab%3Druns%26id%3D42"
+            assert response.status_code == 200
+            body = response.body.decode()
+            assert "/protected?tab=runs&id=42" in body
+            assert "window.location.hash" in body
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_subresource_returns_401(self, auth_middleware, create_mock_request, mock_config):
@@ -653,7 +663,7 @@ class TestAuthMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_html_accept_redirects(self, auth_middleware, create_mock_request, mock_config):
-        """Without Sec-Fetch-Dest, an Accept: text/html header still redirects."""
+        """Without Sec-Fetch-Dest, an Accept: text/html header still triggers login."""
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True
 
         with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
@@ -665,8 +675,8 @@ class TestAuthMiddleware:
 
             response = await auth_middleware.dispatch(request, lambda r: pytest.fail("should not be called"))
 
-            assert isinstance(response, RedirectResponse)
-            assert response.status_code == 302
+            assert response.status_code == 200
+            assert "window.location.hash" in response.body.decode()
 
     @pytest.mark.asyncio
     async def test_dispatch_basic_auth_header(self, auth_middleware, create_mock_request, mock_store):
@@ -809,8 +819,8 @@ class TestAuthMiddleware:
 
             response = await auth_middleware.dispatch(request, mock_call_next)
 
-            assert isinstance(response, RedirectResponse)
-            assert response.status_code == 302
+            assert response.status_code == 200
+            assert "window.location.hash" in response.body.decode()
 
     @pytest.mark.asyncio
     async def test_dispatch_request_state_isolation(self, auth_middleware, create_mock_request, mock_store):


### PR DESCRIPTION
## Problem

When `AUTOMATIC_LOGIN_REDIRECT=true`, clicking a deep link loses the fragment after SSO login — the user lands on the homepage instead.

URL fragments (`#...`) are never sent to the server (RFC 3986 §3.5). The auth middleware only sees `GET /`, so it builds `?next=%2F` and the fragment is lost through the redirect chain.

## Fix

Replace the server-side 302 with a tiny HTML page whose inline JavaScript captures `window.location.hash` and includes it in the `?next=` parameter before redirecting to `/login`.

This is the same pattern already used in `reauth.html` for session-expiry 401s, extended to cover the initial unauthenticated visit. `_sanitize_next()` already accepts fragment paths (its docstring lists `/#/experiments/0` as a valid example).

A `<noscript>` meta-refresh fallback preserves the previous 302 behaviour for clients without JavaScript.

## Changes

- `auth_middleware.py`: `_handle_auth_redirect()` returns `HTMLResponse` instead of `RedirectResponse` when `AUTOMATIC_LOGIN_REDIRECT=true`
- `test_auth_middleware.py`: Updated 5 tests to assert HTML+JS response instead of 302

## Testing

- All 59 middleware tests pass
- Manually verified the HTML captures `window.location.hash` and encodes it in `encodeURIComponent()`