### PR TITLE
test(auth): cover user-assigned regex granting resource creation (#195)

### DIFF
--- a/mlflow_oidc_auth/tests/test_creation_authz.py
+++ b/mlflow_oidc_auth/tests/test_creation_authz.py
@@ -228,6 +228,73 @@ class TestDefaultPermissionActuallyGatesCreation:
         assert result.permission.can_update is False
 
 
+class TestUserAssignedRegexGrantsCreation:
+    """#195 governance path: a name-regex assigned directly to a USER grants creation.
+
+    The existing coverage exercises group-regex and the default fallback; none proves
+    that a pattern assigned to the user themselves lets them create matching resources
+    while still denying names outside the pattern. That is the core #195 use case
+    (an admin grants a user/team a creation scope via a name pattern).
+    """
+
+    def test_user_experiment_regex_grants_only_matching_names(self):
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        user_regexes = [_regex(r"^alice/.*", "EDIT")]
+        with (
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", "NO_PERMISSIONS"),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_experiment_regex_permissions.return_value = user_regexes
+            store.get_groups_ids_for_user.return_value = []
+            store.list_group_experiment_regex_permissions_for_groups_ids.return_value = []
+
+            allowed = perms.effective_new_experiment_permission("alice/exp-1", "alice")
+            denied = perms.effective_new_experiment_permission("bob/exp-1", "alice")
+
+        assert allowed.kind == "regex" and allowed.permission == EDIT and allowed.permission.can_update is True
+        assert denied.kind == "fallback" and denied.permission == NO_PERMISSIONS and denied.permission.can_update is False
+
+    def test_validator_allows_creation_for_user_regex_match_end_to_end(self):
+        """Full path with the flag on: a user whose regex matches the new name may create it."""
+        from mlflow_oidc_auth.validators.experiment import validate_can_create_experiment
+
+        with (
+            patch.object(config, "RESTRICT_RESOURCE_CREATION", True),
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", "NO_PERMISSIONS"),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.validators.experiment.get_request_param", return_value="alice/exp-1"),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_experiment_regex_permissions.return_value = [_regex(r"^alice/.*", "EDIT")]
+            store.get_groups_ids_for_user.return_value = []
+            store.list_group_experiment_regex_permissions_for_groups_ids.return_value = []
+
+            assert validate_can_create_experiment("alice") is True
+
+    def test_user_model_regex_grants_only_matching_names(self):
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        with (
+            patch.object(config, "DEFAULT_MLFLOW_PERMISSION", "NO_PERMISSIONS"),
+            patch.object(config, "MLFLOW_ENABLE_WORKSPACES", False),
+            patch.object(config, "PERMISSION_SOURCE_ORDER", ["regex", "group-regex"]),
+            patch("mlflow_oidc_auth.utils.permissions.store") as store,
+        ):
+            store.list_registered_model_regex_permissions.return_value = [_regex(r"^team-ml/.*", "MANAGE")]
+            store.get_groups_ids_for_user.return_value = []
+            store.list_group_registered_model_regex_permissions_for_groups_ids.return_value = []
+
+            allowed = perms.effective_new_registered_model_permission("team-ml/model-a", "alice")
+            denied = perms.effective_new_registered_model_permission("other/model-a", "alice")
+
+        assert allowed.permission == MANAGE and allowed.permission.can_update is True
+        assert denied.permission == NO_PERMISSIONS and denied.permission.can_update is False
+
+
 class TestCreateHandlersBound:
     """CreateExperiment/CreateRegisteredModel must be wired into the before-request handlers (#202)."""
 


### PR DESCRIPTION
## Summary

Validation + regression coverage for #195 (*configurable permissions to restrict experiment/model creation*).

**The feature is already implemented on `main`** — it shipped with #247 as the opt-in `RESTRICT_RESOURCE_CREATION` flag. When enabled, `CreateExperiment`/`CreateRegisteredModel` require `EDIT+` on the new resource name, resolved via regex / group-regex with `DEFAULT_MLFLOW_PERMISSION` as fallback, returning 403 otherwise.

The maintainers chose a lighter design than #195's *Implementation Details* section proposed — reusing the existing permission machinery instead of adding new permission levels (`CREATE_EXPERIMENT`/`CREATE_MODEL`), DB columns, or dedicated API endpoints (see @nitaibezerra's note in the issue). #195's **problem statement and use cases** (enterprise governance, multi-tenant, compliance) are fully satisfied.

**Gap this closes:** existing tests cover group-regex and the default fallback, but none prove the core governance path where a name-regex assigned to the **user** grants creation. Added, through the real resolver and the validator:

- user experiment regex `^alice/.*` EDIT → grants `alice/exp-1` (`kind=regex`), denies `bob/exp-1` (falls back to `NO_PERMISSIONS`)
- full validator path allows creation for a user-regex match with the flag on
- same for registered models (`^team-ml/.*` MANAGE)

Test-only change. All 25 tests in the file pass.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)