### PR TITLE
fix(oauth): send OIDC scopes space-delimited per RFC 6749 (#238)

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -98,7 +98,9 @@ class AppConfig:
         # OIDC_REDIRECT_URI: If not set, will be calculated dynamically based on request headers
         # This enables automatic proxy path detection for OIDC callbacks
         self.OIDC_REDIRECT_URI = config_manager.get("OIDC_REDIRECT_URI")
-        self.OIDC_SCOPE = config_manager.get("OIDC_SCOPE", "openid,email,profile")
+        # Space-delimited per OAuth 2.0 (RFC 6749 §3.3). Comma-separated values are also
+        # accepted for backward compatibility and normalized in oauth._build_scope (#238).
+        self.OIDC_SCOPE = config_manager.get("OIDC_SCOPE", "openid email profile")
         self.OIDC_PROVIDER_DISPLAY_NAME = config_manager.get("OIDC_PROVIDER_DISPLAY_NAME", "Login with OIDC")
         self.OIDC_GROUPS_ATTRIBUTE = config_manager.get("OIDC_GROUPS_ATTRIBUTE", "groups")
         self.OIDC_AUDIENCE = config_manager.get("OIDC_AUDIENCE")

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -31,23 +31,23 @@ def _has_required_config() -> bool:
 
 
 def _build_scope() -> str:
-    """Build the OIDC scope string, adding ``offline_access`` if refresh is enabled.
+    """Build the space-delimited OIDC scope string for the authorize/token requests.
 
-    Authlib accepts either comma- or space-separated scopes. We normalise to the
-    same separator the user configured to keep the rendered authorize URL
-    predictable, while making sure ``offline_access`` is present when the
-    refresh-token flow is enabled.
+    OAuth 2.0 (RFC 6749 §3.3) requires the ``scope`` parameter to be space-delimited.
+    We accept the configured value in comma- or space-separated form (or a mix) and
+    always emit space-delimited scopes, so strict providers like Microsoft Entra ID do
+    not reject the request (issue #238). ``offline_access`` is appended when the
+    refresh-token flow is enabled. Duplicate scopes are collapsed, order preserved.
     """
 
     raw = config.OIDC_SCOPE or ""
-    if not config.OIDC_USE_REFRESH_TOKEN:
-        return raw
-
-    separator = "," if "," in raw else " "
-    scopes = [s.strip() for s in raw.replace(",", " ").split() if s.strip()]
-    if "offline_access" not in scopes:
+    scopes = [s for s in raw.replace(",", " ").split() if s]
+    if config.OIDC_USE_REFRESH_TOKEN and "offline_access" not in scopes:
         scopes.append("offline_access")
-    return separator.join(scopes)
+
+    seen: set[str] = set()
+    unique = [s for s in scopes if not (s in seen or seen.add(s))]
+    return " ".join(unique)
 
 
 def ensure_oidc_client_registered() -> bool:

--- a/mlflow_oidc_auth/tests/test_config.py
+++ b/mlflow_oidc_auth/tests/test_config.py
@@ -125,7 +125,7 @@ class TestAppConfig(unittest.TestCase):
         self.assertEqual(config.OIDC_PROVIDER_DISPLAY_NAME, "Login with OIDC")
         self.assertIsNone(config.OIDC_DISCOVERY_URL)
         self.assertEqual(config.OIDC_GROUPS_ATTRIBUTE, "groups")
-        self.assertEqual(config.OIDC_SCOPE, "openid,email,profile")
+        self.assertEqual(config.OIDC_SCOPE, "openid email profile")
         self.assertIsNone(config.OIDC_GROUP_DETECTION_PLUGIN)
         self.assertIsNone(config.OIDC_REDIRECT_URI)
         self.assertIsNone(config.OIDC_CLIENT_ID)

--- a/mlflow_oidc_auth/tests/test_oauth.py
+++ b/mlflow_oidc_auth/tests/test_oauth.py
@@ -407,25 +407,44 @@ class TestOAuthSecurity(unittest.TestCase):
 
 
 class TestBuildScope(unittest.TestCase):
-    """Test the ``_build_scope`` helper that adds ``offline_access`` when refresh is enabled."""
+    """``_build_scope`` must always emit space-delimited scopes (RFC 6749 §3.3, issue #238)."""
 
-    def test_no_offline_access_when_refresh_disabled(self):
+    def test_comma_scope_is_normalized_to_spaces_when_refresh_disabled(self):
+        """The #238 bug: a comma-separated scope must go out space-delimited, not verbatim."""
         from mlflow_oidc_auth import oauth as oauth_mod
 
         with (
             patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
             patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,email,profile", create=True),
         ):
-            self.assertEqual(oauth_mod._build_scope(), "openid,email,profile")
+            self.assertEqual(oauth_mod._build_scope(), "openid email profile")
 
-    def test_appends_offline_access_to_csv_scope(self):
+    def test_space_scope_is_preserved_when_refresh_disabled(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid email profile", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid email profile")
+
+    def test_mixed_and_padded_separators_are_normalized(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", " openid, email profile ,groups ", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid email profile groups")
+
+    def test_appends_offline_access_space_delimited_from_csv_scope(self):
         from mlflow_oidc_auth import oauth as oauth_mod
 
         with (
             patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", True, create=True),
             patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,email,profile", create=True),
         ):
-            self.assertEqual(oauth_mod._build_scope(), "openid,email,profile,offline_access")
+            self.assertEqual(oauth_mod._build_scope(), "openid email profile offline_access")
 
     def test_appends_offline_access_to_space_separated_scope(self):
         from mlflow_oidc_auth import oauth as oauth_mod
@@ -443,7 +462,25 @@ class TestBuildScope(unittest.TestCase):
             patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", True, create=True),
             patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,offline_access,email", create=True),
         ):
-            self.assertEqual(oauth_mod._build_scope(), "openid,offline_access,email")
+            self.assertEqual(oauth_mod._build_scope(), "openid offline_access email")
+
+    def test_duplicate_scopes_are_collapsed(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "openid,openid email email", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "openid email")
+
+    def test_empty_scope_yields_empty_string(self):
+        from mlflow_oidc_auth import oauth as oauth_mod
+
+        with (
+            patch.object(oauth_mod.config, "OIDC_USE_REFRESH_TOKEN", False, create=True),
+            patch.object(oauth_mod.config, "OIDC_SCOPE", "", create=True),
+        ):
+            self.assertEqual(oauth_mod._build_scope(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #238 — authentication failing against Microsoft Entra ID (and other strict providers) because the plugin sent scopes comma-separated instead of space-delimited.

**Root cause:** the default `OIDC_SCOPE` was `"openid,email,profile"` (comma), and `_build_scope` returned it verbatim when refresh tokens were disabled (the default) — and even when enabled it *preserved the comma separator*. OAuth 2.0 (RFC 6749 §3.3) requires the `scope` parameter to be space-delimited, so providers like Entra ID receive one invalid scope `openid,email,profile` and reject the request.

**Fix:** `_build_scope` now **always** emits space-delimited scopes. It accepts comma-, space-, or mixed-separated input (backward compatible with existing comma configs), collapses duplicates, preserves order, and appends `offline_access` when the refresh flow is on. The default is also changed to `"openid email profile"` for clarity, though normalization makes the stored separator irrelevant.

**End-to-end proof** (comma config → what reaches the provider):
```
OIDC_SCOPE="openid,email,profile"  →  client scope: 'openid email profile'
```

## Tests
- `TestBuildScope` rewritten to assert space-delimited output: comma→space, space preserved, mixed/padded normalized, duplicates collapsed, `offline_access` appended space-delimited, empty→empty. (The three old tests asserting comma-preservation encoded the bug.)
- `test_config` default assertion updated to the space-delimited default.

Note: the pre-existing `test_secret_key_fallback_logs_warning` test-isolation flake (fails on clean main when run alongside other config tests, passes in isolation) is unrelated to this change.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)