### PR TITLE
test(auth): prove DEFAULT_MLFLOW_PERMISSION gates resource creation (#202)

### DIFF
--- a/mlflow_oidc_auth/tests/test_creation_authz.py
+++ b/mlflow_oidc_auth/tests/test_creation_authz.py
@@ -1,11 +1,18 @@
 """Tests for RESTRICT_RESOURCE_CREATION authorization on experiment/model creation (#247, #202)."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.models import PermissionResult
 from mlflow_oidc_auth.permissions import EDIT, MANAGE, NO_PERMISSIONS, READ
+
+
+def _regex(pattern, permission, priority=1):
+    """A stand-in for a stored regex-permission row (has .regex/.permission/.priority)."""
+    return SimpleNamespace(regex=pattern, permission=permission, priority=priority)
 
 
 class TestCreateValidatorsAreNoOpWhenDisabled:
@@ -128,6 +135,97 @@ class TestEffectiveNewPermissionWorkspaceFallback:
                 result = effective_new_experiment_permission("new-exp", "user1")
         assert result.kind == "fallback"
         assert result.permission == MANAGE
+
+
+class TestDefaultPermissionActuallyGatesCreation:
+    """#202 regression: DEFAULT_MLFLOW_PERMISSION must actually take effect for creation.
+
+    The tests above mock the permission resolver, so they never exercise the real
+    default fallback (permissions.py ``get_permission_from_store_or_default``). These
+    drive the whole chain with only the store and config stubbed, so a regression that
+    stops honoring DEFAULT_MLFLOW_PERMISSION on the create path would fail here.
+    """
+
+    def _drive(self, name, *, default, exp_regexes=(), group_regexes=(), group_ids=()):
+        """Run the real effective_new_experiment_permission with a stubbed store/config."""
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        with (
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", default),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_experiment_regex_permissions.return_value = list(exp_regexes)
+            store.get_groups_ids_for_user.return_value = list(group_ids)
+            store.list_group_experiment_regex_permissions_for_groups_ids.return_value = list(group_regexes)
+            return perms.effective_new_experiment_permission(name, "dev-b-1@example.com")
+
+    def test_no_match_with_no_permissions_default_denies(self):
+        """The literal #202 bug: with NO_PERMISSIONS default and no matching rule, creation is denied."""
+        result = self._drive("anything", default="NO_PERMISSIONS")
+        assert result.kind == "fallback"
+        assert result.permission == NO_PERMISSIONS
+        assert result.permission.can_update is False
+
+    def test_no_match_with_permissive_default_allows(self):
+        """Legacy behavior stays available: a permissive default still authorizes creation."""
+        result = self._drive("anything", default="EDIT")
+        assert result.permission == EDIT
+        assert result.permission.can_update is True
+
+    def test_reporter_scenario_group_regex_only_grants_matching_prefix(self):
+        """AndreGodinho7's exact case: group project-b (regex ^project-b/.*, MANAGE), default NO_PERMISSIONS.
+
+        The user may create under their own prefix but not an unprefixed name nor another
+        tenant's prefix — which is precisely what the reporter said did NOT work.
+        """
+        group_regexes = [_regex(r"^project-b/.*", "MANAGE")]
+        kw = dict(default="NO_PERMISSIONS", group_regexes=group_regexes, group_ids=["grp-b"])
+
+        own = self._drive("project-b/exp", **kw)
+        assert own.permission == MANAGE and own.permission.can_update is True
+
+        other = self._drive("project-a/exp", **kw)
+        assert other.permission == NO_PERMISSIONS and other.permission.can_update is False
+
+        unprefixed = self._drive("exp", **kw)
+        assert unprefixed.permission == NO_PERMISSIONS and unprefixed.permission.can_update is False
+
+    def test_validator_denies_creation_end_to_end_with_no_permissions_default(self):
+        """Full path: flag on + NO_PERMISSIONS default + no rule -> validate_can_create_experiment False."""
+        from mlflow_oidc_auth.utils import permissions as perms
+        from mlflow_oidc_auth.validators.experiment import validate_can_create_experiment
+
+        with (
+            patch.object(config, "RESTRICT_RESOURCE_CREATION", True),
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", "NO_PERMISSIONS"),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="unowned-exp"),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_experiment_regex_permissions.return_value = []
+            store.get_groups_ids_for_user.return_value = []
+            store.list_group_experiment_regex_permissions_for_groups_ids.return_value = []
+            assert validate_can_create_experiment("dev-b-1@example.com") is False
+
+    def test_registered_model_default_no_permissions_denies_end_to_end(self):
+        """Same guarantee for CreateRegisteredModel through the real resolver."""
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        with (
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", "NO_PERMISSIONS"),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_registered_model_regex_permissions.return_value = []
+            store.get_groups_ids_for_user.return_value = []
+            store.list_group_registered_model_regex_permissions_for_groups_ids.return_value = []
+            result = perms.effective_new_registered_model_permission("unowned-model", "dev-b-1@example.com")
+        assert result.permission == NO_PERMISSIONS
+        assert result.permission.can_update is False
 
 
 class TestCreateHandlersBound:


### PR DESCRIPTION
## Summary

Revalidation + regression coverage for #202 (`DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS` did not stop experiment/model **creation**).

**The bug is already fixed on `main`** — it landed with #247: `CreateExperiment` and `CreateRegisteredModel` now have before-request validators (before_request.py), opt-in via `RESTRICT_RESOURCE_CREATION`. When enabled, creation requires `EDIT+` on the new resource name, resolved from name regex / group-regex with the global `DEFAULT_MLFLOW_PERMISSION` as the fallback. So `RESTRICT_RESOURCE_CREATION=true` + `DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS` denies creation unless a pattern grants it — exactly what the issue asked for.

**The gap this PR closes:** the existing `test_creation_authz.py` tests all *mock* the permission resolver, so none actually exercise the `DEFAULT_MLFLOW_PERMISSION` fallback that the issue is about. This adds end-to-end tests that drive the real `effective_new_*_permission` chain with only the store and config stubbed:

- no matching rule + `NO_PERMISSIONS` default → creation **denied** (the literal bug)
- no matching rule + permissive default → still **allowed** (legacy behavior preserved)
- **the reporter's exact scenario** (@AndreGodinho7): group regex `^project-b/.*` MANAGE grants creation only under that prefix, denying an unprefixed name and another tenant's prefix
- the full validator path (flag on + `NO_PERMISSIONS` default) denies, for both experiment and registered model

Test-only change (no production code touched). All 22 tests in the file pass.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)