### PR TITLE
ci: disable SonarQube workflow until SONAR_TOKEN is fixed

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,14 +1,20 @@
 name: SonarQube
 
+# TEMPORARILY DISABLED. The SonarCloud scan fails on JRE/engine provisioning with
+# HTTP 403 — the SONAR_TOKEN needs regenerating (and/or Automatic Analysis toggled)
+# in SonarCloud before this can run. Until then it runs on manual dispatch only, so it
+# does not block PRs. To re-enable, restore the pull_request + push triggers below.
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - reopened
+#       - synchronize
+#   push:
+#     branches:
+#       - main
 
 jobs:
   sonarqube:


### PR DESCRIPTION
Temporarily switches the standalone `SonarQube` workflow to `workflow_dispatch` (manual) only. The scan fails on JRE/engine provisioning with HTTP 403 — the `SONAR_TOKEN` needs regenerating in SonarCloud (and/or Automatic Analysis toggled). Until then it was showing red on every same-repo PR with no code signal. The job/config are kept; re-enable by restoring the `pull_request`+`push` triggers (left commented in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)