### PR TITLE
fix(auth): close the proto-JSON dual-spelling authorization bypass (#270)

### DIFF
--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -136,7 +136,7 @@ from mlflow_oidc_auth.bridge import get_fastapi_admin_status, get_fastapi_userna
 import mlflow_oidc_auth.responses as responses
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.store import store
-from mlflow_oidc_auth.hooks.dual_spelling_guard import find_dual_spelling_collision
+from mlflow_oidc_auth.hooks.dual_spelling_guard import find_dual_spelling_collision, has_unexpected_get_body
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.validators import (
     validate_can_create_experiment,
@@ -696,6 +696,13 @@ def before_request_hook():
     if collision is not None:
         logger.warning(f"Rejecting {request.method} {request.path}: field '{collision}' specified under multiple spellings")
         return responses.make_bad_request_response({"message": f"Ambiguous request: field '{collision}' was specified under multiple spellings"})
+    # Issue #270: a GET with an empty query string makes MLflow proto-parse the JSON
+    # body instead of the args. Validators that read request.args then authorize
+    # vacuously — without any store lookup — while MLflow serves whatever the body
+    # named. No legitimate client sends a GET body, so reject it.
+    if has_unexpected_get_body(request):
+        logger.warning(f"Rejecting {request.method} {request.path}: GET carries a request body that MLflow would parse")
+        return responses.make_bad_request_response({"message": "Ambiguous request: GET parameters must be sent in the query string, not a request body"})
     # Issue #262: an authenticated user with no permission-DB record (e.g. API-first via a
     # bearer token, never logged in through the browser) would have MLflow commit the new
     # resource while the after-request MANAGE grant fails on the missing user, leaving an

--- a/mlflow_oidc_auth/hooks/before_request.py
+++ b/mlflow_oidc_auth/hooks/before_request.py
@@ -136,6 +136,7 @@ from mlflow_oidc_auth.bridge import get_fastapi_admin_status, get_fastapi_userna
 import mlflow_oidc_auth.responses as responses
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.store import store
+from mlflow_oidc_auth.hooks.dual_spelling_guard import find_dual_spelling_collision
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.validators import (
     validate_can_create_experiment,
@@ -685,6 +686,16 @@ def before_request_hook():
     logger.debug(f"Before request hook called for path: {request.path}, method: {request.method}, username: {username}, is admin: {is_admin}")
     validator = _find_validator(request)
     _stash_gateway_context(validator)
+    # Issue #270: reject proto-JSON dual-spelling before any authorization decision.
+    # A body that spells one field two ways (e.g. experiment_id + experimentId) is
+    # ambiguous — protobuf silently keeps the last, letting a single-spelling authz
+    # check be bypassed while MLflow acts on the other value. No legitimate client
+    # sends both, so 400 is always safe. Runs before the admin early-out because the
+    # request is malformed regardless of who sends it.
+    collision = find_dual_spelling_collision(request)
+    if collision is not None:
+        logger.warning(f"Rejecting {request.method} {request.path}: field '{collision}' specified under multiple spellings")
+        return responses.make_bad_request_response({"message": f"Ambiguous request: field '{collision}' was specified under multiple spellings"})
     # Issue #262: an authenticated user with no permission-DB record (e.g. API-first via a
     # bearer token, never logged in through the browser) would have MLflow commit the new
     # resource while the after-request MANAGE grant fails on the missing user, leaving an

--- a/mlflow_oidc_auth/hooks/dual_spelling_guard.py
+++ b/mlflow_oidc_auth/hooks/dual_spelling_guard.py
@@ -1,0 +1,122 @@
+"""Reject requests that carry one proto field under two spellings (issue #270).
+
+MLflow parses request bodies as proto-JSON.  ``protobuf.ParseDict`` accepts a
+field under BOTH its snake_case name AND its lowerCamelCase ``json_name``, and
+when both keys appear it silently resolves to the LAST one in JSON order, which
+is caller-controlled.  Any authorization check that reads a single spelling of a
+field can therefore be bypassed::
+
+    {"experiment_id": "attacker_own", "experimentId": "victim"}
+
+makes the validator authorize ``attacker_own`` (which the caller owns) while
+MLflow operates on ``victim``.  The impact spans cross-tenant READ as well as
+WRITE/DELETE on every gated mutating route.
+
+No legitimate MLflow client emits a field under two spellings: the Python client
+serializes with ``preserving_proto_field_name=True`` (snake_case) and the browser
+UI sends snake_case request bodies.  Rejecting a dual-spelling request with 400
+therefore cannot break a real client — it only closes the ambiguity an attacker
+relies on.
+
+The ``(path, method) -> proto class`` map is derived directly from MLflow's own
+service registry via ``get_endpoints``, so it covers every proto endpoint MLflow
+serves — current and future — with no manual maintenance.  The request body is
+read through MLflow's own ``_get_normalized_request_json`` so the guard inspects
+exactly the dict MLflow will ``parse_dict`` (force-parsed, double-encoding aware),
+leaving no room for a ``Content-Type`` evasion.
+"""
+
+import re
+from typing import List, Optional, Pattern, Tuple
+
+from flask import Request
+
+from mlflow.server.handlers import get_endpoints, _get_normalized_request_json
+
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+# A "collidable" field is one whose snake_case name differs from its camelCase
+# json_name (i.e. a multi-word field).  Single-word fields have name == json_name
+# and cannot be spelled two ways, so they can never collide.
+_CollidablePairs = List[Tuple[str, str]]
+
+_EXACT_COLLIDABLE: dict[Tuple[str, str], _CollidablePairs] = {}
+_PATTERN_COLLIDABLE: List[Tuple[Pattern[str], str, _CollidablePairs]] = []
+
+
+def _re_compile_path(path: str) -> Pattern[str]:
+    """Turn a path with ``<param>`` segments into a full-match regex."""
+    return re.compile(re.sub(r"<([^>]+)>", r"([^/]+)", path))
+
+
+def _build_proto_route_maps() -> None:
+    """Populate the collidable-field maps from MLflow's full proto surface.
+
+    ``get_endpoints(lambda rc: rc)`` yields ``(path, handler, methods)`` for every
+    registered endpoint, with the handler being the request proto class for proto
+    routes and a plain function (``_graphql``, server-info, scoring, ...) otherwise.
+    We keep only proto handlers that actually have collidable fields.
+    """
+    for http_path, handler, methods in get_endpoints(lambda rc: rc):
+        descriptor = getattr(handler, "DESCRIPTOR", None)
+        if descriptor is None:
+            continue  # non-proto handler
+        collidable = [(f.name, f.json_name) for f in descriptor.fields if f.name != f.json_name]
+        if not collidable:
+            continue
+        if "<" in http_path:
+            compiled = _re_compile_path(http_path)
+            for method in methods:
+                _PATTERN_COLLIDABLE.append((compiled, method, collidable))
+        else:
+            for method in methods:
+                _EXACT_COLLIDABLE[(http_path, method)] = collidable
+
+
+_build_proto_route_maps()
+
+
+def _collidable_fields_for(path: str, method: str) -> Optional[_CollidablePairs]:
+    """Return the collidable field pairs for a route, or ``None`` if it has none.
+
+    Exact paths are looked up first (the common case, O(1)); the regex list is
+    scanned only for parameterized paths.
+    """
+    fields = _EXACT_COLLIDABLE.get((path, method))
+    if fields is not None:
+        return fields
+    for compiled, m, collidable in _PATTERN_COLLIDABLE:
+        if m == method and compiled.fullmatch(path):
+            return collidable
+    return None
+
+
+def find_dual_spelling_collision(req: Request) -> Optional[str]:
+    """Return the snake_case name of a dual-spelled field, or ``None`` if clean.
+
+    Only the request body is inspected: on GET, MLflow builds the proto solely
+    from ``request.args`` keyed by ``field.name`` (snake_case), so a camelCase
+    query parameter is never read and no dual-spelling vector exists there.
+    """
+    collidable = _collidable_fields_for(req.path, req.method)
+    if not collidable:
+        return None
+    if req.method == "GET":
+        return None
+
+    try:
+        data = _get_normalized_request_json(req)
+    except Exception:
+        # Malformed / wrong-content-type body: MLflow will reject it downstream,
+        # so there is nothing for the guard to protect.
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    keys = data.keys()
+    for snake, camel in collidable:
+        if snake in keys and camel in keys:
+            return snake
+    return None

--- a/mlflow_oidc_auth/hooks/dual_spelling_guard.py
+++ b/mlflow_oidc_auth/hooks/dual_spelling_guard.py
@@ -78,6 +78,29 @@ def _build_proto_route_maps() -> None:
 _build_proto_route_maps()
 
 
+def _assert_maps_populated() -> None:
+    """Fail loudly if the route maps came up empty.
+
+    The maps are derived from MLflow's registry rather than hardcoded, so a future
+    MLflow release that changes the ``get_endpoints`` handler contract (or stops
+    exposing proto classes) would yield empty maps — and this guard would silently
+    become a no-op, quietly reopening the cross-tenant bypass it exists to close.
+    A security control must not fail open silently, so refuse to start instead.
+    MLflow always serves proto routes with multi-word fields (experiment_id, run_id,
+    ...), so empty maps mean the derivation broke, never a legitimate state.
+    """
+    if not _EXACT_COLLIDABLE and not _PATTERN_COLLIDABLE:
+        raise RuntimeError(
+            "mlflow-oidc-auth: could not derive any proto routes from MLflow's endpoint "
+            "registry, so the dual-spelling authorization guard would be inert. This "
+            "usually means the installed MLflow version changed the get_endpoints() "
+            "contract. Refusing to start rather than run without the guard (issue #270)."
+        )
+
+
+_assert_maps_populated()
+
+
 def _collidable_fields_for(path: str, method: str) -> Optional[_CollidablePairs]:
     """Return the collidable field pairs for a route, or ``None`` if it has none.
 

--- a/mlflow_oidc_auth/hooks/dual_spelling_guard.py
+++ b/mlflow_oidc_auth/hooks/dual_spelling_guard.py
@@ -1,4 +1,4 @@
-"""Reject requests that carry one proto field under two spellings (issue #270).
+"""Reject ambiguous requests before any authorization decision (issue #270).
 
 MLflow parses request bodies as proto-JSON.  ``protobuf.ParseDict`` accepts a
 field under BOTH its snake_case name AND its lowerCamelCase ``json_name``, and
@@ -18,19 +18,41 @@ UI sends snake_case request bodies.  Rejecting a dual-spelling request with 400
 therefore cannot break a real client — it only closes the ambiguity an attacker
 relies on.
 
-The ``(path, method) -> proto class`` map is derived directly from MLflow's own
-service registry via ``get_endpoints``, so it covers every proto endpoint MLflow
-serves — current and future — with no manual maintenance.  The request body is
-read through MLflow's own ``_get_normalized_request_json`` so the guard inspects
-exactly the dict MLflow will ``parse_dict`` (force-parsed, double-encoding aware),
-leaving no room for a ``Content-Type`` evasion.
+GET requests need care.  MLflow's ``_get_request_message`` builds the proto from
+``request.args`` (keyed by snake_case ``field.name``, so camelCase query params
+are never read) **only when the query string is non-empty**::
+
+    if flask_request.method == "GET" and flask_request.args:   # args path
+        ...
+    else:                                                       # body path
+        request_json = _get_normalized_request_json(flask_request)
+    parse_dict(request_json, request_message)
+
+A GET with an *empty* query string therefore falls through and proto-parses the
+JSON **body**, with full dual-spelling semantics.  Worse, validators that read
+only ``request.args`` find nothing in such a request and authorize *vacuously*
+(no store lookup at all) while MLflow serves whatever the body named.  So a GET
+that carries a body MLflow will parse is rejected outright — see
+``has_unexpected_get_body``.  No legitimate client sends a GET body; real clients
+put GET parameters in the query string, which stays on the safe args path.
+
+The ``(path, method) -> proto class`` map is derived from MLflow's own service
+registry via ``get_endpoints``, so it covers every proto endpoint MLflow serves —
+current and future — with no manual maintenance.  A few proto-parsing handlers are
+registered with ``@app.route`` instead and never appear in that registry, so they
+are bound by enumerating the real Flask routing table (see
+``_NON_REGISTRY_PROTO_ROUTES``).  The request body is read through MLflow's own
+``_get_normalized_request_json`` so the guard inspects exactly the dict MLflow will
+``parse_dict`` (force-parsed, double-encoding aware), leaving no room for a
+``Content-Type`` evasion.
 """
 
 import re
-from typing import List, Optional, Pattern, Tuple
+from typing import Any, Dict, List, Optional, Pattern, Set, Tuple
 
 from flask import Request
 
+from mlflow.protos.service_pb2 import SearchDatasets
 from mlflow.server.handlers import get_endpoints, _get_normalized_request_json
 
 from mlflow_oidc_auth.logger import get_logger
@@ -42,8 +64,20 @@ logger = get_logger()
 # and cannot be spelled two ways, so they can never collide.
 _CollidablePairs = List[Tuple[str, str]]
 
-_EXACT_COLLIDABLE: dict[Tuple[str, str], _CollidablePairs] = {}
+_EXACT_COLLIDABLE: Dict[Tuple[str, str], _CollidablePairs] = {}
 _PATTERN_COLLIDABLE: List[Tuple[Pattern[str], str, _CollidablePairs]] = []
+
+# Every proto-backed route, whether or not it has collidable fields. Used to decide
+# whether a GET body would be proto-parsed by MLflow.
+_EXACT_PROTO_ROUTES: Set[Tuple[str, str]] = set()
+_PATTERN_PROTO_ROUTES: List[Tuple[Pattern[str], str]] = []
+
+# Proto-parsing handlers MLflow registers with @app.route rather than through the
+# service registry, so get_endpoints() never yields their live path. MLflow also
+# registers malformed twins of some of these ("/api/2.0mlflow/...", missing the
+# slash) which DO appear in the registry — binding only those would leave the real
+# route unguarded. Enumerating the routing table avoids having to predict spellings.
+_NON_REGISTRY_PROTO_ROUTES = (("mlflow/experiments/search-datasets", "POST", SearchDatasets),)
 
 
 def _re_compile_path(path: str) -> Pattern[str]:
@@ -51,28 +85,46 @@ def _re_compile_path(path: str) -> Pattern[str]:
     return re.compile(re.sub(r"<([^>]+)>", r"([^/]+)", path))
 
 
+def _register_route(http_path: str, methods, descriptor) -> None:
+    """Record one route's proto membership and its collidable field pairs."""
+    collidable = [(f.name, f.json_name) for f in descriptor.fields if f.name != f.json_name]
+    parameterized = "<" in http_path
+    compiled = _re_compile_path(http_path) if parameterized else None
+    for method in methods:
+        if parameterized:
+            _PATTERN_PROTO_ROUTES.append((compiled, method))
+            if collidable:
+                _PATTERN_COLLIDABLE.append((compiled, method, collidable))
+        else:
+            _EXACT_PROTO_ROUTES.add((http_path, method))
+            if collidable:
+                _EXACT_COLLIDABLE[(http_path, method)] = collidable
+
+
+def _bind_non_registry_proto_routes() -> None:
+    """Bind proto-parsing routes that MLflow serves outside the service registry."""
+    from mlflow.server import app as mlflow_flask_app
+
+    for suffix, method, proto in _NON_REGISTRY_PROTO_ROUTES:
+        for rule in mlflow_flask_app.url_map.iter_rules():
+            path = str(rule)
+            if path.endswith(suffix) and method in (rule.methods or set()):
+                _register_route(path, [method], proto.DESCRIPTOR)
+
+
 def _build_proto_route_maps() -> None:
-    """Populate the collidable-field maps from MLflow's full proto surface.
+    """Populate the route maps from MLflow's full proto surface.
 
     ``get_endpoints(lambda rc: rc)`` yields ``(path, handler, methods)`` for every
     registered endpoint, with the handler being the request proto class for proto
     routes and a plain function (``_graphql``, server-info, scoring, ...) otherwise.
-    We keep only proto handlers that actually have collidable fields.
     """
     for http_path, handler, methods in get_endpoints(lambda rc: rc):
         descriptor = getattr(handler, "DESCRIPTOR", None)
         if descriptor is None:
             continue  # non-proto handler
-        collidable = [(f.name, f.json_name) for f in descriptor.fields if f.name != f.json_name]
-        if not collidable:
-            continue
-        if "<" in http_path:
-            compiled = _re_compile_path(http_path)
-            for method in methods:
-                _PATTERN_COLLIDABLE.append((compiled, method, collidable))
-        else:
-            for method in methods:
-                _EXACT_COLLIDABLE[(http_path, method)] = collidable
+        _register_route(http_path, methods, descriptor)
+    _bind_non_registry_proto_routes()
 
 
 _build_proto_route_maps()
@@ -116,26 +168,47 @@ def _collidable_fields_for(path: str, method: str) -> Optional[_CollidablePairs]
     return None
 
 
-def find_dual_spelling_collision(req: Request) -> Optional[str]:
-    """Return the snake_case name of a dual-spelled field, or ``None`` if clean.
+def _is_proto_route(path: str, method: str) -> bool:
+    """True when MLflow will build a proto message for this route."""
+    if (path, method) in _EXACT_PROTO_ROUTES:
+        return True
+    for compiled, m in _PATTERN_PROTO_ROUTES:
+        if m == method and compiled.fullmatch(path):
+            return True
+    return False
 
-    Only the request body is inspected: on GET, MLflow builds the proto solely
-    from ``request.args`` keyed by ``field.name`` (snake_case), so a camelCase
-    query parameter is never read and no dual-spelling vector exists there.
-    """
-    collidable = _collidable_fields_for(req.path, req.method)
-    if not collidable:
-        return None
-    if req.method == "GET":
-        return None
 
+def _request_body(req: Request) -> Optional[Dict[str, Any]]:
+    """The dict MLflow will ``parse_dict``, or ``None`` if there isn't one."""
     try:
         data = _get_normalized_request_json(req)
     except Exception:
         # Malformed / wrong-content-type body: MLflow will reject it downstream,
         # so there is nothing for the guard to protect.
         return None
-    if not isinstance(data, dict):
+    return data if isinstance(data, dict) else None
+
+
+def _mlflow_reads_args(req: Request) -> bool:
+    """True when MLflow builds the proto from the query string and ignores the body.
+
+    Mirrors ``_get_request_message``: the args path is taken only for a GET whose
+    query string is non-empty. Query args are keyed by snake_case ``field.name``,
+    so camelCase params are never read and dual spelling is not a vector there.
+    """
+    return req.method == "GET" and bool(req.args)
+
+
+def find_dual_spelling_collision(req: Request) -> Optional[str]:
+    """Return the snake_case name of a dual-spelled field, or ``None`` if clean."""
+    collidable = _collidable_fields_for(req.path, req.method)
+    if not collidable:
+        return None
+    if _mlflow_reads_args(req):
+        return None
+
+    data = _request_body(req)
+    if not data:
         return None
 
     keys = data.keys()
@@ -143,3 +216,19 @@ def find_dual_spelling_collision(req: Request) -> Optional[str]:
         if snake in keys and camel in keys:
             return snake
     return None
+
+
+def has_unexpected_get_body(req: Request) -> bool:
+    """True for a GET that carries a body MLflow will proto-parse.
+
+    With an empty query string MLflow parses the JSON body instead of the args. A
+    validator that reads ``request.args`` then finds nothing and authorizes without
+    consulting the store at all, while MLflow serves whatever the body named — a
+    cross-tenant read that needs no dual spelling. No legitimate client sends a GET
+    body (real clients put GET parameters in the query string), so reject it.
+    """
+    if req.method != "GET" or req.args:
+        return False
+    if not _is_proto_route(req.path, req.method):
+        return False
+    return bool(_request_body(req))

--- a/mlflow_oidc_auth/responses/__init__.py
+++ b/mlflow_oidc_auth/responses/__init__.py
@@ -1,7 +1,13 @@
-from mlflow_oidc_auth.responses.client_error import make_auth_required_response, make_forbidden_response, make_basic_auth_response
+from mlflow_oidc_auth.responses.client_error import (
+    make_auth_required_response,
+    make_forbidden_response,
+    make_bad_request_response,
+    make_basic_auth_response,
+)
 
 __all__ = [
     "make_auth_required_response",
     "make_forbidden_response",
+    "make_bad_request_response",
     "make_basic_auth_response",
 ]

--- a/mlflow_oidc_auth/responses/client_error.py
+++ b/mlflow_oidc_auth/responses/client_error.py
@@ -15,6 +15,14 @@ def make_forbidden_response(msg=None) -> Response:
     return response
 
 
+def make_bad_request_response(msg=None) -> Response:
+    if msg is None:
+        msg = {"message": "Bad request"}
+    response = make_response(jsonify(msg))
+    response.status_code = 400
+    return response
+
+
 def make_basic_auth_response() -> Response:
     response = make_response("You are not authenticated. Please see documentation for details" "https://github.com/mlflow-oidc/mlflow-oidc-auth")
     response.status_code = 401

--- a/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
+++ b/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
@@ -8,6 +8,7 @@ spellings with 400, before any authorization decision.
 """
 
 import json
+from unittest.mock import patch
 
 import pytest
 from flask import Flask, request
@@ -33,6 +34,26 @@ def _json_ctx(path, method, body=None, query=None):
 
 # A concrete gated route with two collidable fields, used across the vector tests.
 _UPDATE_EXPERIMENT = "/api/2.0/mlflow/experiments/update"
+
+
+def test_empty_route_maps_fail_loudly_instead_of_disabling_the_guard():
+    """A broken MLflow contract must crash at startup, not silently disable the guard.
+
+    The maps are derived from MLflow's registry, so a future release that changes the
+    get_endpoints() handler contract would yield empty maps and turn this guard into a
+    no-op — silently reopening the bypass. Verify that state is refused, not tolerated.
+    """
+    with (
+        patch.object(guard, "_EXACT_COLLIDABLE", {}),
+        patch.object(guard, "_PATTERN_COLLIDABLE", []),
+    ):
+        with pytest.raises(RuntimeError, match="dual-spelling authorization guard would be inert"):
+            guard._assert_maps_populated()
+
+
+def test_maps_populated_check_passes_with_real_mlflow():
+    """The live MLflow install must yield a non-empty map (the guard is actually active)."""
+    guard._assert_maps_populated()
 
 
 def test_route_maps_cover_the_full_proto_surface():

--- a/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
+++ b/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
@@ -16,7 +16,10 @@ from flask import Flask, request
 from mlflow.server.handlers import get_endpoints
 
 from mlflow_oidc_auth.hooks import dual_spelling_guard as guard
-from mlflow_oidc_auth.hooks.dual_spelling_guard import find_dual_spelling_collision
+from mlflow_oidc_auth.hooks.dual_spelling_guard import (
+    find_dual_spelling_collision,
+    has_unexpected_get_body,
+)
 
 app = Flask(__name__)
 app.secret_key = "test_secret_key"
@@ -82,9 +85,74 @@ def test_camel_only_body_is_clean():
 
 
 def test_get_query_dual_spelling_is_not_a_vector():
-    """MLflow builds GET protos from args keyed by field.name (snake) only."""
+    """With a NON-EMPTY query string MLflow builds GET protos from args, keyed by snake field.name."""
     with _json_ctx("/api/2.0/mlflow/experiments/get", "GET", query={"experiment_id": "own", "experimentId": "victim"}):
         assert find_dual_spelling_collision(request) is None
+
+
+def test_get_with_empty_query_and_dual_spelled_body_is_rejected():
+    """A GET with an EMPTY query string proto-parses the BODY, so it must be checked.
+
+    MLflow's _get_request_message takes the args path only when request.args is
+    non-empty; otherwise it parse_dicts the body and last-spelling-wins applies.
+    Exempting every GET left the #270 bypass fully open on the GET surface.
+    """
+    with _json_ctx("/api/2.0/mlflow/experiments/get", "GET", {"experiment_id": "own", "experimentId": "victim"}):
+        assert find_dual_spelling_collision(request) == "experiment_id"
+
+
+def test_get_with_query_args_and_a_body_ignores_the_body():
+    """When args are present MLflow ignores the body entirely, so it is not a vector."""
+    with _json_ctx(
+        "/api/2.0/mlflow/experiments/get",
+        "GET",
+        {"experiment_id": "own", "experimentId": "victim"},
+        query={"experiment_id": "own"},
+    ):
+        assert find_dual_spelling_collision(request) is None
+        assert has_unexpected_get_body(request) is False
+
+
+def test_get_body_on_proto_route_is_rejected_even_without_dual_spelling():
+    """A GET body defeats args-only validators, which then authorize with no store lookup.
+
+    validate_can_read_metric_history_bulk_interval reads request.args; on a GET with an
+    empty query string it finds no run_ids and returns True without consulting the store,
+    while MLflow proto-parses the body and serves the run named there. No dual spelling
+    is needed, so has_unexpected_get_body must reject it.
+    """
+    with _json_ctx(
+        "/ajax-api/2.0/mlflow/metrics/get-history-bulk-interval",
+        "GET",
+        {"run_ids": ["victim_run"], "metric_key": "loss"},
+    ):
+        assert has_unexpected_get_body(request) is True
+
+
+def test_plain_get_without_body_is_allowed():
+    with _json_ctx("/api/2.0/mlflow/experiments/get", "GET"):
+        assert has_unexpected_get_body(request) is False
+
+
+def test_get_body_on_non_proto_route_is_allowed():
+    """Routes MLflow never proto-parses read args only, so a stray body is harmless."""
+    with _json_ctx("/api/2.0/mlflow/get-artifact", "GET", {"stray": "body"}):
+        assert has_unexpected_get_body(request) is False
+
+
+def test_live_search_datasets_route_is_covered():
+    """MLflow serves search-datasets via @app.route, so it is absent from get_endpoints().
+
+    Only the malformed twins ("/api/2.0mlflow/...", missing a slash, bound to
+    _not_implemented) appear in the registry. Binding only those would leave the real
+    route unguarded, so the live path is bound from the Flask routing table.
+    """
+    for path in (
+        "/ajax-api/2.0/mlflow/experiments/search-datasets",
+        "/api/2.0mlflow/experiments/search-datasets",
+    ):
+        with _json_ctx(path, "POST", {"experiment_ids": ["own"], "experimentIds": ["victim"]}):
+            assert find_dual_spelling_collision(request) == "experiment_ids", f"unguarded: {path}"
 
 
 def test_unmapped_route_is_ignored():
@@ -160,6 +228,13 @@ def test_hook_returns_400_on_dual_spelling():
     assert resp.status_code == 400
 
 
+def test_hook_returns_400_on_get_with_body():
+    """End-to-end: a GET carrying a proto-parsable body is rejected before authorization."""
+    resp = _hook_response("/api/2.0/mlflow/experiments/get", "GET", {"experiment_id": "own"})
+    assert resp is not None
+    assert resp.status_code == 400
+
+
 def test_hook_rejects_dual_spelling_even_for_admin():
     """A dual-spelled body is malformed regardless of who sends it."""
     from unittest.mock import patch
@@ -193,6 +268,14 @@ def test_every_collidable_route_rejects_dual_spelling():
     for path, method, snake, camel in routes:
         if method != "GET":
             continue
-        # GET routes read args by field.name (snake) only — not a dual-spelling vector.
+        # With a non-empty query string MLflow reads args by field.name (snake) only,
+        # so a camelCase query param is never read — not a dual-spelling vector.
         with _json_ctx(path, method, query={snake: "own", camel: "victim"}):
             assert find_dual_spelling_collision(request) is None, f"unexpected GET rejection on {path}"
+        # But with an EMPTY query string MLflow proto-parses the body, so the same
+        # dual spelling in a body IS a vector and must be rejected.
+        with _json_ctx(path, method, {snake: "own", camel: "victim"}):
+            assert find_dual_spelling_collision(request) == snake, f"guard missed GET-body dual-spelling on {path}"
+        # And any GET body on a proto route defeats args-only validators.
+        with _json_ctx(path, method, {snake: "own"}):
+            assert has_unexpected_get_body(request) is True, f"guard missed GET body on {path}"

--- a/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
+++ b/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
@@ -208,6 +208,49 @@ def _fill_path_params(path):
     return re.sub(r"<[^>]+>", "PLACEHOLDER", path)
 
 
+# Gated routes MLflow never proto-parses: their handlers read request.args only, so
+# neither dual spelling nor a GET body can make the validator and MLflow disagree.
+# Verified by inspecting each live view for a _get_request_message call.
+_ARGS_ONLY_EXEMPT_SUFFIXES = (
+    "/get-artifact",
+    "/model-versions/get-artifact",
+    "mlflow/gateway-proxy",
+    "mlflow/get-trace-artifact",
+    "mlflow/metrics/get-history-bulk",
+    "mlflow/runs/create-promptlab-run",
+    "mlflow/upload-artifact",
+    "mlflow/gateway/provider-config",
+    "mlflow/gateway/secrets/config",
+    "mlflow/gateway/supported-models",
+    "mlflow/gateway/supported-providers",
+    "mlflow/scorer/invoke",
+)
+
+
+def test_every_gated_route_is_guard_covered_or_explicitly_exempt():
+    """Coverage assertion: no gated route may silently escape the guard.
+
+    This is what would have caught experiments/search-datasets, whose live path MLflow
+    registers with @app.route and therefore never appears in get_endpoints(). A gated
+    route is acceptable only if the guard covers it, or its validator is an
+    unconditional deny (no field is read, so there is nothing to bypass), or MLflow
+    never proto-parses it. Anything else is a gap and must fail here.
+    """
+    from mlflow_oidc_auth.hooks.before_request import BEFORE_REQUEST_VALIDATORS, _deny_non_admin
+
+    gaps = []
+    for (path, method), validator in BEFORE_REQUEST_VALIDATORS.items():
+        if guard._is_proto_route(path, method):
+            continue
+        if validator is _deny_non_admin:
+            continue  # admin-only hard deny: no request field feeds the decision
+        if any(path.endswith(suffix) for suffix in _ARGS_ONLY_EXEMPT_SUFFIXES):
+            continue
+        gaps.append(f"{method} {path} -> {getattr(validator, '__name__', validator)}")
+
+    assert not gaps, "gated routes neither guard-covered nor exempt (see #270):\n" + "\n".join(sorted(gaps))
+
+
 def _hook_response(path, method, body):
     from unittest.mock import patch
 

--- a/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
+++ b/mlflow_oidc_auth/tests/hooks/test_dual_spelling_guard.py
@@ -1,0 +1,177 @@
+"""Tests for the proto-JSON dual-spelling request guard (issue #270).
+
+MLflow parses request bodies as proto-JSON, which accepts a field under both its
+snake_case name and its camelCase json_name and, when both appear, silently keeps
+the last one in JSON order. A single-spelling authorization check can therefore be
+bypassed. The guard rejects any request that carries one proto field under two
+spellings with 400, before any authorization decision.
+"""
+
+import json
+
+import pytest
+from flask import Flask, request
+
+from mlflow.server.handlers import get_endpoints
+
+from mlflow_oidc_auth.hooks import dual_spelling_guard as guard
+from mlflow_oidc_auth.hooks.dual_spelling_guard import find_dual_spelling_collision
+
+app = Flask(__name__)
+app.secret_key = "test_secret_key"
+
+
+def _json_ctx(path, method, body=None, query=None):
+    kwargs = {"path": path, "method": method}
+    if body is not None:
+        kwargs["data"] = json.dumps(body)
+        kwargs["content_type"] = "application/json"
+    if query is not None:
+        kwargs["query_string"] = query
+    return app.test_request_context(**kwargs)
+
+
+# A concrete gated route with two collidable fields, used across the vector tests.
+_UPDATE_EXPERIMENT = "/api/2.0/mlflow/experiments/update"
+
+
+def test_route_maps_cover_the_full_proto_surface():
+    """The guard's maps are derived from MLflow's own registry, not hand-maintained."""
+    assert guard._EXACT_COLLIDABLE, "exact collidable-route map is empty"
+    assert guard._PATTERN_COLLIDABLE, "parameterized collidable-route map is empty"
+    # UpdateExperiment is a representative gated mutating route.
+    fields = guard._collidable_fields_for(_UPDATE_EXPERIMENT, "POST")
+    assert ("experiment_id", "experimentId") in fields
+
+
+def test_dual_spelling_in_body_is_detected():
+    with _json_ctx(_UPDATE_EXPERIMENT, "POST", {"experiment_id": "own", "experimentId": "victim"}):
+        assert find_dual_spelling_collision(request) == "experiment_id"
+
+
+def test_snake_only_body_is_clean():
+    with _json_ctx(_UPDATE_EXPERIMENT, "POST", {"experiment_id": "own", "new_name": "x"}):
+        assert find_dual_spelling_collision(request) is None
+
+
+def test_camel_only_body_is_clean():
+    """A camelCase-only body is a single spelling — not a bypass — so the guard passes."""
+    with _json_ctx(_UPDATE_EXPERIMENT, "POST", {"experimentId": "own", "newName": "x"}):
+        assert find_dual_spelling_collision(request) is None
+
+
+def test_get_query_dual_spelling_is_not_a_vector():
+    """MLflow builds GET protos from args keyed by field.name (snake) only."""
+    with _json_ctx("/api/2.0/mlflow/experiments/get", "GET", query={"experiment_id": "own", "experimentId": "victim"}):
+        assert find_dual_spelling_collision(request) is None
+
+
+def test_unmapped_route_is_ignored():
+    with _json_ctx("/api/2.0/mlflow/does-not-exist", "POST", {"experiment_id": "a", "experimentId": "b"}):
+        assert find_dual_spelling_collision(request) is None
+
+
+def test_non_json_body_does_not_crash():
+    with app.test_request_context(path=_UPDATE_EXPERIMENT, method="POST", data="not json", content_type="text/plain"):
+        assert find_dual_spelling_collision(request) is None
+
+
+def test_empty_body_is_clean():
+    with app.test_request_context(path=_UPDATE_EXPERIMENT, method="POST"):
+        assert find_dual_spelling_collision(request) is None
+
+
+def _iter_collidable_routes():
+    """Yield (path, method, snake, camel) for every gated collidable route.
+
+    Exact routes plus one representative concrete path per parameterized route
+    (with ``<param>`` segments filled in), so the structural assertion exercises
+    real request paths.
+    """
+    for (path, method), pairs in guard._EXACT_COLLIDABLE.items():
+        snake, camel = pairs[0]
+        yield path, method, snake, camel
+    seen = set()
+    for _pattern, method, pairs in guard._PATTERN_COLLIDABLE:
+        # Recover a concrete path from the same registry the maps were built from.
+        for http_path, handler, methods in get_endpoints(lambda rc: rc):
+            if "<" not in http_path or method not in methods:
+                continue
+            descriptor = getattr(handler, "DESCRIPTOR", None)
+            if descriptor is None:
+                continue
+            collidable = [(f.name, f.json_name) for f in descriptor.fields if f.name != f.json_name]
+            if collidable != pairs:
+                continue
+            concrete = _fill_path_params(http_path)
+            key = (concrete, method)
+            if key in seen:
+                continue
+            seen.add(key)
+            snake, camel = pairs[0]
+            yield concrete, method, snake, camel
+            break
+
+
+def _fill_path_params(path):
+    import re
+
+    return re.sub(r"<[^>]+>", "PLACEHOLDER", path)
+
+
+def _hook_response(path, method, body):
+    from unittest.mock import patch
+
+    from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+    with _json_ctx(path, method, body):
+        with (
+            patch("mlflow_oidc_auth.hooks.before_request.get_fastapi_username", return_value="test_user"),
+            patch("mlflow_oidc_auth.hooks.before_request.get_fastapi_admin_status", return_value=False),
+        ):
+            return before_request_hook()
+
+
+def test_hook_returns_400_on_dual_spelling():
+    """End-to-end: the hook rejects a dual-spelled body before authorization runs."""
+    resp = _hook_response(_UPDATE_EXPERIMENT, "POST", {"experiment_id": "own", "experimentId": "victim", "new_name": "x"})
+    assert resp is not None
+    assert resp.status_code == 400
+
+
+def test_hook_rejects_dual_spelling_even_for_admin():
+    """A dual-spelled body is malformed regardless of who sends it."""
+    from unittest.mock import patch
+
+    from mlflow_oidc_auth.hooks.before_request import before_request_hook
+
+    with _json_ctx(_UPDATE_EXPERIMENT, "POST", {"experiment_id": "own", "experimentId": "victim"}):
+        with (
+            patch("mlflow_oidc_auth.hooks.before_request.get_fastapi_username", return_value="admin"),
+            patch("mlflow_oidc_auth.hooks.before_request.get_fastapi_admin_status", return_value=True),
+        ):
+            resp = before_request_hook()
+    assert resp is not None
+    assert resp.status_code == 400
+
+
+def test_every_collidable_route_rejects_dual_spelling():
+    """Structural guard: every current AND future gated route auto-gets coverage.
+
+    A new proto endpoint added to MLflow, or a new field, is picked up by the
+    registry-derived maps, so no route can silently reintroduce the bypass.
+    """
+    routes = list(_iter_collidable_routes())
+    assert routes, "expected at least some collidable routes"
+    body_routes = [r for r in routes if r[1] != "GET"]
+    assert body_routes, "expected at least some collidable body routes"
+    for path, method, snake, camel in body_routes:
+        # Body-carrying routes must reject a dual-spelled field.
+        with _json_ctx(path, method, {snake: "own", camel: "victim"}):
+            assert find_dual_spelling_collision(request) == snake, f"guard missed dual-spelling on {method} {path}"
+    for path, method, snake, camel in routes:
+        if method != "GET":
+            continue
+        # GET routes read args by field.name (snake) only — not a dual-spelling vector.
+        with _json_ctx(path, method, query={snake: "own", camel: "victim"}):
+            assert find_dual_spelling_collision(request) is None, f"unexpected GET rejection on {path}"

--- a/mlflow_oidc_auth/tests/hooks/test_prompt_optimization_job.py
+++ b/mlflow_oidc_auth/tests/hooks/test_prompt_optimization_job.py
@@ -6,7 +6,11 @@ for Get/Delete/Cancel (which carry only job_id) and experiment-level validators
 for Create/Search (which carry experiment_id).
 """
 
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
+from flask import Flask, request
 from mlflow.protos.service_pb2 import (
     CreatePromptOptimizationJob,
     GetPromptOptimizationJob,
@@ -23,6 +27,9 @@ from mlflow_oidc_auth.validators import (
     validate_can_delete_prompt_optimization_job,
     validate_can_update_prompt_optimization_job,
 )
+from mlflow_oidc_auth.validators import prompt_optimization_job as job_validator
+
+app = Flask(__name__)
 
 
 class TestPromptOptimizationJobHandlers:
@@ -58,3 +65,55 @@ class TestPromptOptimizationJobHandlers:
             CancelPromptOptimizationJob,
         }
         assert expected.issubset(set(BEFORE_REQUEST_HANDLERS.keys()))
+
+
+class TestPromptOptimizationJobIdSource:
+    """job_id must be read from the URL path — the identifier MLflow dispatches on."""
+
+    def _perm(self, **flags):
+        perm = MagicMock()
+        for k, v in flags.items():
+            setattr(perm.permission, k, v)
+        return perm
+
+    def test_job_id_read_from_path_not_body(self):
+        """A body job_id must never override the path job_id (cross-source bypass)."""
+        job = MagicMock()
+        job.params = json.dumps({"experiment_id": "exp-victim"})
+        with app.test_request_context(
+            path="/api/3.0/mlflow/prompt-optimization/jobs/VICTIM_JOB",
+            method="DELETE",
+            json={"job_id": "OWN_JOB"},
+            content_type="application/json",
+        ):
+            request.view_args = {"job_id": "VICTIM_JOB"}
+            with (
+                patch.object(job_validator, "get_job", return_value=job) as mock_get_job,
+                patch.object(
+                    job_validator,
+                    "effective_experiment_permission",
+                    return_value=self._perm(can_delete=False),
+                ),
+            ):
+                assert validate_can_delete_prompt_optimization_job("attacker") is False
+                # Resolution used the path job, not the attacker's body job.
+                mock_get_job.assert_called_once_with("VICTIM_JOB")
+
+    def test_job_id_resolves_permission_from_path(self):
+        job = MagicMock()
+        job.params = json.dumps({"experiment_id": "exp1"})
+        with app.test_request_context(
+            path="/api/3.0/mlflow/prompt-optimization/jobs/JOB123",
+            method="GET",
+        ):
+            request.view_args = {"job_id": "JOB123"}
+            with (
+                patch.object(job_validator, "get_job", return_value=job) as mock_get_job,
+                patch.object(
+                    job_validator,
+                    "effective_experiment_permission",
+                    return_value=self._perm(can_read=True),
+                ),
+            ):
+                assert validate_can_read_prompt_optimization_job("user1") is True
+                mock_get_job.assert_called_once_with("JOB123")

--- a/mlflow_oidc_auth/tests/validators/test_experiment.py
+++ b/mlflow_oidc_auth/tests/validators/test_experiment.py
@@ -82,6 +82,22 @@ def test__get_permission_from_experiment_name_not_found():
         mock_get_permission.assert_called_once_with("MANAGE")
 
 
+def test_read_by_name_missing_experiment_proceeds_for_mlflow_404():
+    """Contract lock: read-by-name of a missing experiment must NOT be denied here.
+
+    MLflow returns 404 for a non-existent experiment and the UI depends on that
+    status. If this validator failed closed it would turn the 404 into a 403, so a
+    missing experiment must pass authorization and defer to MLflow. Do not "harden"
+    this into a denial.
+    """
+    with (
+        patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="does-not-exist"),
+        patch("mlflow_oidc_auth.validators.experiment._get_tracking_store") as mock_store,
+    ):
+        mock_store.return_value.get_experiment_by_name.return_value = None
+        assert experiment.validate_can_read_experiment_by_name("alice") is True
+
+
 def test__get_experiment_id_from_view_args_match():
     mock_request = MagicMock()
     mock_request.view_args = {"artifact_path": "123/some/path"}

--- a/mlflow_oidc_auth/tests/validators/test_gateway.py
+++ b/mlflow_oidc_auth/tests/validators/test_gateway.py
@@ -208,16 +208,22 @@ class TestGatewaySecretValidators:
             assert validate_can_read_gateway_secret("user1") is False
 
     def test_update_gateway_secret_allowed(self):
-        """Test UPDATE when user has permission."""
+        """Test UPDATE resolves the current secret via secret_id (not a request secret_name)."""
         with app.test_request_context(
             path="/api/3.0/mlflow/gateway/secrets/update",
             method="POST",
-            json={"secret_name": "my-secret"},
+            json={"secret_id": "sec-123"},
             content_type="application/json",
         ):
-            with patch(
-                "mlflow_oidc_auth.validators.gateway.can_update_gateway_secret",
-                return_value=True,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_secret_name_from_id",
+                    return_value="my-secret",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_update_gateway_secret",
+                    return_value=True,
+                ),
             ):
                 assert validate_can_update_gateway_secret("user1") is True
 
@@ -293,17 +299,27 @@ class TestGatewayModelDefinitionValidators:
             # Should return False (fail-closed) since name can't be extracted
             assert validate_can_read_gateway_model_definition("user1") is False
 
-    def test_update_gateway_model_definition_with_name(self):
-        """Test UPDATE when name is available and user has permission."""
+    def test_update_gateway_model_definition_with_id(self):
+        """Test UPDATE resolves the current model definition via model_definition_id.
+
+        The ``name`` field carries the *new* name on a rename, so the check must
+        resolve the current name from the id rather than trust a request ``name``.
+        """
         with app.test_request_context(
             path="/api/3.0/mlflow/gateway/model-definitions/update",
             method="POST",
-            json={"name": "my-model-def"},
+            json={"model_definition_id": "md-123", "name": "renamed"},
             content_type="application/json",
         ):
-            with patch(
-                "mlflow_oidc_auth.validators.gateway.can_update_gateway_model_definition",
-                return_value=True,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_model_definition_name_from_id",
+                    return_value="my-model-def",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_update_gateway_model_definition",
+                    return_value=True,
+                ),
             ):
                 assert validate_can_update_gateway_model_definition("user1") is True
 
@@ -312,12 +328,18 @@ class TestGatewayModelDefinitionValidators:
         with app.test_request_context(
             path="/api/3.0/mlflow/gateway/model-definitions/update",
             method="POST",
-            json={"name": "my-model-def"},
+            json={"model_definition_id": "md-123"},
             content_type="application/json",
         ):
-            with patch(
-                "mlflow_oidc_auth.validators.gateway.can_update_gateway_model_definition",
-                return_value=False,
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_model_definition_name_from_id",
+                    return_value="my-model-def",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_update_gateway_model_definition",
+                    return_value=False,
+                ),
             ):
                 assert validate_can_update_gateway_model_definition("user1") is False
 
@@ -375,3 +397,112 @@ class TestGatewayModelDefinitionValidators:
                     return_value=True,
                 ):
                     assert validate_can_read_gateway_model_definition("user1") is True
+
+
+class TestGatewayCrossFieldBypass:
+    """Regression tests for the #270 cross-field bypass.
+
+    A request that names one resource the caller owns (via ``name``) and another
+    the caller does NOT own (via ``*_id`` that MLflow actually dispatches on) must
+    be denied — the caller has to be authorized on every resource referenced.
+    """
+
+    @staticmethod
+    def _only_owns(owned):
+        def _check(name, _username):
+            return name == owned
+
+        return _check
+
+    def test_read_endpoint_denied_when_id_points_elsewhere(self):
+        with app.test_request_context(
+            path="/api/3.0/mlflow/gateway/endpoints/get",
+            method="GET",
+            query_string={"name": "own-endpoint", "endpoint_id": "victim-id"},
+        ):
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_endpoint_name_from_id",
+                    return_value="victim-endpoint",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_read_gateway_endpoint",
+                    side_effect=self._only_owns("own-endpoint"),
+                ),
+            ):
+                assert validate_can_read_gateway_endpoint("attacker") is False
+
+    def test_delete_endpoint_denied_when_id_points_elsewhere(self):
+        with app.test_request_context(
+            path="/api/3.0/mlflow/gateway/endpoints/delete",
+            method="POST",
+            json={"name": "own-endpoint", "endpoint_id": "victim-id"},
+            content_type="application/json",
+        ):
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_endpoint_name_from_id",
+                    return_value="victim-endpoint",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_manage_gateway_endpoint",
+                    side_effect=self._only_owns("own-endpoint"),
+                ),
+            ):
+                assert validate_can_delete_gateway_endpoint("attacker") is False
+
+    def test_delete_secret_denied_when_id_points_elsewhere(self):
+        with app.test_request_context(
+            path="/api/3.0/mlflow/gateway/secrets/delete",
+            method="POST",
+            json={"secret_name": "own-secret", "secret_id": "victim-id"},
+            content_type="application/json",
+        ):
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_secret_name_from_id",
+                    return_value="victim-secret",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_manage_gateway_secret",
+                    side_effect=self._only_owns("own-secret"),
+                ),
+            ):
+                assert validate_can_delete_gateway_secret("attacker") is False
+
+    def test_read_model_definition_denied_when_id_points_elsewhere(self):
+        with app.test_request_context(
+            path="/api/3.0/mlflow/gateway/model-definitions/get",
+            method="GET",
+            query_string={"name": "own-md", "model_definition_id": "victim-id"},
+        ):
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_model_definition_name_from_id",
+                    return_value="victim-md",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_read_gateway_model_definition",
+                    side_effect=self._only_owns("own-md"),
+                ),
+            ):
+                assert validate_can_read_gateway_model_definition("attacker") is False
+
+    def test_read_endpoint_allowed_when_both_name_the_same_resource(self):
+        """A legit request that names one resource two ways (name + its own id) still passes."""
+        with app.test_request_context(
+            path="/api/3.0/mlflow/gateway/endpoints/get",
+            method="GET",
+            query_string={"name": "own-endpoint", "endpoint_id": "own-id"},
+        ):
+            with (
+                patch(
+                    "mlflow_oidc_auth.validators.gateway._resolve_endpoint_name_from_id",
+                    return_value="own-endpoint",
+                ),
+                patch(
+                    "mlflow_oidc_auth.validators.gateway.can_read_gateway_endpoint",
+                    side_effect=self._only_owns("own-endpoint"),
+                ),
+            ):
+                assert validate_can_read_gateway_endpoint("owner") is True

--- a/mlflow_oidc_auth/tests/validators/test_prompt_optimization_job.py
+++ b/mlflow_oidc_auth/tests/validators/test_prompt_optimization_job.py
@@ -32,10 +32,10 @@ def _make_job_entity(experiment_id: str):
 
 
 def _patch_job_resolution(experiment_id: str = "exp-123", **perm_kwargs):
-    """Context managers that patch get_request_param, get_job, and effective_experiment_permission."""
+    """Context managers that patch get_url_param, get_job, and effective_experiment_permission."""
     return (
         patch(
-            "mlflow_oidc_auth.validators.prompt_optimization_job.get_request_param",
+            "mlflow_oidc_auth.validators.prompt_optimization_job.get_url_param",
             return_value="job-456",
         ),
         patch(
@@ -68,7 +68,7 @@ class TestGetPermissionFromPromptOptimizationJobId:
         job.params = json.dumps({"experiment_id": "exp-999", "other_param": "value"})
         with (
             patch(
-                "mlflow_oidc_auth.validators.prompt_optimization_job.get_request_param",
+                "mlflow_oidc_auth.validators.prompt_optimization_job.get_url_param",
                 return_value="job-1",
             ),
             patch(

--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -22,7 +22,10 @@ def _get_permission_from_experiment_name(username: str) -> Permission:
     experiment_name = get_request_param("experiment_name")
     store_exp = _get_tracking_store().get_experiment_by_name(experiment_name)
     if store_exp is None:
-        # experiment is not exist, need return all permissions
+        # The experiment does not exist. This helper only gates read-by-name, so we
+        # let the request proceed and MLflow return its own 404 (the UI relies on 404,
+        # not 403, for a missing experiment). Do NOT reuse this helper for a mutating
+        # or creation check — granting MANAGE on a non-existent name would fail open.
         return get_permission("MANAGE")
     return effective_experiment_permission(store_exp.experiment_id, username).permission
 

--- a/mlflow_oidc_auth/validators/gateway.py
+++ b/mlflow_oidc_auth/validators/gateway.py
@@ -33,13 +33,14 @@ _logger = get_logger()
 def validate_can_read_gateway_endpoint(username: str) -> bool:
     """Validate READ permission on a gateway endpoint.
 
-    ``GetGatewayEndpoint`` provides ``name`` (or ``endpoint_id``).
-    We check by name when available, falling back to ID resolution.
+    ``GetGatewayEndpoint`` accepts both ``name`` and ``endpoint_id``, and MLflow
+    passes both to the store, so a request may reference two different resources
+    (issue #270 cross-field bypass). We require READ on *every* resource named.
     """
-    name = _get_gateway_endpoint_name()
-    if not name:
+    names = _all_gateway_endpoint_names()
+    if not names:
         return False
-    return can_read_gateway_endpoint(name, username)
+    return all(can_read_gateway_endpoint(name, username) for name in names)
 
 
 def validate_can_update_gateway_endpoint(username: str) -> bool:
@@ -59,21 +60,22 @@ def validate_can_update_gateway_endpoint(username: str) -> bool:
 def validate_can_delete_gateway_endpoint(username: str) -> bool:
     """Validate MANAGE permission for deleting a gateway endpoint.
 
-    The name is already stashed in ``flask.g`` by
-    ``_stash_gateway_context`` (which runs for all users).
+    ``DeleteGatewayEndpoint`` identifies the resource by ``endpoint_id`` only, so
+    any ``name`` in the body is ignored by MLflow. We still require MANAGE on every
+    resource the request references (issue #270 cross-field bypass).
     """
-    name = _get_gateway_endpoint_name()
-    if not name:
+    names = _all_gateway_endpoint_names()
+    if not names:
         return False
-    return can_manage_gateway_endpoint(name, username)
+    return all(can_manage_gateway_endpoint(name, username) for name in names)
 
 
 def validate_can_manage_gateway_endpoint_validator(username: str) -> bool:
     """Validate MANAGE permission on a gateway endpoint."""
-    name = _get_gateway_endpoint_name()
-    if not name:
+    names = _all_gateway_endpoint_names()
+    if not names:
         return False
-    return can_manage_gateway_endpoint(name, username)
+    return all(can_manage_gateway_endpoint(name, username) for name in names)
 
 
 # ---------------------------------------------------------------------------
@@ -84,17 +86,23 @@ def validate_can_manage_gateway_endpoint_validator(username: str) -> bool:
 def validate_can_read_gateway_secret(username: str) -> bool:
     """Validate READ permission on a gateway secret.
 
-    ``GetGatewaySecretInfo`` provides ``secret_name`` (or ``secret_id``).
+    ``GetGatewaySecretInfo`` accepts both ``secret_name`` and ``secret_id``; we
+    require READ on every resource referenced (issue #270 cross-field bypass).
     """
-    name = _get_gateway_secret_name()
-    if not name:
+    names = _all_gateway_secret_names()
+    if not names:
         return False
-    return can_read_gateway_secret(name, username)
+    return all(can_read_gateway_secret(name, username) for name in names)
 
 
 def validate_can_update_gateway_secret(username: str) -> bool:
-    """Validate UPDATE permission on a gateway secret."""
-    name = _get_gateway_secret_name()
+    """Validate UPDATE permission on a gateway secret.
+
+    ``UpdateGatewaySecret`` identifies the resource by ``secret_id`` only, so we
+    resolve the current name from the id rather than trusting a request ``secret_name``
+    (issue #270 cross-field bypass).
+    """
+    name = _get_gateway_secret_name_for_update()
     if not name:
         return False
     return can_update_gateway_secret(name, username)
@@ -103,13 +111,13 @@ def validate_can_update_gateway_secret(username: str) -> bool:
 def validate_can_delete_gateway_secret(username: str) -> bool:
     """Validate MANAGE permission for deleting a gateway secret.
 
-    The name is already stashed in ``flask.g`` by
-    ``_stash_gateway_context`` (which runs for all users).
+    ``DeleteGatewaySecret`` identifies the resource by ``secret_id`` only; we still
+    require MANAGE on every resource the request references (issue #270).
     """
-    name = _get_gateway_secret_name()
-    if not name:
+    names = _all_gateway_secret_names()
+    if not names:
         return False
-    return can_manage_gateway_secret(name, username)
+    return all(can_manage_gateway_secret(name, username) for name in names)
 
 
 # ---------------------------------------------------------------------------
@@ -120,20 +128,25 @@ def validate_can_delete_gateway_secret(username: str) -> bool:
 def validate_can_read_gateway_model_definition(username: str) -> bool:
     """Validate READ permission on a gateway model definition.
 
-    ``GetGatewayModelDefinition`` only provides ``model_definition_id``,
-    so we fall back to ID resolution via the tracking store. If
-    resolution fails, we deny access (fail-closed).
+    ``GetGatewayModelDefinition`` identifies the resource by ``model_definition_id``,
+    so any request ``name`` is ignored by MLflow. We require READ on every resource
+    the request references (issue #270 cross-field bypass). Fail-closed on no match.
     """
-    name = _get_gateway_model_definition_name()
-    if not name:
+    names = _all_gateway_model_definition_names()
+    if not names:
         _logger.warning("Cannot resolve gateway model definition name — denying access (fail-closed)")
         return False
-    return can_read_gateway_model_definition(name, username)
+    return all(can_read_gateway_model_definition(name, username) for name in names)
 
 
 def validate_can_update_gateway_model_definition(username: str) -> bool:
-    """Validate UPDATE permission on a gateway model definition."""
-    name = _get_gateway_model_definition_name()
+    """Validate UPDATE permission on a gateway model definition.
+
+    ``UpdateGatewayModelDefinition`` identifies the resource by ``model_definition_id``
+    (the ``name`` field carries the *new* name on a rename), so we resolve the current
+    name from the id rather than trusting a request ``name`` (issue #270).
+    """
+    name = _get_gateway_model_definition_name_for_update()
     if not name:
         _logger.warning("Cannot resolve gateway model definition name — denying access (fail-closed)")
         return False
@@ -143,14 +156,14 @@ def validate_can_update_gateway_model_definition(username: str) -> bool:
 def validate_can_delete_gateway_model_definition(username: str) -> bool:
     """Validate MANAGE permission for deleting a gateway model definition.
 
-    The name is already stashed in ``flask.g`` by
-    ``_stash_gateway_context`` (which runs for all users).
+    ``DeleteGatewayModelDefinition`` identifies the resource by ``model_definition_id``;
+    we require MANAGE on every resource the request references (issue #270).
     """
-    name = _get_gateway_model_definition_name()
-    if not name:
+    names = _all_gateway_model_definition_names()
+    if not names:
         _logger.warning("Cannot resolve gateway model definition name — denying access (fail-closed)")
         return False
-    return can_manage_gateway_model_definition(name, username)
+    return all(can_manage_gateway_model_definition(name, username) for name in names)
 
 
 # ---------------------------------------------------------------------------
@@ -194,67 +207,97 @@ def _resolve_model_definition_name_from_id(model_definition_id: str) -> str | No
         return None
 
 
-def _get_gateway_endpoint_name() -> str | None:
-    """Extract gateway endpoint name from the request.
-
-    Tries ``name`` first, then falls back to resolving ``endpoint_id``
-    via the tracking store.
-    """
+def _safe_param(name: str) -> str | None:
+    """Read a request parameter without raising when it is absent."""
     try:
-        return get_request_param("name")
-    except Exception:
-        pass
-    try:
-        endpoint_id = get_request_param("endpoint_id")
-        return _resolve_endpoint_name_from_id(endpoint_id)
+        value = get_request_param(name)
     except Exception:
         return None
+    return value or None
+
+
+def _all_gateway_endpoint_names() -> list[str]:
+    """Every endpoint name a read/delete request references.
+
+    ``GetGatewayEndpoint``/``DeleteGatewayEndpoint`` may carry ``name`` and/or
+    ``endpoint_id``, and MLflow resolves whichever the store prefers.  To close the
+    cross-field bypass (issue #270) we return *all* distinct resources referenced —
+    the ``name`` as given and the name resolved from ``endpoint_id`` — so the caller
+    must be authorized on every one.
+    """
+    names: list[str] = []
+    direct = _safe_param("name")
+    if direct:
+        names.append(direct)
+    endpoint_id = _safe_param("endpoint_id")
+    if endpoint_id:
+        resolved = _resolve_endpoint_name_from_id(endpoint_id)
+        if resolved:
+            names.append(resolved)
+    # De-duplicate while preserving order (a legit request naming one resource two ways).
+    return list(dict.fromkeys(names))
 
 
 def _get_gateway_endpoint_name_for_update() -> str | None:
-    """Extract the *current* gateway endpoint name for update requests.
+    """Resolve the *current* endpoint name for update requests.
 
-    Unlike ``_get_gateway_endpoint_name``, this deliberately skips the
-    ``name`` request parameter because in ``UpdateGatewayEndpoint`` the
-    ``name`` field holds the *new* name.  We resolve the current name
-    via ``endpoint_id`` instead.
+    ``UpdateGatewayEndpoint`` identifies the resource by ``endpoint_id`` (the ``name``
+    field holds the *new* name on a rename), so we resolve the current name via the id.
     """
-    try:
-        endpoint_id = get_request_param("endpoint_id")
-        return _resolve_endpoint_name_from_id(endpoint_id)
-    except Exception:
+    endpoint_id = _safe_param("endpoint_id")
+    if not endpoint_id:
         return None
+    return _resolve_endpoint_name_from_id(endpoint_id)
 
 
-def _get_gateway_secret_name() -> str | None:
-    """Extract gateway secret name from the request.
+def _all_gateway_secret_names() -> list[str]:
+    """Every secret name a read/delete request references (see ``_all_gateway_endpoint_names``)."""
+    names: list[str] = []
+    direct = _safe_param("secret_name")
+    if direct:
+        names.append(direct)
+    secret_id = _safe_param("secret_id")
+    if secret_id:
+        resolved = _resolve_secret_name_from_id(secret_id)
+        if resolved:
+            names.append(resolved)
+    return list(dict.fromkeys(names))
 
-    Tries ``secret_name`` first, then falls back to resolving ``secret_id``
-    via the tracking store.
+
+def _get_gateway_secret_name_for_update() -> str | None:
+    """Resolve the current secret name for update requests.
+
+    ``UpdateGatewaySecret`` identifies the resource by ``secret_id`` only, so we resolve
+    the current name via the id rather than trusting a request ``secret_name``.
     """
-    try:
-        return get_request_param("secret_name")
-    except Exception:
-        pass
-    try:
-        secret_id = get_request_param("secret_id")
-        return _resolve_secret_name_from_id(secret_id)
-    except Exception:
+    secret_id = _safe_param("secret_id")
+    if not secret_id:
         return None
+    return _resolve_secret_name_from_id(secret_id)
 
 
-def _get_gateway_model_definition_name() -> str | None:
-    """Extract gateway model definition name from the request.
+def _all_gateway_model_definition_names() -> list[str]:
+    """Every model-definition name a read/delete request references (see ``_all_gateway_endpoint_names``)."""
+    names: list[str] = []
+    direct = _safe_param("name")
+    if direct:
+        names.append(direct)
+    model_definition_id = _safe_param("model_definition_id")
+    if model_definition_id:
+        resolved = _resolve_model_definition_name_from_id(model_definition_id)
+        if resolved:
+            names.append(resolved)
+    return list(dict.fromkeys(names))
 
-    Tries ``name`` first, then falls back to resolving ``model_definition_id``
-    via the tracking store.
+
+def _get_gateway_model_definition_name_for_update() -> str | None:
+    """Resolve the current model-definition name for update requests.
+
+    ``UpdateGatewayModelDefinition`` identifies the resource by ``model_definition_id``
+    (the ``name`` field holds the *new* name on a rename), so we resolve the current
+    name via the id rather than trusting a request ``name``.
     """
-    try:
-        return get_request_param("name")
-    except Exception:
-        pass
-    try:
-        model_definition_id = get_request_param("model_definition_id")
-        return _resolve_model_definition_name_from_id(model_definition_id)
-    except Exception:
+    model_definition_id = _safe_param("model_definition_id")
+    if not model_definition_id:
         return None
+    return _resolve_model_definition_name_from_id(model_definition_id)

--- a/mlflow_oidc_auth/validators/prompt_optimization_job.py
+++ b/mlflow_oidc_auth/validators/prompt_optimization_job.py
@@ -11,7 +11,7 @@ from mlflow.server.jobs import get_job
 from mlflow_oidc_auth.permissions import Permission
 from mlflow_oidc_auth.utils import (
     effective_experiment_permission,
-    get_request_param,
+    get_url_param,
 )
 
 
@@ -28,7 +28,11 @@ def _get_permission_from_prompt_optimization_job_id(username: str) -> Permission
     Returns:
         The effective Permission for the job's parent experiment.
     """
-    job_id = get_request_param("job_id")
+    # job_id is a URL path parameter (/prompt-optimization/jobs/<job_id>), which is
+    # the identifier MLflow itself dispatches on. Reading it from the query/body
+    # instead would let a request authorize one job (in the body) while MLflow acts
+    # on the job named in the path (issue #270 cross-source bypass).
+    job_id = get_url_param("job_id")
     job_entity = get_job(job_id)
     params = json.loads(job_entity.params)
     experiment_id = params.get("experiment_id")


### PR DESCRIPTION
## Summary

Fixes the systemic proto-JSON dual-spelling authorization bypass (#270), plus three related same-resource identifier bugs that the systemic guard cannot see.

MLflow parses request bodies as proto-JSON. `protobuf.ParseDict` accepts a field under **both** its snake_case name and its camelCase `json_name`, and when both appear it silently keeps the **last** one in JSON order — caller-controlled. Any authorization check that reads a single spelling can be bypassed:

```json
{"experiment_id": "attacker_own", "experimentId": "victim"}
```

authorizes `attacker_own` (owned) while MLflow operates on `victim` — across cross-tenant **READ** and **WRITE/DELETE**.

### Research grounding
Verified empirically against the installed MLflow 3.14:
- `parse_dict` never rejects dual-spelling — it silently last-wins; it also accepts camelCase-only.
- MLflow does **not** normalize camelCase server-side.
- Real clients send snake_case (Python client uses `preserving_proto_field_name=True`; the browser UI sends snake request bodies). **No legitimate client emits one field under two spellings**, so rejecting such a request with 400 cannot break a real client.

## What's in this PR

**1. Central dual-spelling guard** (`hooks/dual_spelling_guard.py`)
Rejects any request that carries one proto field under two spellings with **400**, before any authorization decision. The `(path, method) → proto class` map is derived from MLflow's own service registry via `get_endpoints`, so it covers **every** proto endpoint MLflow serves (current *and* future) with no manual maintenance. The body is read through MLflow's own `_get_normalized_request_json`, so the guard inspects exactly the dict MLflow will parse (force-parsed, double-encoding aware, no `Content-Type` evasion). Fails loudly at import if the derived map is empty, rather than silently degrading to a no-op.

**1b. GET handling** — MLflow builds the proto from `request.args` (snake-keyed, so camelCase params are never read) **only when the query string is non-empty**; with an empty query string it proto-parses the **body**. So:
- a GET with query args is left alone (MLflow ignores the body);
- a GET with an empty query string has its body checked exactly like a POST;
- **any** GET carrying a proto-parsable body is rejected — validators that read `request.args` otherwise find nothing and authorize *vacuously*, with no store lookup, while MLflow serves whatever the body named. Scoped to proto-backed routes, so args-only routes still accept a stray body.

Proto-parsing handlers MLflow registers with `@app.route` (notably `experiments/search-datasets`, whose live path never appears in `get_endpoints` — only malformed twins do) are bound by enumerating the real Flask routing table. A coverage test asserts every gated route is guard-covered or explicitly exempt.

**2. Gateway cross-field fix** (`validators/gateway.py`)
The gateway read/delete validators preferred the `name`/`secret_name` field, but MLflow identifies these resources by `*_id`. An attacker could send `name=<owned>` alongside `*_id=<victim>`. Read/delete now require permission on **every** distinct resource referenced (name-as-given **and** id-resolved name). Update (rename) resolves the current name from the required id only.

**3. Prompt-optimization job source fix** (`validators/prompt_optimization_job.py`)
`job_id` is a URL **path** parameter, but the validator read it from the query/body. Switched to `get_url_param` so the check and MLflow agree on the resource.

**4. Experiment read-by-name 404 lock** (`validators/experiment.py`)
No behavior change — clarifies that a read-by-name of a missing experiment deliberately passes so MLflow returns its own **404** (the UI depends on 404, not 403), and adds a regression test so a future "fail-closed" change can't silently turn it into a 403.

## Relationship to #269
#269's per-validator union reads remain as belt-and-suspenders: the guard closes the attack, and the union additionally handles a hypothetical camelCase-only legitimate client (which the guard passes through). No changes to #269 here.

## Tests
- **Structural guard test** derives every collidable route from MLflow's registry and asserts each body route rejects a dual-spelled field — new proto endpoints/fields are auto-covered and cannot silently reintroduce the bypass.
- Per-vector tests (body dual-spelling → 400; snake-only and camel-only clean; GET query not a vector; admins also get 400).
- Gateway cross-field bypass regression tests (name+id mismatch → denied; same-resource-two-ways → allowed).
- Job cross-source test (body `job_id` never overrides the path).
- Experiment 404 contract lock.

All touched suites green (378 passed locally).

### Post-review hardening
A 12-agent adversarial review (each finding independently refutation-tested) raised 34 findings; 11 survived. They collapsed to one critical root cause — the guard originally exempted **every** GET on the mistaken premise that MLflow always builds GET protos from query args — plus the missing search-datasets route. Both are fixed above, with regression tests and a non-vacuous coverage assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
