### PR TITLE
fix: deduplicate group_names in set_groups_for_user to prevent UniqueViolation

### DIFF
--- a/mlflow_oidc_auth/repository/group.py
+++ b/mlflow_oidc_auth/repository/group.py
@@ -132,6 +132,11 @@ class GroupRepository:
         :param username: The username of the user.
         :param group_names: A list of group names to be set for the user.
         """
+        # Deduplicate while preserving order. Some IdPs (e.g. Microsoft Entra ID)
+        # can emit the same group GUID more than once in the token when a user holds
+        # multiple app roles that are backed by the same security group. Without
+        # deduplication the second INSERT violates the unique_user_group constraint.
+        group_names = list(dict.fromkeys(group_names))
         with self._Session() as session:
             user = get_user(session, username)
             user_groups = list_user_groups(session, user)

--- a/mlflow_oidc_auth/tests/repository/test_group.py
+++ b/mlflow_oidc_auth/tests/repository/test_group.py
@@ -196,3 +196,26 @@ def test_set_groups_for_user(repo, session):
         session.delete.assert_called_once_with(group1)
         assert session.add.call_count == 2
         session.flush.assert_called_once()
+
+
+def test_set_groups_for_user_deduplicates_group_names(repo, session):
+    """Regression test: duplicate group names in the token (e.g. Microsoft Entra ID
+    emitting the same security group GUID twice when a user holds multiple app roles
+    backed by the same group) must not cause a UniqueViolation on user_groups."""
+    user = MagicMock(id=1)
+    group1 = MagicMock(id=10)
+    group2 = MagicMock(id=20)
+    session.delete = MagicMock()
+    session.add = MagicMock()
+    session.flush = MagicMock()
+    with (
+        patch("mlflow_oidc_auth.repository.group.get_user", return_value=user),
+        patch("mlflow_oidc_auth.repository.group.list_user_groups", return_value=[]),
+        # get_group should only be called twice despite three names being passed
+        patch("mlflow_oidc_auth.repository.group.get_group", side_effect=[group1, group2]),
+        patch("mlflow_oidc_auth.db.models.SqlUserGroup", return_value=MagicMock()),
+    ):
+        repo.set_groups_for_user("user", ["g1", "g2", "g2"])  # "g2" appears twice
+        # Only two unique groups should be inserted, not three
+        assert session.add.call_count == 2
+        session.flush.assert_called_once()


### PR DESCRIPTION
## Problem

When a user holds multiple app roles that are backed by the **same** Azure AD / Microsoft Entra ID security group, the IdP emits the same group GUID more than once in the JWT `groups` claim.

`set_groups_for_user` iterates over the list without deduplication:

```python
for group_name in group_names:          # e.g. ['grp-a', 'grp-b', 'grp-b']
    group = get_group(session, group_name)
    user_group = SqlUserGroup(user_id=user.id, group_id=group.id)
    session.add(user_group)             # (1, 42) added twice
session.flush()                         # second INSERT → UniqueViolation
```

SQLAlchemy's autoflush inserts the first `(user_id, group_id)` pair successfully; the second INSERT violates the `unique_user_group` constraint. The exception propagates through the OIDC callback handler, causing every login attempt for the affected user to fail with:

> `Failed to update user/groups`

### Reproduction

Assign a user to two different app roles (e.g. `Mlflow.Admin` **and** `Mlflow.User`) that are both backed by the same Azure AD security group. The shared group GUID will appear twice in the token's `groups` claim:

```json
{
  "groups": [
    "cf9eeb1e-f30e-4899-9dfb-d14971c26a82",
    "e1a7315d-2c6d-4bb8-ad73-7078b233788c",
    "de7e552b-f949-40bd-bcdf-72dc77b39ff7",
    "de7e552b-f949-40bd-bcdf-72dc77b39ff7"
  ]
}
```

This was verified by decoding a live Azure AD access token for the affected user.

## Fix

Deduplicate `group_names` with `list(dict.fromkeys(...))` before the insert loop, which removes duplicates while preserving the original order.

```python
group_names = list(dict.fromkeys(group_names))
```

## Tests

Added `test_set_groups_for_user_deduplicates_group_names` to `mlflow_oidc_auth/tests/repository/test_group.py`. Passes three group names where the third is a duplicate of the second and asserts that only two `session.add` calls are made.
