### PR TITLE
fix(auth): add configurable HTTP timeout on OIDC discovery and JWKS fetches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,7 @@ The plugin uses TTL caches to avoid repeated database lookups on every request. 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `OIDC_JWKS_CACHE_TTL_SECONDS` | Integer | `300` | Time-to-live (seconds) for the JWKS key set cache. The OIDC provider's signing keys are fetched once and cached for this duration. This is always a local in-process cache (not affected by `CACHE_BACKEND`) because JWKS data is identical across replicas |
+| `OIDC_HTTP_TIMEOUT_SECONDS` | Integer | `10` | Timeout (seconds) applied to OIDC discovery and JWKS HTTP fetches. Set lower for faster failover when the IdP is unreachable; without a timeout a hung IdP can block request threads until the OS-level TCP timeout (~2 minutes), causing cascading auth failures |
 | `PERMISSION_CACHE_TTL_SECONDS` | Integer | `30` | Time-to-live (seconds) for the permission resolution cache. Cached permission decisions expire after this duration. Lower values mean faster propagation of permission changes; higher values reduce database load |
 | `CACHE_BACKEND` | String | `local` | Cache backend for permission and workspace caches. Options: `local` (in-process TTL cache) or `redis` (shared Redis instance). Use `redis` for multi-replica deployments where permission changes must propagate immediately across all replicas |
 | `CACHE_REDIS_URL` | String | None | Redis connection URL. Required when `CACHE_BACKEND=redis`. Example: `redis://localhost:6379/0` or `redis://:password@redis-host:6379/1` |

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -45,16 +45,19 @@ def _get_oidc_jwks(force_refresh: bool = False) -> dict:
         if cached is not None:
             return cached
 
-    # Fetch outside the lock to avoid blocking other threads during HTTP I/O
+    # Fetch outside the lock to avoid blocking other threads during HTTP I/O.
+    # Timeouts are essential: without them, a hung IdP can block request threads
+    # until the OS-level TCP timeout (~2 minutes), causing cascading auth failures.
+    timeout = config.OIDC_HTTP_TIMEOUT_SECONDS
     try:
         logger.debug("Fetching OIDC discovery metadata")
-        metadata = requests.get(config.OIDC_DISCOVERY_URL).json()
+        metadata = requests.get(config.OIDC_DISCOVERY_URL, timeout=timeout).json()
         jwks_uri = metadata.get("jwks_uri")
         if not jwks_uri:
             raise ValueError("No jwks_uri found in OIDC discovery metadata")
 
         logger.debug("Fetching JWKS from %s", jwks_uri)
-        jwks = requests.get(jwks_uri).json()
+        jwks = requests.get(jwks_uri, timeout=timeout).json()
     except requests.exceptions.RequestException as e:
         logger.error("Failed to fetch OIDC JWKS: %s", e)
         raise

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -111,6 +111,11 @@ class AppConfig:
         # JWKS caching settings
         self.OIDC_JWKS_CACHE_TTL_SECONDS = config_manager.get_int("OIDC_JWKS_CACHE_TTL_SECONDS", default=300)
 
+        # HTTP timeout for OIDC discovery and JWKS fetches (seconds). Without
+        # this, a hung IdP can block request threads until the OS-level TCP
+        # timeout (~2 minutes), causing cascading auth failures.
+        self.OIDC_HTTP_TIMEOUT_SECONDS = config_manager.get_int("OIDC_HTTP_TIMEOUT_SECONDS", default=10)
+
         # Permission cache settings
         self.PERMISSION_CACHE_TTL_SECONDS = config_manager.get_int("PERMISSION_CACHE_TTL_SECONDS", default=30)
 

--- a/mlflow_oidc_auth/tests/test_auth.py
+++ b/mlflow_oidc_auth/tests/test_auth.py
@@ -27,6 +27,7 @@ class TestGetOidcJwks:
     def test_get_oidc_jwks_success(self, mock_config, mock_requests):
         """Test successful JWKS retrieval from OIDC provider"""
         mock_config.OIDC_DISCOVERY_URL = "https://example.com/.well-known/openid_configuration"
+        mock_config.OIDC_HTTP_TIMEOUT_SECONDS = 10
 
         discovery_response = MagicMock()
         discovery_response.json.return_value = {"jwks_uri": "https://example.com/jwks"}
@@ -38,9 +39,28 @@ class TestGetOidcJwks:
         result = _get_oidc_jwks()
 
         assert mock_requests.get.call_count == 2
-        mock_requests.get.assert_any_call("https://example.com/.well-known/openid_configuration")
-        mock_requests.get.assert_any_call("https://example.com/jwks")
+        mock_requests.get.assert_any_call("https://example.com/.well-known/openid_configuration", timeout=10)
+        mock_requests.get.assert_any_call("https://example.com/jwks", timeout=10)
         assert result == {"keys": [{"kty": "RSA", "kid": "test"}]}
+
+    @patch("mlflow_oidc_auth.auth.requests")
+    @patch("mlflow_oidc_auth.auth.config")
+    def test_get_oidc_jwks_uses_configured_timeout(self, mock_config, mock_requests):
+        """Test that OIDC_HTTP_TIMEOUT_SECONDS overrides the default timeout"""
+        mock_config.OIDC_DISCOVERY_URL = "https://example.com/.well-known/openid_configuration"
+        mock_config.OIDC_HTTP_TIMEOUT_SECONDS = 3
+
+        discovery_response = MagicMock()
+        discovery_response.json.return_value = {"jwks_uri": "https://example.com/jwks"}
+        jwks_response = MagicMock()
+        jwks_response.json.return_value = {"keys": []}
+
+        mock_requests.get.side_effect = [discovery_response, jwks_response]
+
+        _get_oidc_jwks()
+
+        for call in mock_requests.get.call_args_list:
+            assert call.kwargs.get("timeout") == 3
 
     @patch("mlflow_oidc_auth.auth.requests")
     @patch("mlflow_oidc_auth.auth.config")

--- a/mlflow_oidc_auth/tests/test_auth_module.py
+++ b/mlflow_oidc_auth/tests/test_auth_module.py
@@ -32,7 +32,7 @@ def test_get_oidc_jwks_missing_discovery_url(monkeypatch):
 def test_get_oidc_jwks_missing_jwks_uri(monkeypatch):
     monkeypatch.setattr(config, "OIDC_DISCOVERY_URL", "http://example/.well-known")
 
-    def fake_get(url):
+    def fake_get(url, **kwargs):
         return DummyResponse({})
 
     monkeypatch.setattr(requests, "get", fake_get)
@@ -46,7 +46,7 @@ def test_get_oidc_jwks_success(monkeypatch):
 
     calls = []
 
-    def fake_get(url):
+    def fake_get(url, **kwargs):
         calls.append(url)
         if url == "http://example/.well-known":
             return DummyResponse({"jwks_uri": "http://jwks"})
@@ -64,7 +64,7 @@ def test_get_oidc_jwks_success(monkeypatch):
 def test_get_oidc_jwks_request_exception(monkeypatch):
     monkeypatch.setattr(config, "OIDC_DISCOVERY_URL", "http://example/.well-known")
 
-    def fake_get(url):
+    def fake_get(url, **kwargs):
         raise requests.exceptions.RequestException("boom")
 
     monkeypatch.setattr(requests, "get", fake_get)


### PR DESCRIPTION
Lands #246 (by @remidebette... — original author's commit preserved) rebased onto current `main`, plus a one-line test fix: the `_get_oidc_jwks` request stubs in `test_auth_module.py` needed to accept the new `timeout=` kwarg. Adds `OIDC_HTTP_TIMEOUT_SECONDS` (default 10) so a hung IdP can't block request threads for ~2 minutes.

Could not push directly to the org fork branch (maintainer-edit not honored for the SSH identity), so landing via a base-repo branch. Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)