### PR TITLE
test(auth): lock login redirect to a scheme-relative Location (#128)

### DIFF
--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -935,3 +935,55 @@ class TestAuthMiddleware:
         assert success is False
         assert username is None
         assert error == "Session access failed"
+
+
+class TestLoginRedirectSchemeRelative:
+    """The login redirect must be scheme-relative so it can't downgrade https->http (#128).
+
+    Behind a TLS-terminating proxy (e.g. Azure Application Gateway) the server sees the
+    request as http. If the redirect Location were an absolute http:// URL the browser
+    would be sent to http and the proxy would 404. Emitting a path-only Location makes the
+    browser resolve it against the current (https) origin, so the scheme is preserved.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("automatic_login_redirect", [True, False])
+    async def test_redirect_location_has_no_scheme(self, automatic_login_redirect):
+        from unittest.mock import AsyncMock
+
+        middleware = AuthMiddleware.__new__(AuthMiddleware)  # bypass __init__ (no app needed)
+
+        fake_url = MagicMock(scheme="http", path="/some/page", query="a=1")
+        request = MagicMock(url=fake_url, headers={}, scope={})
+
+        with (
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+            patch("mlflow_oidc_auth.utils.get_base_path", new=AsyncMock(return_value="")),
+        ):
+            cfg.AUTOMATIC_LOGIN_REDIRECT = automatic_login_redirect
+            response = await middleware._handle_auth_redirect(request)
+
+        location = response.headers["location"]
+        assert not location.startswith("http://"), f"redirect downgraded to http: {location}"
+        assert not location.startswith("https://"), f"redirect hardcoded a scheme: {location}"
+        assert location.startswith("/"), f"redirect is not path-relative: {location}"
+
+    @pytest.mark.asyncio
+    async def test_redirect_honors_forwarded_prefix_without_scheme(self):
+        """With a proxy path prefix the Location stays path-only (prefix + /login), still no scheme."""
+        from unittest.mock import AsyncMock
+
+        middleware = AuthMiddleware.__new__(AuthMiddleware)
+        fake_url = MagicMock(scheme="http", path="/page", query="")
+        request = MagicMock(url=fake_url, headers={}, scope={})
+
+        with (
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+            patch("mlflow_oidc_auth.utils.get_base_path", new=AsyncMock(return_value="/mlflow")),
+        ):
+            cfg.AUTOMATIC_LOGIN_REDIRECT = True
+            response = await middleware._handle_auth_redirect(request)
+
+        location = response.headers["location"]
+        assert location.startswith("/mlflow/login")
+        assert "http://" not in location and "https://" not in location


### PR DESCRIPTION
## Summary

Validation + regression coverage for #128 (`AUTOMATIC_LOGIN_REDIRECT` downgrading https → http behind a TLS-terminating proxy).

**Already fixed on `main`.** `_handle_auth_redirect` builds the redirect from `get_base_path` — which returns a **path only** (X-Forwarded-Prefix / root_path / base_url.path, never a scheme+host) — as `"{base_path}/login?next=..."`. A path-only `Location` header makes the browser resolve it against its current (https) origin, so the scheme is preserved. Verified empirically with a request whose server-seen scheme is `http`:

```
AUTOMATIC_LOGIN_REDIRECT=True  -> Location='/login?next=%2Fsome%2Fpage%3Fa%3D1'   (scheme-relative)
AUTOMATIC_LOGIN_REDIRECT=False -> Location='/oidc/ui'                              (scheme-relative)
```

The reporter's http-downgrade was on an older version (before the path-relative redirect + `ProxyHeadersMiddleware`); the maintainer had already asked them to retest.

## Tests
`TestLoginRedirectSchemeRelative` asserts the redirect `Location` has no scheme (not `http://`, not `https://`; path-relative) for `AUTOMATIC_LOGIN_REDIRECT` on/off and with a forwarded path prefix — so an absolute-URL redirect can't reintroduce the downgrade.

Test-only change. Full `test_auth_middleware.py` (62 tests) passes.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)