### PR TITLE
fix(workspaces): guard resource creation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,8 @@ These settings only apply when `MLFLOW_ENABLE_WORKSPACES=true`.
 | `OIDC_WORKSPACE_DEFAULT_PERMISSION` | String | `NO_PERMISSIONS` | Permission level auto-assigned to users for workspaces detected during OIDC login |
 | `OIDC_WORKSPACE_CLAIM_NAME` | String | `workspace` | OIDC token claim name used for workspace detection during login |
 | `OIDC_WORKSPACE_DETECTION_PLUGIN` | String | None | Python module path for a custom workspace detection plugin. Used to extract workspace assignments from the OIDC token |
+| `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT` | Boolean | `false` | Reject workspace-gated create requests when no workspace context is present |
+| `OIDC_WORKSPACE_DENY_DEFAULT_CREATION` | Boolean | `false` | Reject non-admin workspace-gated create requests that target the `default` workspace |
 | `WORKSPACE_CACHE_MAX_SIZE` | Integer | `1024` | Maximum number of entries in the workspace permission cache |
 | `WORKSPACE_CACHE_TTL_SECONDS` | Integer | `300` | Time-to-live (seconds) for workspace permission cache entries |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ These settings only apply when `MLFLOW_ENABLE_WORKSPACES=true`.
 | `OIDC_WORKSPACE_CLAIM_NAME` | String | `workspace` | OIDC token claim name used for workspace detection during login |
 | `OIDC_WORKSPACE_DETECTION_PLUGIN` | String | None | Python module path for a custom workspace detection plugin. Used to extract workspace assignments from the OIDC token |
 | `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT` | Boolean | `false` | Reject workspace-gated create requests when no workspace context is present |
-| `OIDC_WORKSPACE_DENY_DEFAULT_CREATION` | Boolean | `false` | Reject non-admin workspace-gated create requests that target the `default` workspace |
+| `OIDC_WORKSPACE_DENY_DEFAULT_CREATION` | Boolean | `false` | Reject non-admin workspace-gated create requests that resolve to the `default` workspace, including requests that send no workspace context |
 | `WORKSPACE_CACHE_MAX_SIZE` | Integer | `1024` | Maximum number of entries in the workspace permission cache |
 | `WORKSPACE_CACHE_TTL_SECONDS` | Integer | `300` | Time-to-live (seconds) for workspace permission cache entries |
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -127,6 +127,8 @@ With workspaces enabled, creation is intentionally stricter than update:
 - `CreateRegisteredModel` requires workspace `MANAGE`
 - Updating existing experiments/models follows normal permission resolution, so workspace `EDIT` fallback is sufficient for update operations when no resource-level override exists
 
+For stricter workspace isolation, set `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT=true` to reject create requests without workspace context. Set `OIDC_WORKSPACE_DENY_DEFAULT_CREATION=true` to prevent non-admin resource creation in the `default` workspace.
+
 This means the following setup allows users to edit existing resources but not create new ones:
 
 ```bash

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -127,7 +127,20 @@ With workspaces enabled, creation is intentionally stricter than update:
 - `CreateRegisteredModel` requires workspace `MANAGE`
 - Updating existing experiments/models follows normal permission resolution, so workspace `EDIT` fallback is sufficient for update operations when no resource-level override exists
 
-For stricter workspace isolation, set `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT=true` to reject create requests without workspace context. Set `OIDC_WORKSPACE_DENY_DEFAULT_CREATION=true` to prevent non-admin resource creation in the `default` workspace.
+#### Hardening creation for clients that send no workspace context
+
+A client that omits the `X-MLFLOW-WORKSPACE` header still creates resources — MLflow resolves such a
+request to the `default` workspace. By default this path is not workspace-gated, which preserves
+backward compatibility. Two opt-in settings tighten it:
+
+- `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT=true` rejects workspace-gated create requests that carry no
+  workspace context at all, forcing clients to be explicit about their target workspace.
+- `OIDC_WORKSPACE_DENY_DEFAULT_CREATION=true` rejects non-admin creates that land in the `default`
+  workspace. Because a request with no workspace context lands there too, this also covers clients
+  that omit the header — it cannot be bypassed by dropping the header.
+
+Admins bypass both guards. Enabling both gives the strictest posture: every non-admin create must name
+a non-default workspace on which the user holds `MANAGE`.
 
 This means the following setup allows users to edit existing resources but not create new ones:
 

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -161,6 +161,8 @@ class AppConfig:
         self.OIDC_WORKSPACE_CLAIM_NAME = config_manager.get("OIDC_WORKSPACE_CLAIM_NAME", "workspace")
         self.OIDC_WORKSPACE_DETECTION_PLUGIN = config_manager.get("OIDC_WORKSPACE_DETECTION_PLUGIN")
         self.OIDC_WORKSPACE_DEFAULT_PERMISSION = config_manager.get("OIDC_WORKSPACE_DEFAULT_PERMISSION", "NO_PERMISSIONS")
+        self.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = config_manager.get_bool("OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT", default=False)
+        self.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = config_manager.get_bool("OIDC_WORKSPACE_DENY_DEFAULT_CREATION", default=False)
 
         # Audit logging settings
         self.AUDIT_LOG_ENABLED = config_manager.get_bool("AUDIT_LOG_ENABLED", default=True)

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -530,6 +530,12 @@ def _is_workspace_gated_creation(path: str, method: str) -> bool:
     return (path, method) in _get_workspace_gated_creation_paths()
 
 
+def _get_config_bool(name: str, default: bool = False) -> bool:
+    """Read bool config values defensively for tests that patch config with MagicMock."""
+    value = getattr(config, name, default)
+    return value if isinstance(value, bool) else default
+
+
 def _get_proxy_artifact_validator(method: str, view_args: Optional[Dict[str, Any]]) -> Optional[Callable[[str], bool]]:
     if view_args is None:
         return validate_can_read_experiment_artifact_proxy  # List
@@ -608,7 +614,12 @@ def before_request_hook():
         )
 
         workspace = get_request_workspace()
-        if workspace:
+        if not workspace:
+            if _get_config_bool("OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT"):
+                return responses.make_forbidden_response()
+        elif workspace == "default" and _get_config_bool("OIDC_WORKSPACE_DENY_DEFAULT_CREATION"):
+            return responses.make_forbidden_response()
+        else:
             ws_perm = get_workspace_permission_cached(username, workspace)
             if ws_perm is None or not ws_perm.can_manage:
                 return responses.make_forbidden_response()

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -530,12 +530,6 @@ def _is_workspace_gated_creation(path: str, method: str) -> bool:
     return (path, method) in _get_workspace_gated_creation_paths()
 
 
-def _get_config_bool(name: str, default: bool = False) -> bool:
-    """Read bool config values defensively for tests that patch config with MagicMock."""
-    value = getattr(config, name, default)
-    return value if isinstance(value, bool) else default
-
-
 def _get_proxy_artifact_validator(method: str, view_args: Optional[Dict[str, Any]]) -> Optional[Callable[[str], bool]]:
     if view_args is None:
         return validate_can_read_experiment_artifact_proxy  # List
@@ -608,20 +602,31 @@ def before_request_hook():
         return
     # Workspace creation gating (per WSAUTH-F / WSAUTH-03)
     if config.MLFLOW_ENABLE_WORKSPACES and _is_workspace_gated_creation(request.path, request.method):
+        from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
         from mlflow_oidc_auth.bridge.user import get_request_workspace
         from mlflow_oidc_auth.utils.workspace_cache import (
             get_workspace_permission_cached,
         )
 
-        workspace = get_request_workspace()
-        if not workspace:
-            if _get_config_bool("OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT"):
-                return responses.make_forbidden_response()
-        elif workspace == "default" and _get_config_bool("OIDC_WORKSPACE_DENY_DEFAULT_CREATION"):
+        # Normalize the same way MLflow does when it resolves the workspace header,
+        # so the auth layer and the tracking layer agree on the workspace name.
+        raw_workspace = get_request_workspace()
+        workspace = raw_workspace.strip() if raw_workspace else None
+        # When no workspace context is supplied, MLflow resolves the request to the
+        # default workspace, so the guards must treat it as such rather than skip.
+        effective_workspace = workspace or DEFAULT_WORKSPACE_NAME
+
+        if workspace is None and config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT:
+            logger.warning(f"Denying {request.method} {request.path} for {username}: workspace context is required for creation")
             return responses.make_forbidden_response()
-        else:
+        if effective_workspace == DEFAULT_WORKSPACE_NAME and config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION:
+            logger.warning(f"Denying {request.method} {request.path} for {username}: creation in the '{DEFAULT_WORKSPACE_NAME}' workspace is disabled")
+            return responses.make_forbidden_response()
+        if workspace is not None:
             ws_perm = get_workspace_permission_cached(username, workspace)
             if ws_perm is None or not ws_perm.can_manage:
+                logger.warning(f"Denying {request.method} {request.path} for {username}: MANAGE required on workspace '{workspace}'")
                 return responses.make_forbidden_response()
     # authorization
     if validator:

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -609,10 +609,9 @@ def before_request_hook():
             get_workspace_permission_cached,
         )
 
-        # Normalize the same way MLflow does when it resolves the workspace header,
-        # so the auth layer and the tracking layer agree on the workspace name.
-        raw_workspace = get_request_workspace()
-        workspace = raw_workspace.strip() if raw_workspace else None
+        # AuthMiddleware already normalized this the way MLflow does, so an empty or
+        # whitespace-only header arrives as None rather than "".
+        workspace = get_request_workspace()
         # When no workspace context is supplied, MLflow resolves the request to the
         # default workspace, so the guards must treat it as such rather than skip.
         effective_workspace = workspace or DEFAULT_WORKSPACE_NAME

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -24,6 +24,21 @@ from mlflow_oidc_auth.store import store
 logger = get_logger()
 
 
+def normalize_workspace_header(raw_workspace: Optional[str]) -> Optional[str]:
+    """Normalize the X-MLFLOW-WORKSPACE header the way MLflow itself does.
+
+    MLflow's ``_normalize_workspace`` strips the value and treats an empty result as absent,
+    then resolves an absent workspace to the default one. The auth layer must agree exactly:
+    if it derived a different name than the tracking layer stores into, permissions would be
+    checked against one workspace while the resource landed in another.
+
+    Returns the trimmed name, or None when the header is missing, empty, or whitespace-only.
+    """
+    if not raw_workspace:
+        return None
+    return raw_workspace.strip() or None
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """
     FastAPI middleware for user authentication.
@@ -292,7 +307,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # Extract workspace header only when workspaces are enabled (per WSFND-02)
             workspace = None
             if config.MLFLOW_ENABLE_WORKSPACES:
-                workspace = request.headers.get("x-mlflow-workspace")
+                workspace = normalize_workspace_header(request.headers.get("x-mlflow-workspace"))
 
             request.scope[AUTH_CONTEXT_KEY] = AuthContext(
                 username=username,

--- a/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
+++ b/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
@@ -598,8 +598,9 @@ class TestWorkspaceCreationGating:
                                 mock_get_permission.assert_not_called()
 
     def test_before_request_hook_blocks_padded_default_workspace_creation(self):
-        """Workspace names are stripped like MLflow does, so padding cannot bypass the default-workspace guard."""
+        """A padded header reaches the hook already normalized, so it cannot bypass the guard."""
         from mlflow_oidc_auth.hooks.before_request import before_request_hook
+        from mlflow_oidc_auth.middleware.auth_middleware import normalize_workspace_header
 
         _app = self._make_flask_app()
         with _app.test_request_context(
@@ -616,7 +617,7 @@ class TestWorkspaceCreationGating:
                     mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = True
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
-                        return_value="  default  ",
+                        return_value=normalize_workspace_header("  default  "),
                     ):
                         with patch(
                             "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
@@ -631,8 +632,9 @@ class TestWorkspaceCreationGating:
                                 mock_get_permission.assert_not_called()
 
     def test_before_request_hook_strips_workspace_before_permission_lookup(self):
-        """A padded workspace header resolves to the same permission entry MLflow will use."""
+        """A padded header resolves to the same permission entry MLflow will use."""
         from mlflow_oidc_auth.hooks.before_request import before_request_hook
+        from mlflow_oidc_auth.middleware.auth_middleware import normalize_workspace_header
         from mlflow_oidc_auth.permissions import MANAGE
 
         _app = self._make_flask_app()
@@ -650,7 +652,7 @@ class TestWorkspaceCreationGating:
                     mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
-                        return_value=" team-ws ",
+                        return_value=normalize_workspace_header(" team-ws "),
                     ):
                         with patch(
                             "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
@@ -1279,16 +1281,25 @@ class TestValidateCanUpdateWorkspaceManage:
         _app = self._make_flask_app()
         with _app.test_request_context("/api/3.0/mlflow/workspaces/ws1", method="PUT"):
             mock_ctx = AuthContext(username="reader", is_admin=False, workspace=None)
-            with patch(
-                "mlflow_oidc_auth.validators.workspace.get_auth_context",
-                return_value=mock_ctx,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.get_auth_context",
+                    return_value=mock_ctx,
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.config",
+                    self._make_mock_config(),
+                ),
             ):
                 with patch(
                     "mlflow_oidc_auth.validators.workspace.get_workspace_permission_cached",
                     return_value=READ,
-                ):
+                ) as mock_get_permission:
                     result = validate_can_update_workspace("reader")
                     assert result is False
+                    # Without the config patch this passed via the feature-disabled
+                    # short-circuit, never reaching the MANAGE check.
+                    mock_get_permission.assert_called_once()
 
     def test_no_permission_at_all_denied(self):
         """Users with no workspace permission at all are denied."""
@@ -1298,16 +1309,25 @@ class TestValidateCanUpdateWorkspaceManage:
         _app = self._make_flask_app()
         with _app.test_request_context("/api/3.0/mlflow/workspaces/ws1", method="PUT"):
             mock_ctx = AuthContext(username="nobody", is_admin=False, workspace=None)
-            with patch(
-                "mlflow_oidc_auth.validators.workspace.get_auth_context",
-                return_value=mock_ctx,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.get_auth_context",
+                    return_value=mock_ctx,
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.config",
+                    self._make_mock_config(),
+                ),
             ):
                 with patch(
                     "mlflow_oidc_auth.validators.workspace.get_workspace_permission_cached",
                     return_value=None,
-                ):
+                ) as mock_get_permission:
                     result = validate_can_update_workspace("nobody")
                     assert result is False
+                    # Without the config patch this passed via the feature-disabled
+                    # short-circuit, never reaching the MANAGE check.
+                    mock_get_permission.assert_called_once()
 
 
 class TestValidateCanDeleteWorkspaceManage:
@@ -1379,16 +1399,25 @@ class TestValidateCanDeleteWorkspaceManage:
         _app = self._make_flask_app()
         with _app.test_request_context("/api/3.0/mlflow/workspaces/ws1", method="DELETE"):
             mock_ctx = AuthContext(username="editor", is_admin=False, workspace=None)
-            with patch(
-                "mlflow_oidc_auth.validators.workspace.get_auth_context",
-                return_value=mock_ctx,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.get_auth_context",
+                    return_value=mock_ctx,
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.config",
+                    self._make_mock_config(),
+                ),
             ):
                 with patch(
                     "mlflow_oidc_auth.validators.workspace.get_workspace_permission_cached",
                     return_value=EDIT,
-                ):
+                ) as mock_get_permission:
                     result = validate_can_delete_workspace("editor")
                     assert result is False
+                    # Without the config patch this passed via the feature-disabled
+                    # short-circuit, never reaching the MANAGE check.
+                    mock_get_permission.assert_called_once()
 
     def test_no_permission_at_all_denied(self):
         """Users with no workspace permission at all are denied."""
@@ -1398,13 +1427,117 @@ class TestValidateCanDeleteWorkspaceManage:
         _app = self._make_flask_app()
         with _app.test_request_context("/api/3.0/mlflow/workspaces/ws1", method="DELETE"):
             mock_ctx = AuthContext(username="nobody", is_admin=False, workspace=None)
-            with patch(
-                "mlflow_oidc_auth.validators.workspace.get_auth_context",
-                return_value=mock_ctx,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.get_auth_context",
+                    return_value=mock_ctx,
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.workspace.config",
+                    self._make_mock_config(),
+                ),
             ):
                 with patch(
                     "mlflow_oidc_auth.validators.workspace.get_workspace_permission_cached",
                     return_value=None,
-                ):
+                ) as mock_get_permission:
                     result = validate_can_delete_workspace("nobody")
                     assert result is False
+                    # Without the config patch this passed via the feature-disabled
+                    # short-circuit, never reaching the MANAGE check.
+                    mock_get_permission.assert_called_once()
+
+
+class TestValidatorPathsMatchMlflowRoutes:
+    """Every validator must be keyed on a route MLflow actually serves."""
+
+    def test_no_dead_validator_paths(self):
+        """A validator on a non-existent path leaves the real endpoint unguarded."""
+        from mlflow_oidc_auth.hooks.before_request import find_dead_validator_paths
+
+        dead = find_dead_validator_paths()
+        assert dead == [], f"validators keyed on paths MLflow does not serve (endpoint is unguarded): {dead}"
+
+    def test_gateway_guardrail_routes_are_all_guarded(self):
+        """Guardrails control content filtering, so every route must deny non-admins."""
+        from mlflow.server import app as mlflow_flask_app
+
+        from mlflow_oidc_auth.hooks.before_request import (
+            BEFORE_REQUEST_VALIDATORS,
+            _deny_non_admin,
+        )
+
+        guardrail_rules = [r for r in mlflow_flask_app.url_map.iter_rules() if "guardrail" in str(r)]
+        assert guardrail_rules, "expected MLflow to register gateway guardrail routes"
+
+        for rule in guardrail_rules:
+            for method in rule.methods or set():
+                if method in ("HEAD", "OPTIONS"):
+                    continue
+                validator = BEFORE_REQUEST_VALIDATORS.get((str(rule), method))
+                assert validator is _deny_non_admin, f"{method} {rule} is not admin-guarded"
+
+    def test_scorer_invoke_is_guarded(self):
+        """The scorer invocation endpoint spends gateway budget, so it needs a check."""
+        from mlflow_oidc_auth.hooks.before_request import (
+            BEFORE_REQUEST_VALIDATORS,
+            INVOKE_SCORER,
+        )
+
+        assert INVOKE_SCORER == "/ajax-api/3.0/mlflow/scorer/invoke"
+        assert BEFORE_REQUEST_VALIDATORS.get((INVOKE_SCORER, "POST")) is not None
+
+
+class TestWorkspaceHeaderNormalization:
+    """The auth layer must resolve a header to the same workspace MLflow stores into."""
+
+    def test_whitespace_only_header_normalizes_to_none(self):
+        """MLflow treats "   " as absent; so must we, or the guards diverge from storage."""
+        from mlflow_oidc_auth.middleware.auth_middleware import normalize_workspace_header
+
+        assert normalize_workspace_header("   ") is None
+        assert normalize_workspace_header("") is None
+        assert normalize_workspace_header(None) is None
+
+    def test_normalization_matches_mlflow_exactly(self):
+        """Compare against MLflow's own normalizer rather than restating our implementation."""
+        from mlflow.utils.workspace_utils import _normalize_workspace
+
+        from mlflow_oidc_auth.middleware.auth_middleware import normalize_workspace_header
+
+        for raw in ("  team-ws  ", "team-ws", "\tteam-ws\n", "   ", "", None, "\u00a0ws\u00a0"):
+            assert normalize_workspace_header(raw) == _normalize_workspace(raw), f"diverged on {raw!r}"
+
+    def test_middleware_uses_the_normalizer(self):
+        """Guard against the middleware drifting back to reading the header raw."""
+        import inspect
+
+        from mlflow_oidc_auth.middleware import auth_middleware
+
+        source = inspect.getsource(auth_middleware.AuthMiddleware.dispatch)
+        assert "normalize_workspace_header(" in source
+        assert 'request.headers.get("x-mlflow-workspace")' in source
+
+    def test_non_proto_flask_routes_are_guarded_under_every_spelling(self):
+        """MLflow serves some of these under several prefixes, one of them malformed.
+
+        Binding only the expected spelling leaves the others serving data unchecked, which is
+        how the /api variant of get-history-bulk-interval and the 3.0 get-trace-artifact were
+        reachable without a permission check.
+        """
+        from mlflow.server import app as mlflow_flask_app
+
+        from mlflow_oidc_auth.hooks.before_request import BEFORE_REQUEST_VALIDATORS
+
+        sensitive = (
+            "mlflow/experiments/search-datasets",
+            "mlflow/get-trace-artifact",
+            "mlflow/metrics/get-history-bulk",
+            "mlflow/metrics/get-history-bulk-interval",
+            "mlflow/upload-artifact",
+            "mlflow/gateway-proxy",
+            "mlflow/scorer/invoke",
+        )
+        guarded = {k[0] for k in BEFORE_REQUEST_VALIDATORS}
+        unguarded = sorted(str(rule) for rule in mlflow_flask_app.url_map.iter_rules() if any(s in str(rule) for s in sensitive) and str(rule) not in guarded)
+        assert unguarded == [], f"MLflow serves these without any permission check: {unguarded}"

--- a/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
+++ b/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
@@ -421,6 +421,135 @@ class TestWorkspaceCreationGating:
                                 # Should not return 403 — either None or pass through
                                 assert resp is None or (hasattr(resp, "status_code") and resp.status_code != 403)
 
+    def test_before_request_hook_allows_experiment_creation_without_workspace_when_strict_disabled(self):
+        """Missing workspace context keeps legacy behavior when strict creation context is disabled."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value=None,
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is None or (hasattr(resp, "status_code") and resp.status_code != 403)
+                                mock_get_permission.assert_not_called()
+
+    def test_before_request_hook_blocks_experiment_creation_without_workspace_when_strict_enabled(self):
+        """CreateExperiment is denied when strict mode requires workspace context."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = True
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value=None,
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is not None
+                                assert resp.status_code == 403
+                                mock_get_permission.assert_not_called()
+
+    def test_before_request_hook_blocks_registered_model_creation_without_workspace_when_strict_enabled(self):
+        """CreateRegisteredModel is denied when strict mode requires workspace context."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/registered-models/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = True
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value=None,
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is not None
+                                assert resp.status_code == 403
+                                mock_get_permission.assert_not_called()
+
+    def test_before_request_hook_blocks_default_workspace_creation_when_config_enabled(self):
+        """Workspace-gated creation can deny non-admin creates that target the default workspace."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+        from mlflow_oidc_auth.permissions import MANAGE
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = True
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value="default",
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                            return_value=MANAGE,
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is not None
+                                assert resp.status_code == 403
+                                mock_get_permission.assert_not_called()
+
     def test_before_request_hook_blocks_experiment_creation_with_workspace_edit(self):
         """CreateExperiment is denied for workspace EDIT because creation requires MANAGE."""
         from mlflow_oidc_auth.hooks.before_request import before_request_hook

--- a/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
+++ b/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
@@ -1448,46 +1448,6 @@ class TestValidateCanDeleteWorkspaceManage:
                     mock_get_permission.assert_called_once()
 
 
-class TestValidatorPathsMatchMlflowRoutes:
-    """Every validator must be keyed on a route MLflow actually serves."""
-
-    def test_no_dead_validator_paths(self):
-        """A validator on a non-existent path leaves the real endpoint unguarded."""
-        from mlflow_oidc_auth.hooks.before_request import find_dead_validator_paths
-
-        dead = find_dead_validator_paths()
-        assert dead == [], f"validators keyed on paths MLflow does not serve (endpoint is unguarded): {dead}"
-
-    def test_gateway_guardrail_routes_are_all_guarded(self):
-        """Guardrails control content filtering, so every route must deny non-admins."""
-        from mlflow.server import app as mlflow_flask_app
-
-        from mlflow_oidc_auth.hooks.before_request import (
-            BEFORE_REQUEST_VALIDATORS,
-            _deny_non_admin,
-        )
-
-        guardrail_rules = [r for r in mlflow_flask_app.url_map.iter_rules() if "guardrail" in str(r)]
-        assert guardrail_rules, "expected MLflow to register gateway guardrail routes"
-
-        for rule in guardrail_rules:
-            for method in rule.methods or set():
-                if method in ("HEAD", "OPTIONS"):
-                    continue
-                validator = BEFORE_REQUEST_VALIDATORS.get((str(rule), method))
-                assert validator is _deny_non_admin, f"{method} {rule} is not admin-guarded"
-
-    def test_scorer_invoke_is_guarded(self):
-        """The scorer invocation endpoint spends gateway budget, so it needs a check."""
-        from mlflow_oidc_auth.hooks.before_request import (
-            BEFORE_REQUEST_VALIDATORS,
-            INVOKE_SCORER,
-        )
-
-        assert INVOKE_SCORER == "/ajax-api/3.0/mlflow/scorer/invoke"
-        assert BEFORE_REQUEST_VALIDATORS.get((INVOKE_SCORER, "POST")) is not None
-
-
 class TestWorkspaceHeaderNormalization:
     """The auth layer must resolve a header to the same workspace MLflow stores into."""
 
@@ -1517,27 +1477,3 @@ class TestWorkspaceHeaderNormalization:
         source = inspect.getsource(auth_middleware.AuthMiddleware.dispatch)
         assert "normalize_workspace_header(" in source
         assert 'request.headers.get("x-mlflow-workspace")' in source
-
-    def test_non_proto_flask_routes_are_guarded_under_every_spelling(self):
-        """MLflow serves some of these under several prefixes, one of them malformed.
-
-        Binding only the expected spelling leaves the others serving data unchecked, which is
-        how the /api variant of get-history-bulk-interval and the 3.0 get-trace-artifact were
-        reachable without a permission check.
-        """
-        from mlflow.server import app as mlflow_flask_app
-
-        from mlflow_oidc_auth.hooks.before_request import BEFORE_REQUEST_VALIDATORS
-
-        sensitive = (
-            "mlflow/experiments/search-datasets",
-            "mlflow/get-trace-artifact",
-            "mlflow/metrics/get-history-bulk",
-            "mlflow/metrics/get-history-bulk-interval",
-            "mlflow/upload-artifact",
-            "mlflow/gateway-proxy",
-            "mlflow/scorer/invoke",
-        )
-        guarded = {k[0] for k in BEFORE_REQUEST_VALIDATORS}
-        unguarded = sorted(str(rule) for rule in mlflow_flask_app.url_map.iter_rules() if any(s in str(rule) for s in sensitive) and str(rule) not in guarded)
-        assert unguarded == [], f"MLflow serves these without any permission check: {unguarded}"

--- a/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
+++ b/mlflow_oidc_auth/tests/hooks/test_workspace_hooks.py
@@ -280,6 +280,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="new-ws",
@@ -311,6 +313,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="new-ws",
@@ -342,6 +346,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="new-ws",
@@ -373,6 +379,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="team-ws",
@@ -405,6 +413,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="team-ws",
@@ -436,6 +446,7 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
@@ -467,6 +478,7 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = True
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
@@ -499,6 +511,7 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = True
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
@@ -532,6 +545,7 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
                     mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = True
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
@@ -550,6 +564,106 @@ class TestWorkspaceCreationGating:
                                 assert resp.status_code == 403
                                 mock_get_permission.assert_not_called()
 
+    def test_before_request_hook_blocks_missing_workspace_creation_when_deny_default_enabled(self):
+        """A request without workspace context lands in the default workspace, so it must be denied too."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = True
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value=None,
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is not None
+                                assert resp.status_code == 403
+                                mock_get_permission.assert_not_called()
+
+    def test_before_request_hook_blocks_padded_default_workspace_creation(self):
+        """Workspace names are stripped like MLflow does, so padding cannot bypass the default-workspace guard."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = True
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value="  default  ",
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is not None
+                                assert resp.status_code == 403
+                                mock_get_permission.assert_not_called()
+
+    def test_before_request_hook_strips_workspace_before_permission_lookup(self):
+        """A padded workspace header resolves to the same permission entry MLflow will use."""
+        from mlflow_oidc_auth.hooks.before_request import before_request_hook
+        from mlflow_oidc_auth.permissions import MANAGE
+
+        _app = self._make_flask_app()
+        with _app.test_request_context(
+            "/api/2.0/mlflow/experiments/create",
+            method="POST",
+        ):
+            with patch(
+                "mlflow_oidc_auth.hooks.before_request._get_auth_context",
+                return_value=("testuser", False),
+            ):
+                with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
+                    mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
+                    with patch(
+                        "mlflow_oidc_auth.bridge.user.get_request_workspace",
+                        return_value=" team-ws ",
+                    ):
+                        with patch(
+                            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+                            return_value=MANAGE,
+                        ) as mock_get_permission:
+                            with patch(
+                                "mlflow_oidc_auth.hooks.before_request._find_validator",
+                                return_value=None,
+                            ):
+                                resp = before_request_hook()
+                                assert resp is None or (hasattr(resp, "status_code") and resp.status_code != 403)
+                                mock_get_permission.assert_called_once_with("testuser", "team-ws")
+
     def test_before_request_hook_blocks_experiment_creation_with_workspace_edit(self):
         """CreateExperiment is denied for workspace EDIT because creation requires MANAGE."""
         from mlflow_oidc_auth.hooks.before_request import before_request_hook
@@ -566,6 +680,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="team-ws",
@@ -598,6 +714,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     with patch(
                         "mlflow_oidc_auth.bridge.user.get_request_workspace",
                         return_value="team-ws",
@@ -654,6 +772,8 @@ class TestWorkspaceCreationGating:
             ):
                 with patch("mlflow_oidc_auth.hooks.before_request.config") as mock_config:
                     mock_config.MLFLOW_ENABLE_WORKSPACES = True
+                    mock_config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT = False
+                    mock_config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION = False
                     # Admin should bypass — no 403
                     resp = before_request_hook()
                     assert resp is None

--- a/mlflow_oidc_auth/tests/test_config.py
+++ b/mlflow_oidc_auth/tests/test_config.py
@@ -314,6 +314,8 @@ class TestAppConfig(unittest.TestCase):
         with patch.dict(os.environ, {}, clear=True):
             config = AppConfig()
             self.assertFalse(config.MLFLOW_ENABLE_WORKSPACES)
+            self.assertFalse(config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT)
+            self.assertFalse(config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION)
 
     def test_workspace_feature_flags_override(self):
         """Test that workspace feature flags can be overridden via environment variables."""
@@ -321,10 +323,14 @@ class TestAppConfig(unittest.TestCase):
             os.environ,
             {
                 "MLFLOW_ENABLE_WORKSPACES": "true",
+                "OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT": "true",
+                "OIDC_WORKSPACE_DENY_DEFAULT_CREATION": "true",
             },
         ):
             config = AppConfig()
             self.assertTrue(config.MLFLOW_ENABLE_WORKSPACES)
+            self.assertTrue(config.OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT)
+            self.assertTrue(config.OIDC_WORKSPACE_DENY_DEFAULT_CREATION)
 
     def test_workspace_feature_flags_disabled_by_default(self):
         """Test that workspaces are disabled by default."""

--- a/mlflow_oidc_auth/tests/utils/test_permissions.py
+++ b/mlflow_oidc_auth/tests/utils/test_permissions.py
@@ -686,3 +686,60 @@ class TestResolvePermissionWorkspaceFallback(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPermissionCacheWorkspaceKey:
+    """The cache key must describe what resolve_permission actually did."""
+
+    def test_headerless_and_explicit_default_do_not_share_a_cache_entry(self):
+        """A header-less request skips the workspace check; an explicit default does not.
+
+        Keying both as "default" served the header-less fallback to the explicit-default
+        request, silently granting access that should have been workspace-denied.
+        """
+        from unittest.mock import patch
+
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        calls = []
+
+        def fake_builder(resource_id, username, **kwargs):
+            calls.append((resource_id, username))
+            return {}
+
+        with (
+            patch.dict(perms.PERMISSION_REGISTRY, {"experiment": fake_builder}),
+            patch.object(perms.config, "MLFLOW_ENABLE_WORKSPACES", True),
+            patch.object(
+                perms,
+                "get_permission_from_store_or_default",
+                return_value=perms.PermissionResult(perms.get_permission("READ"), "fallback"),
+            ),
+        ):
+            perms._get_permission_cache().clear()
+
+            with patch("mlflow_oidc_auth.bridge.user.get_request_workspace", return_value=None):
+                headerless = perms.resolve_permission("experiment", "1", "bob")
+
+            with (
+                patch("mlflow_oidc_auth.bridge.user.get_request_workspace", return_value="default"),
+                patch("mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached", return_value=None),
+            ):
+                explicit_default = perms.resolve_permission("experiment", "1", "bob")
+
+        assert headerless.kind == "fallback"
+        assert explicit_default.kind == "workspace-deny"
+        assert explicit_default.permission == perms.NO_PERMISSIONS
+        assert len(calls) == 2, "the two requests shared a cache entry"
+
+    def test_distinct_workspaces_do_not_share_a_cache_entry(self):
+        """The same resource id denotes different entities in different workspaces."""
+        from unittest.mock import patch
+
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        assert perms._make_cache_key("experiment", "1", "bob", "ws-a") != perms._make_cache_key("experiment", "1", "bob", "ws-b")
+
+        with patch.object(perms.config, "MLFLOW_ENABLE_WORKSPACES", False):
+            assert perms._get_cache_workspace() is None
+            assert perms._make_cache_key("experiment", "1", "bob", None) == "experiment:1:bob"

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -52,18 +52,46 @@ def _get_permission_cache() -> CacheBackend:
     return _permission_cache
 
 
-def _make_cache_key(resource_type: str, resource_id: str, username: str) -> str:
-    """Build a string cache key from the permission lookup tuple."""
+def _get_effective_workspace() -> str | None:
+    """Return the workspace this request resolves to, or None when workspaces are off.
+
+    Mirrors MLflow: a request with no workspace context is served from the default
+    workspace, so it must key as the default rather than as "no workspace".
+    """
+    if not config.MLFLOW_ENABLE_WORKSPACES:
+        return None
+
+    from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
+
+    from mlflow_oidc_auth.bridge.user import get_request_workspace
+
+    return get_request_workspace() or DEFAULT_WORKSPACE_NAME
+
+
+def _make_cache_key(resource_type: str, resource_id: str, username: str, workspace: str | None = None) -> str:
+    """Build a string cache key from the permission lookup tuple.
+
+    The workspace is part of the key whenever workspaces are enabled: the same
+    resource id denotes different entities in different workspaces, and a result
+    may itself be workspace-derived, so a workspace-blind key would serve one
+    tenant's decision to another for the lifetime of the entry.
+    """
+    if workspace is not None:
+        return f"{workspace}:{resource_type}:{resource_id}:{username}"
     return f"{resource_type}:{resource_id}:{username}"
 
 
-def invalidate_permission_cache(resource_type: str, resource_id: str, username: str) -> None:
+def invalidate_permission_cache(resource_type: str, resource_id: str, username: str, workspace: str | None = None) -> None:
     """Remove a specific permission entry from cache.
 
-    Call after permission CUD operations for a specific user+resource.
+    Call after permission CUD operations for a specific user+resource. When
+    workspaces are enabled, pass the workspace the entry was cached under;
+    omitting it falls back to the workspace of the current request.
     """
     cache = _get_permission_cache()
-    cache.delete(_make_cache_key(resource_type, resource_id, username))
+    if workspace is None:
+        workspace = _get_effective_workspace()
+    cache.delete(_make_cache_key(resource_type, resource_id, username, workspace))
 
 
 def flush_permission_cache() -> None:
@@ -264,7 +292,8 @@ def resolve_permission(resource_type: str, resource_id: str, username: str, **kw
     every request. The cache key is ``resource_type:resource_id:username``.
     """
     cache = _get_permission_cache()
-    cache_key = _make_cache_key(resource_type, resource_id, username)
+    effective_workspace = _get_effective_workspace()
+    cache_key = _make_cache_key(resource_type, resource_id, username, effective_workspace)
 
     cached = cache.get(cache_key)
     if cached is not None:

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -52,20 +52,30 @@ def _get_permission_cache() -> CacheBackend:
     return _permission_cache
 
 
-def _get_effective_workspace() -> str | None:
-    """Return the workspace this request resolves to, or None when workspaces are off.
+# Distinguishes "no workspace context on this request" from a workspace literally named
+# after it. Cannot collide with a real name: MLflow's WorkspaceNameValidator rejects ":".
+_NO_WORKSPACE_CACHE_MARKER = "::no-workspace"
 
-    Mirrors MLflow: a request with no workspace context is served from the default
-    workspace, so it must key as the default rather than as "no workspace".
+
+def _get_cache_workspace() -> str | None:
+    """Return the workspace component of the cache key, or None when workspaces are off.
+
+    This must describe what ``resolve_permission`` actually *did*, not what MLflow would
+    resolve the request to. A header-less request currently skips workspace authorization
+    entirely and keeps the resource-level fallback, whereas an explicit
+    ``X-MLFLOW-WORKSPACE: default`` request runs the workspace check and can come back
+    ``workspace-deny``. Those are different decisions, so they must not share a key —
+    substituting the default workspace name here let a header-less result be served to an
+    explicit-default request, and vice versa, for the lifetime of the entry.
     """
     if not config.MLFLOW_ENABLE_WORKSPACES:
         return None
 
-    from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
-
     from mlflow_oidc_auth.bridge.user import get_request_workspace
 
-    return get_request_workspace() or DEFAULT_WORKSPACE_NAME
+    # None also covers resolution outside a Flask request context, which likewise skips
+    # the workspace branch below and so belongs in the same bucket.
+    return get_request_workspace() or _NO_WORKSPACE_CACHE_MARKER
 
 
 def _make_cache_key(resource_type: str, resource_id: str, username: str, workspace: str | None = None) -> str:
@@ -90,7 +100,7 @@ def invalidate_permission_cache(resource_type: str, resource_id: str, username: 
     """
     cache = _get_permission_cache()
     if workspace is None:
-        workspace = _get_effective_workspace()
+        workspace = _get_cache_workspace()
     cache.delete(_make_cache_key(resource_type, resource_id, username, workspace))
 
 
@@ -292,8 +302,7 @@ def resolve_permission(resource_type: str, resource_id: str, username: str, **kw
     every request. The cache key is ``resource_type:resource_id:username``.
     """
     cache = _get_permission_cache()
-    effective_workspace = _get_effective_workspace()
-    cache_key = _make_cache_key(resource_type, resource_id, username, effective_workspace)
+    cache_key = _make_cache_key(resource_type, resource_id, username, _get_cache_workspace())
 
     cached = cache.get(cache_key)
     if cached is not None:


### PR DESCRIPTION
Adds opt-in guards for workspace-enabled deployments.

When workspaces are enabled, create requests with an explicit workspace are checked against workspace permissions. Clients that do not send workspace context could still fall through the legacy path and create experiments or registered models outside the intended workspace boundary.

Two optional settings, both off by default so existing behaviour is unchanged:

- `OIDC_WORKSPACE_REQUIRE_CREATION_CONTEXT` — reject workspace-gated create requests when no workspace context is present
- `OIDC_WORKSPACE_DENY_DEFAULT_CREATION` — reject non-admin create requests targeting the `default` workspace

> **Stacked on #264 → #263.** Base retargets automatically as those merge. Review only the commits above `fix(security): guard endpoints…`.

### Fixes found in review

**The deny-default guard did not actually guard.** It sat in an `elif` reachable only when a workspace header was present. MLflow resolves a header-less request to the `default` workspace, so a non-admin bypassed the flag by simply omitting `X-MLFLOW-WORKSPACE` — landing in `default` with no permission check at all. It only worked if `REQUIRE_CREATION_CONTEXT` was *also* set, which the docs presented as independent.

**Header normalization happened in two places and drifted.** The guard stripped the header while `resolve_permission`'s fallback used the raw value, so a padded header authorized creation against `team-ws` and then hard-denied everything else against `" team-ws "`. A whitespace-only header stripped to `""` rather than `None`, diverging from MLflow. Normalization now happens once, in `AuthMiddleware`, and is asserted against MLflow's own `_normalize_workspace` rather than restating the logic.

**The permission cache conflated two different decisions.** A header-less request skips workspace authorization; an explicit `X-MLFLOW-WORKSPACE: default` runs it and can return `workspace-deny`. Keying both as `default` served one to the other within the TTL.

Also removed `_get_config_bool`, which existed to tolerate tests that patch config with a `MagicMock` and silently coerced any non-bool to the default — fail-open behaviour in a security guard. The tests set the flags explicitly instead; that alone exposed one test passing vacuously.

### Known gap, needs a decision

With both flags off (the default), a non-admin creating a resource with `X-MLFLOW-WORKSPACE: default` must hold MANAGE on the default workspace, but the same user sending **no header** gets no workspace check at all — and MLflow resolves both to the same workspace.

Closing this would deny header-less creates for anyone lacking MANAGE on `default`, breaking existing deployments on upgrade, so it is left as a deliberate decision rather than folded in. Options: fix outright, gate the leniency behind an opt-out flag, or document as intended. `docs/workspaces.md` should be reworded once that is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)