### PR TITLE
fix(auth): close three fail-open workspace cache invalidation holes (#253)

### DIFF
--- a/mlflow_oidc_auth/cache/backend.py
+++ b/mlflow_oidc_auth/cache/backend.py
@@ -42,6 +42,17 @@ class CacheBackend(Protocol):
         """
         ...
 
+    def delete_prefix(self, prefix: str) -> None:
+        """Remove every key in this namespace that starts with ``prefix``.
+
+        Enables targeted invalidation of a related group of entries (e.g. every
+        workspace entry for one user) without clearing the whole namespace, which
+        would throw away every other user's warm entries.
+
+        No-op if nothing matches.
+        """
+        ...
+
     def clear(self) -> None:
         """Remove all entries from this cache namespace."""
         ...

--- a/mlflow_oidc_auth/cache/local_backend.py
+++ b/mlflow_oidc_auth/cache/local_backend.py
@@ -36,5 +36,11 @@ class LocalTTLCacheBackend:
     def delete(self, key: str) -> None:
         self._cache.pop(key, None)
 
+    def delete_prefix(self, prefix: str) -> None:
+        # Materialize the key list first: TTLCache mutates on iteration when
+        # entries expire, and we delete while walking it.
+        for key in [k for k in list(self._cache.keys()) if isinstance(k, str) and k.startswith(prefix)]:
+            self._cache.pop(key, None)
+
     def clear(self) -> None:
         self._cache.clear()

--- a/mlflow_oidc_auth/cache/redis_backend.py
+++ b/mlflow_oidc_auth/cache/redis_backend.py
@@ -18,6 +18,16 @@ from mlflow_oidc_auth.logger import get_logger
 
 logger = get_logger()
 
+# Redis SCAN MATCH is a glob pattern, so metacharacters in a caller-supplied
+# prefix (e.g. a username) must be escaped or they could widen the match.
+_GLOB_METACHARS = ("\\", "*", "?", "[", "]")
+
+
+def _escape_glob(value: str) -> str:
+    for char in _GLOB_METACHARS:
+        value = value.replace(char, "\\" + char)
+    return value
+
 
 class RedisCacheBackend:
     """Redis-backed cache with TTL and namespace prefix.
@@ -61,13 +71,24 @@ class RedisCacheBackend:
     def delete(self, key: str) -> None:
         self._client.delete(self._make_key(key))
 
+    def delete_prefix(self, prefix: str) -> None:
+        """Delete every key in this namespace starting with ``prefix``.
+
+        Uses SCAN to avoid blocking the server (no KEYS *). The caller-supplied
+        prefix is escaped so glob metacharacters in a username cannot widen the
+        match beyond the intended entries.
+        """
+        self._scan_delete(f"{self._make_key(_escape_glob(prefix))}*")
+
     def clear(self) -> None:
         """Delete all keys matching this backend's prefix.
 
         Uses SCAN to avoid blocking the server (no KEYS *).
         """
+        self._scan_delete(f"{self._prefix}*")
+
+    def _scan_delete(self, pattern: str) -> None:
         cursor = 0
-        pattern = f"{self._prefix}*"
         while True:
             cursor, keys = self._client.scan(cursor=cursor, match=pattern, count=500)
             if keys:

--- a/mlflow_oidc_auth/routers/workspace_permissions.py
+++ b/mlflow_oidc_auth/routers/workspace_permissions.py
@@ -132,7 +132,6 @@ async def create_workspace_group_permission(
     """Grant a group permission on a workspace."""
     _validate_permission(body.permission)
     perm = store.create_workspace_group_permission(workspace, body.group_name, body.permission)
-    # Group changes rely on TTL-based cache expiry per D-15
     emit_audit_event(
         "permission.create",
         current_username,

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -1211,6 +1211,19 @@ _PERMISSION_CUD_METHODS = [
     "create_workspace_group_regex_permission",
     "update_workspace_group_regex_permission",
     "delete_workspace_group_regex_permission",
+    # The DeleteWorkspace cascade calls this one (hooks/after_request.py). Without this
+    # entry the permission cache kept serving grants whose kind was "workspace" after
+    # the wipe.
+    "wipe_workspace_permissions",
+]
+
+# Wiping a whole workspace can change the permission of EVERY user in it, and the
+# entries are keyed username:workspace, so there is no bounded target to invalidate —
+# a full workspace-cache flush is the correct choice here. The DeleteWorkspace cascade
+# in hooks/after_request.py already flushes, but doing it at the store keeps the
+# guarantee for any other caller (the same reason the other invalidation lives here).
+_WORKSPACE_WIPE_METHODS = [
+    "wipe_workspace_permissions",
 ]
 
 # Group membership drives the group-scoped branch of workspace resolution, so these
@@ -1368,3 +1381,33 @@ for _method_name in _WORKSPACE_GROUP_CUD_METHODS:
 for _method_name in _WORKSPACE_USER_CUD_METHODS:
     _original = getattr(SqlAlchemyStore, _method_name)
     setattr(SqlAlchemyStore, _method_name, _wrap_with_workspace_user_invalidation(_original))
+
+
+def _wrap_with_workspace_flush(method):
+    """Wrap a workspace-wide mutator to flush the whole workspace cache.
+
+    Invalidation failures are logged, never raised — the mutation already succeeded.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        result = method(self, *args, **kwargs)
+        try:
+            from mlflow_oidc_auth.utils.workspace_cache import flush_workspace_cache
+
+            flush_workspace_cache()
+        except Exception:
+            from mlflow_oidc_auth.logger import get_logger
+
+            get_logger().warning(
+                "Workspace cache flush failed after %s; entries expire via TTL",
+                method.__name__,
+            )
+        return result
+
+    return wrapper
+
+
+for _method_name in _WORKSPACE_WIPE_METHODS:
+    _original = getattr(SqlAlchemyStore, _method_name)
+    setattr(SqlAlchemyStore, _method_name, _wrap_with_workspace_flush(_original))

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -1194,6 +1194,52 @@ _PERMISSION_CUD_METHODS = [
     "set_user_groups",
     "add_user_to_group",
     "remove_user_from_group",
+    # Workspace permissions. When workspaces are enabled these feed permission
+    # resolution through the workspace fallback, so a workspace change can alter an
+    # already-cached resource decision. They were previously excluded on the grounds
+    # that workspace_cache had its own cache — but that cache is a *different*
+    # namespace, so clearing it left the permission cache serving stale results.
+    "create_workspace_permission",
+    "update_workspace_permission",
+    "delete_workspace_permission",
+    "create_workspace_group_permission",
+    "update_workspace_group_permission",
+    "delete_workspace_group_permission",
+    "create_workspace_regex_permission",
+    "update_workspace_regex_permission",
+    "delete_workspace_regex_permission",
+    "create_workspace_group_regex_permission",
+    "update_workspace_group_regex_permission",
+    "delete_workspace_group_regex_permission",
+]
+
+# Group membership drives the group-scoped branch of workspace resolution, so these
+# must additionally drop the mutated user's workspace-cache entries. They take the
+# username as their first positional argument. Targeted (not a full flush) because
+# OIDC login re-syncs membership on every sign-in — flushing here would wipe the
+# whole workspace cache on each login.
+_MEMBERSHIP_CUD_METHODS = [
+    "set_user_groups",
+    "add_user_to_group",
+    "remove_user_from_group",
+]
+
+# Group-scoped workspace permission CUD. Invalidation lives here rather than only in
+# the router so it cannot be bypassed by any other caller of the store. All three take
+# (workspace, group_name) as their first two positional arguments.
+_WORKSPACE_GROUP_CUD_METHODS = [
+    "create_workspace_group_permission",
+    "update_workspace_group_permission",
+    "delete_workspace_group_permission",
+]
+
+# User-scoped workspace permission CUD. The routers already invalidate these, but doing
+# it here too makes the guarantee hold for every caller rather than one code path.
+# All three take (workspace, username) as their first two positional arguments.
+_WORKSPACE_USER_CUD_METHODS = [
+    "create_workspace_permission",
+    "update_workspace_permission",
+    "delete_workspace_permission",
 ]
 
 
@@ -1212,6 +1258,113 @@ def _wrap_with_cache_flush(method):
     return wrapper
 
 
+def _wrap_with_membership_invalidation(method):
+    """Wrap a membership method to drop the mutated user's workspace-cache entries.
+
+    The username is the first positional argument (or the ``username`` keyword).
+    Invalidation failures are logged, never raised — the mutation already succeeded,
+    and masking it would be worse than a short staleness window.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        result = method(self, *args, **kwargs)
+        username = kwargs.get("username") if "username" in kwargs else (args[0] if args else None)
+        if username:
+            try:
+                from mlflow_oidc_auth.utils.workspace_cache import (
+                    invalidate_user_workspace_entries,
+                )
+
+                invalidate_user_workspace_entries(username)
+            except Exception:
+                from mlflow_oidc_auth.logger import get_logger
+
+                get_logger().warning(
+                    "Workspace cache invalidation failed after %s; entries expire via TTL",
+                    method.__name__,
+                )
+        return result
+
+    return wrapper
+
+
 for _method_name in _PERMISSION_CUD_METHODS:
     _original = getattr(SqlAlchemyStore, _method_name)
     setattr(SqlAlchemyStore, _method_name, _wrap_with_cache_flush(_original))
+
+
+def _wrap_with_workspace_group_invalidation(method):
+    """Wrap a group-scoped workspace CUD method to invalidate the group's members.
+
+    Signature is (workspace, group_name, ...). Invalidation failures are logged, never
+    raised — the mutation already succeeded.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        result = method(self, *args, **kwargs)
+        workspace = kwargs.get("workspace") if "workspace" in kwargs else (args[0] if len(args) > 0 else None)
+        group_name = kwargs.get("group_name") if "group_name" in kwargs else (args[1] if len(args) > 1 else None)
+        if workspace and group_name:
+            try:
+                from mlflow_oidc_auth.utils.workspace_cache import (
+                    invalidate_group_workspace_permission,
+                )
+
+                invalidate_group_workspace_permission(group_name=group_name, workspace=workspace)
+            except Exception:
+                from mlflow_oidc_auth.logger import get_logger
+
+                get_logger().warning(
+                    "Workspace cache invalidation failed after %s; entries expire via TTL",
+                    method.__name__,
+                )
+        return result
+
+    return wrapper
+
+
+for _method_name in _MEMBERSHIP_CUD_METHODS:
+    _original = getattr(SqlAlchemyStore, _method_name)
+    setattr(SqlAlchemyStore, _method_name, _wrap_with_membership_invalidation(_original))
+
+
+def _wrap_with_workspace_user_invalidation(method):
+    """Wrap a user-scoped workspace CUD method to invalidate that user's entry.
+
+    Signature is (workspace, username, ...). Invalidation failures are logged, never
+    raised — the mutation already succeeded.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        result = method(self, *args, **kwargs)
+        workspace = kwargs.get("workspace") if "workspace" in kwargs else (args[0] if len(args) > 0 else None)
+        username = kwargs.get("username") if "username" in kwargs else (args[1] if len(args) > 1 else None)
+        if workspace and username:
+            try:
+                from mlflow_oidc_auth.utils.workspace_cache import (
+                    invalidate_workspace_permission,
+                )
+
+                invalidate_workspace_permission(username, workspace)
+            except Exception:
+                from mlflow_oidc_auth.logger import get_logger
+
+                get_logger().warning(
+                    "Workspace cache invalidation failed after %s; entries expire via TTL",
+                    method.__name__,
+                )
+        return result
+
+    return wrapper
+
+
+for _method_name in _WORKSPACE_GROUP_CUD_METHODS:
+    _original = getattr(SqlAlchemyStore, _method_name)
+    setattr(SqlAlchemyStore, _method_name, _wrap_with_workspace_group_invalidation(_original))
+
+for _method_name in _WORKSPACE_USER_CUD_METHODS:
+    _original = getattr(SqlAlchemyStore, _method_name)
+    setattr(SqlAlchemyStore, _method_name, _wrap_with_workspace_user_invalidation(_original))

--- a/mlflow_oidc_auth/tests/cache/test_local_backend.py
+++ b/mlflow_oidc_auth/tests/cache/test_local_backend.py
@@ -91,3 +91,54 @@ class TestLocalTTLCacheBackend:
         backend.set("d", 4)  # Should evict "a"
         assert backend.get("a") is None
         assert backend.get("d") == 4
+
+
+class TestDeletePrefix:
+    """delete_prefix backs targeted workspace-cache invalidation (issue #253).
+
+    Keys are "username:workspace", so an over-delete costs other users their warm
+    entries (perf) and an under-delete leaves a revoked grant live (fail-open).
+    """
+
+    def test_deletes_only_matching_keys(self):
+        backend = LocalTTLCacheBackend(maxsize=100, ttl=60)
+        backend.set("bob:ws1", "a")
+        backend.set("bob:ws2", "b")
+        backend.set("alice:ws1", "c")
+
+        backend.delete_prefix("bob:")
+
+        assert backend.get("bob:ws1") is None
+        assert backend.get("bob:ws2") is None
+        assert backend.get("alice:ws1") == "c"
+
+    def test_does_not_over_delete_usernames_sharing_a_prefix(self):
+        """'bob' must not invalidate 'bob2' or 'bobby' — the colon is the boundary."""
+        backend = LocalTTLCacheBackend(maxsize=100, ttl=60)
+        for key in ("bob:ws1", "bob2:ws1", "bobby:ws1", "bob@example.com:ws1"):
+            backend.set(key, key)
+
+        backend.delete_prefix("bob:")
+
+        assert backend.get("bob:ws1") is None
+        assert backend.get("bob2:ws1") == "bob2:ws1"
+        assert backend.get("bobby:ws1") == "bobby:ws1"
+        assert backend.get("bob@example.com:ws1") == "bob@example.com:ws1"
+
+    def test_no_match_is_a_noop(self):
+        backend = LocalTTLCacheBackend(maxsize=100, ttl=60)
+        backend.set("alice:ws1", "a")
+        backend.delete_prefix("nobody:")
+        assert backend.get("alice:ws1") == "a"
+
+    def test_safe_when_deleting_many_entries(self):
+        """Deleting while walking the TTLCache must not raise (keys are materialized first)."""
+        backend = LocalTTLCacheBackend(maxsize=500, ttl=60)
+        for i in range(200):
+            backend.set(f"bob:ws{i}", i)
+            backend.set(f"eve:ws{i}", i)
+
+        backend.delete_prefix("bob:")
+
+        assert all(backend.get(f"bob:ws{i}") is None for i in range(200))
+        assert all(backend.get(f"eve:ws{i}") == i for i in range(200))

--- a/mlflow_oidc_auth/tests/cache/test_redis_backend.py
+++ b/mlflow_oidc_auth/tests/cache/test_redis_backend.py
@@ -159,3 +159,79 @@ class TestRedisCacheBackend:
 
         backend.delete("foo:bar:baz")
         mock_client.delete.assert_called_once_with("test:foo:bar:baz")
+
+
+class TestGlobEscaping:
+    """SCAN MATCH is a glob pattern, so a username must not act as a wildcard (#253).
+
+    Usernames are not restricted to a safe alphabet, so without escaping a name like
+    ``[a-z]*`` would BOTH match other users' keys (over-delete) AND fail to match its
+    own (under-delete → a revoked grant stays cached, i.e. fail-open).
+    """
+
+    @pytest.fixture
+    def mock_redis(self):
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_redis_module = MagicMock()
+        mock_redis_module.Redis.from_url.return_value = mock_client
+        mock_redis_module.ConnectionError = ConnectionError
+        return mock_redis_module, mock_client
+
+    @pytest.fixture
+    def backend(self, mock_redis):
+        mock_redis_module, _ = mock_redis
+        with patch.dict("sys.modules", {"redis": mock_redis_module}):
+            from mlflow_oidc_auth.cache.redis_backend import RedisCacheBackend
+
+            return RedisCacheBackend(url="redis://localhost:6379/0", prefix="test:", ttl=30)
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("plain", "plain"),
+            ("a*", "a\\*"),
+            ("a?", "a\\?"),
+            ("a[bc]", "a\\[bc\\]"),
+            ("back\\slash", "back\\\\slash"),
+            ("[a-z]*", "\\[a-z\\]\\*"),
+        ],
+    )
+    def test_escapes_every_redis_glob_metacharacter(self, raw, expected):
+        from mlflow_oidc_auth.cache.redis_backend import _escape_glob
+
+        assert _escape_glob(raw) == expected
+
+    def test_backslash_is_escaped_first(self):
+        """If '\\' were escaped last it would double-escape the other metacharacters."""
+        from mlflow_oidc_auth.cache.redis_backend import _escape_glob
+
+        # A literal backslash followed by a star must escape each exactly once.
+        assert _escape_glob("\\*") == "\\\\\\*"
+
+    def test_delete_prefix_scans_with_the_escaped_pattern(self, backend, mock_redis):
+        """The pattern sent to Redis must be namespaced AND escaped."""
+        _, mock_client = mock_redis
+        mock_client.scan.return_value = (0, [])
+
+        backend.delete_prefix("[a-z]*:")
+
+        pattern = mock_client.scan.call_args.kwargs["match"]
+        assert pattern == "test:\\[a-z\\]\\*:*", pattern
+
+    def test_delete_prefix_deletes_returned_keys(self, backend, mock_redis):
+        _, mock_client = mock_redis
+        mock_client.scan.side_effect = [(0, [b"test:bob:ws1", b"test:bob:ws2"])]
+
+        backend.delete_prefix("bob:")
+
+        mock_client.delete.assert_called_once_with(b"test:bob:ws1", b"test:bob:ws2")
+
+    def test_delete_prefix_paginates_until_cursor_zero(self, backend, mock_redis):
+        _, mock_client = mock_redis
+        mock_client.scan.side_effect = [(7, [b"test:bob:a"]), (0, [b"test:bob:b"])]
+
+        backend.delete_prefix("bob:")
+
+        assert mock_client.scan.call_count == 2
+        assert mock_client.delete.call_count == 2

--- a/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
+++ b/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
@@ -47,6 +47,10 @@ def mock_store():
     store.gateway_model_definition_group_repo = MagicMock()
     store.gateway_model_definition_regex_repo = MagicMock()
     store.gateway_model_definition_group_regex_repo = MagicMock()
+    store.workspace_permission_repo = MagicMock()
+    store.workspace_group_permission_repo = MagicMock()
+    store.workspace_regex_permission_repo = MagicMock()
+    store.workspace_group_regex_permission_repo = MagicMock()
     store.ManagedSessionMaker = MagicMock()
     return store
 
@@ -59,10 +63,24 @@ class TestPermissionCUDMethodsList:
         for method_name in _PERMISSION_CUD_METHODS:
             assert hasattr(SqlAlchemyStore, method_name), f"Method {method_name} not found on SqlAlchemyStore"
 
-    def test_no_workspace_methods_included(self):
-        """Workspace methods must NOT be in the list (they have their own cache)."""
-        for method_name in _PERMISSION_CUD_METHODS:
-            assert "workspace" not in method_name, f"Workspace method {method_name} should not be in _PERMISSION_CUD_METHODS"
+    def test_workspace_methods_included(self):
+        """Workspace permission methods MUST be in the list (issue #253).
+
+        They were previously excluded on the grounds that workspace_cache had its own
+        cache. But that is a *different* cache namespace: when workspaces are enabled,
+        workspace permissions feed resolution through the workspace fallback, so
+        clearing only the workspace cache left the permission cache serving a revoked
+        permission until its TTL expired.
+        """
+        for method_name in (
+            "create_workspace_permission",
+            "update_workspace_permission",
+            "delete_workspace_permission",
+            "create_workspace_group_permission",
+            "update_workspace_group_permission",
+            "delete_workspace_group_permission",
+        ):
+            assert method_name in _PERMISSION_CUD_METHODS, f"{method_name} must flush the permission cache"
 
     def test_no_user_management_methods_included(self):
         """User CRUD methods (create_user, update_user, delete_user) must NOT be in the list."""
@@ -386,6 +404,20 @@ class TestComprehensiveCUDCoverage:
             "set_user_groups": ("user1", ["group1"]),
             "add_user_to_group": ("user1", "group1"),
             "remove_user_from_group": ("user1", "group1"),
+            # Workspace permissions (issue #253 — these feed the workspace fallback in
+            # permission resolution, so they must flush the permission cache too)
+            "create_workspace_permission": ("ws1", "user1", "READ"),
+            "update_workspace_permission": ("ws1", "user1", "EDIT"),
+            "delete_workspace_permission": ("ws1", "user1"),
+            "create_workspace_group_permission": ("ws1", "group1", "READ"),
+            "update_workspace_group_permission": ("ws1", "group1", "EDIT"),
+            "delete_workspace_group_permission": ("ws1", "group1"),
+            "create_workspace_regex_permission": (".*", 1, "READ", "user1"),
+            "update_workspace_regex_permission": (".*", 1, "EDIT", "user1", 1),
+            "delete_workspace_regex_permission": ("user1", 1),
+            "create_workspace_group_regex_permission": ("group1", ".*", 1, "READ"),
+            "update_workspace_group_regex_permission": (1, "group1", ".*", 1, "EDIT"),
+            "delete_workspace_group_regex_permission": ("group1", 1),
         }
 
         # Verify every method in _PERMISSION_CUD_METHODS has sample args
@@ -399,3 +431,58 @@ class TestComprehensiveCUDCoverage:
             args = sample_args[method_name]
             method(*args)
             assert mock_flush.called, f"flush_permission_cache() not called after {method_name}"
+
+
+class TestWorkspaceCacheInvalidationRegressions:
+    """Regression tests for the three fail-open holes found while investigating #253.
+
+    All three left REVOKED authorization working until the workspace cache TTL (300s)
+    expired. They are asserted at the store layer because that is where the guarantee
+    now lives — putting invalidation only in the router made it bypassable by any
+    other caller.
+    """
+
+    def test_group_workspace_cud_invalidates_group_members(self, mock_store):
+        """BUG 1: group-scoped workspace CUD used to invalidate nothing (decision D-15)."""
+        member = MagicMock()
+        member.username = "alice"
+        mock_store.group_repo.list_group_members.return_value = [member]
+
+        with patch("mlflow_oidc_auth.utils.workspace_cache.invalidate_group_workspace_permission") as inv:
+            mock_store.delete_workspace_group_permission("ws-prod", "team-a")
+            inv.assert_called_once_with(group_name="team-a", workspace="ws-prod")
+
+    def test_membership_change_invalidates_that_users_workspace_entries(self, mock_store):
+        """BUG 2: membership mutations flushed the permission cache but not the workspace cache."""
+        with patch("mlflow_oidc_auth.utils.workspace_cache.invalidate_user_workspace_entries") as inv:
+            mock_store.set_user_groups("alice", [])
+            inv.assert_called_once_with("alice")
+
+    def test_membership_invalidation_is_targeted_not_a_full_flush(self, mock_store):
+        """Must NOT full-flush: OIDC login re-syncs membership on every sign-in."""
+        with (
+            patch("mlflow_oidc_auth.utils.workspace_cache.invalidate_user_workspace_entries"),
+            patch("mlflow_oidc_auth.utils.workspace_cache.flush_workspace_cache") as flush,
+        ):
+            mock_store.set_user_groups("alice", ["g1"])
+            flush.assert_not_called()
+
+    def test_user_workspace_cud_invalidates_at_store_layer(self, mock_store):
+        """BUG 3: user workspace CUD invalidated only in the router, so direct store calls leaked."""
+        with patch("mlflow_oidc_auth.utils.workspace_cache.invalidate_workspace_permission") as inv:
+            mock_store.delete_workspace_permission("ws-prod", "bob")
+            inv.assert_called_once_with("bob", "ws-prod")
+
+    def test_workspace_cud_also_flushes_the_permission_cache(self, mock_store):
+        """BUG 3 (other half): the workspace cache and permission cache are separate namespaces."""
+        with patch(FLUSH_PATCH_PATH) as mock_flush:
+            mock_store.delete_workspace_permission("ws-prod", "bob")
+            mock_flush.assert_called_once()
+
+    def test_invalidation_failure_never_masks_a_successful_mutation(self, mock_store):
+        """A cache problem must not turn a successful permission change into an error."""
+        with patch(
+            "mlflow_oidc_auth.utils.workspace_cache.invalidate_user_workspace_entries",
+            side_effect=RuntimeError("cache down"),
+        ):
+            mock_store.set_user_groups("alice", ["g1"])  # must not raise

--- a/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
+++ b/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
@@ -418,6 +418,7 @@ class TestComprehensiveCUDCoverage:
             "create_workspace_group_regex_permission": ("group1", ".*", 1, "READ"),
             "update_workspace_group_regex_permission": (1, "group1", ".*", 1, "EDIT"),
             "delete_workspace_group_regex_permission": ("group1", 1),
+            "wipe_workspace_permissions": ("ws1",),
         }
 
         # Verify every method in _PERMISSION_CUD_METHODS has sample args

--- a/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
+++ b/mlflow_oidc_auth/tests/test_store_cache_invalidation.py
@@ -444,10 +444,6 @@ class TestWorkspaceCacheInvalidationRegressions:
 
     def test_group_workspace_cud_invalidates_group_members(self, mock_store):
         """BUG 1: group-scoped workspace CUD used to invalidate nothing (decision D-15)."""
-        member = MagicMock()
-        member.username = "alice"
-        mock_store.group_repo.list_group_members.return_value = [member]
-
         with patch("mlflow_oidc_auth.utils.workspace_cache.invalidate_group_workspace_permission") as inv:
             mock_store.delete_workspace_group_permission("ws-prod", "team-a")
             inv.assert_called_once_with(group_name="team-a", workspace="ws-prod")

--- a/mlflow_oidc_auth/tests/test_workspace_cache_invalidation_e2e.py
+++ b/mlflow_oidc_auth/tests/test_workspace_cache_invalidation_e2e.py
@@ -1,0 +1,189 @@
+"""End-to-end tests for workspace cache invalidation (issue #253).
+
+These use a REAL SqlAlchemyStore on a temporary SQLite database and the REAL local
+cache backend — no mocks of the invalidation path. That is deliberate: the mock-based
+tests in test_store_cache_invalidation.py assert that a helper was *called*, so
+neutering the helpers themselves (delete_prefix, invalidate_user_workspace_entries,
+invalidate_group_workspace_permission) leaves them green. These tests fail instead.
+
+Every case asserts the REVOKED direction. All three bugs fixed here were fail-open —
+denials are never cached, so only a stale *grant* can be served.
+"""
+
+import pytest
+
+from mlflow_oidc_auth.config import config
+
+
+@pytest.fixture
+def ws_store(tmp_path, monkeypatch):
+    """Real store + real cache with workspaces enabled."""
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+    from mlflow_oidc_auth.utils import workspace_cache
+
+    monkeypatch.setattr(config, "MLFLOW_ENABLE_WORKSPACES", True)
+    db_uri = f"sqlite:///{tmp_path / 'auth.db'}"
+    store = SqlAlchemyStore()
+    store.init_db(db_uri)
+
+    # The store facade is a module-level singleton; point it at this instance so the
+    # invalidation helpers (which import it lazily) see the same data.
+    monkeypatch.setattr("mlflow_oidc_auth.store.store", store, raising=False)
+    workspace_cache.flush_workspace_cache()
+    yield store
+    workspace_cache.flush_workspace_cache()
+
+
+def _cached(username, workspace):
+    from mlflow_oidc_auth.utils.workspace_cache import get_workspace_permission_cached
+
+    return get_workspace_permission_cached(username, workspace)
+
+
+class TestGroupScopedWorkspaceRevocation:
+    """BUG 1: group-scoped workspace CUD used to invalidate nothing (decision D-15)."""
+
+    def test_revoking_group_permission_is_visible_immediately(self, ws_store):
+        ws_store.create_user("alice@example.com", "pw", "Alice")
+        ws_store.populate_groups(["team-a"])
+        ws_store.set_user_groups("alice@example.com", ["team-a"])
+        ws_store.create_workspace_group_permission("ws-prod", "team-a", "EDIT")
+
+        assert _cached("alice@example.com", "ws-prod").name == "EDIT", "precondition: cache warm"
+
+        ws_store.delete_workspace_group_permission("ws-prod", "team-a")
+
+        assert _cached("alice@example.com", "ws-prod") is None, "revoked group access still served (fail-open)"
+
+    def test_downgrading_group_permission_is_visible_immediately(self, ws_store):
+        ws_store.create_user("bob@example.com", "pw", "Bob")
+        ws_store.populate_groups(["team-b"])
+        ws_store.set_user_groups("bob@example.com", ["team-b"])
+        ws_store.create_workspace_group_permission("ws-prod", "team-b", "MANAGE")
+        assert _cached("bob@example.com", "ws-prod").name == "MANAGE"
+
+        ws_store.update_workspace_group_permission("ws-prod", "team-b", "READ")
+
+        assert _cached("bob@example.com", "ws-prod").name == "READ", "downgrade not reflected (fail-open)"
+
+
+class TestMembershipRevocation:
+    """BUG 2: membership mutations flushed the permission cache but not the workspace cache."""
+
+    def test_removing_user_from_group_revokes_group_derived_access(self, ws_store):
+        ws_store.create_user("carol@example.com", "pw", "Carol")
+        ws_store.populate_groups(["team-c"])
+        ws_store.set_user_groups("carol@example.com", ["team-c"])
+        ws_store.create_workspace_group_permission("ws-prod", "team-c", "EDIT")
+        assert _cached("carol@example.com", "ws-prod").name == "EDIT"
+
+        ws_store.set_user_groups("carol@example.com", [])
+
+        assert _cached("carol@example.com", "ws-prod") is None, "user in no groups still has group-derived access"
+
+    def test_invalidation_is_targeted_to_the_mutated_user(self, ws_store):
+        """Other users' entries must survive — OIDC re-syncs membership on every login."""
+        for name in ("dave@example.com", "erin@example.com"):
+            ws_store.create_user(name, "pw", name)
+        ws_store.populate_groups(["team-d"])
+        ws_store.set_user_groups("dave@example.com", ["team-d"])
+        ws_store.set_user_groups("erin@example.com", ["team-d"])
+        ws_store.create_workspace_group_permission("ws-prod", "team-d", "EDIT")
+
+        assert _cached("dave@example.com", "ws-prod").name == "EDIT"
+        assert _cached("erin@example.com", "ws-prod").name == "EDIT"
+
+        # Re-assert dave's existing membership (what a login does).
+        ws_store.set_user_groups("dave@example.com", ["team-d"])
+
+        # Erin's entry must still be served from cache — a full flush would drop it.
+        from mlflow_oidc_auth.utils.workspace_cache import _get_cache, _make_cache_key
+
+        assert _get_cache().get(_make_cache_key("erin@example.com", "ws-prod")) is not None, "invalidation was not targeted"
+
+
+class TestUserScopedWorkspaceRevocation:
+    """BUG 3: user workspace CUD invalidated only in the router, so direct store calls leaked."""
+
+    def test_revoking_user_permission_via_store_is_visible_immediately(self, ws_store):
+        ws_store.create_user("frank@example.com", "pw", "Frank")
+        ws_store.create_workspace_permission("ws-prod", "frank@example.com", "EDIT")
+        assert _cached("frank@example.com", "ws-prod").name == "EDIT"
+
+        ws_store.delete_workspace_permission("ws-prod", "frank@example.com")
+
+        assert _cached("frank@example.com", "ws-prod") is None, "revoked user access still served (fail-open)"
+
+    def test_workspace_change_also_clears_the_permission_cache(self, ws_store, monkeypatch):
+        """The workspace cache and permission cache are separate namespaces.
+
+        A workspace grant reaches resource decisions through the workspace fallback, so
+        revoking it must invalidate the resolved-permission entry too.
+        """
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        monkeypatch.setattr("mlflow_oidc_auth.bridge.user.get_request_workspace", lambda: "ws-prod")
+        monkeypatch.setattr(config, "PERMISSION_SOURCE_ORDER", ["user", "group"])
+
+        ws_store.create_user("grace@example.com", "pw", "Grace")
+        ws_store.create_workspace_permission("ws-prod", "grace@example.com", "EDIT")
+
+        warm = perms.resolve_permission("registered_model", "some-model", "grace@example.com")
+        assert warm.permission.name == "EDIT" and warm.kind == "workspace"
+
+        ws_store.delete_workspace_permission("ws-prod", "grace@example.com")
+
+        after = perms.resolve_permission("registered_model", "some-model", "grace@example.com")
+        assert after.permission.name != "EDIT", "permission cache still serves the revoked workspace grant"
+
+
+class TestWorkspaceWipe:
+    """The DeleteWorkspace cascade calls wipe_workspace_permissions."""
+
+    def test_wipe_clears_the_permission_cache(self, ws_store, monkeypatch):
+        """wipe_workspace_permissions was the one workspace mutator missing from the flush list."""
+        from mlflow_oidc_auth.utils import permissions as perms
+
+        monkeypatch.setattr("mlflow_oidc_auth.bridge.user.get_request_workspace", lambda: "ws-doomed")
+        monkeypatch.setattr(config, "PERMISSION_SOURCE_ORDER", ["user", "group"])
+
+        ws_store.create_user("hank@example.com", "pw", "Hank")
+        ws_store.create_workspace_permission("ws-doomed", "hank@example.com", "MANAGE")
+
+        warm = perms.resolve_permission("registered_model", "prod-model", "hank@example.com")
+        assert warm.permission.name == "MANAGE" and warm.kind == "workspace"
+
+        ws_store.wipe_workspace_permissions("ws-doomed")
+
+        after = perms.resolve_permission("registered_model", "prod-model", "hank@example.com")
+        assert after.permission.name != "MANAGE", "permission cache still serves a wiped workspace grant"
+
+    def test_wipe_is_wrapped_for_cache_invalidation(self):
+        """Structural guard: every workspace mutator must be in the flush list."""
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore, _PERMISSION_CUD_METHODS
+
+        assert "wipe_workspace_permissions" in _PERMISSION_CUD_METHODS
+        assert hasattr(SqlAlchemyStore.wipe_workspace_permissions, "__wrapped__")
+
+
+class TestPrefixInvalidationDoesNotOverDelete:
+    """delete_prefix keys on 'username:workspace' — a username must not match a longer one."""
+
+    def test_similar_usernames_are_not_collaterally_invalidated(self, ws_store):
+        for name in ("bob", "bob2", "bobby"):
+            ws_store.create_user(name, "pw", name)
+            ws_store.create_workspace_permission("ws-prod", name, "EDIT")
+            assert _cached(name, "ws-prod").name == "EDIT"
+
+        from mlflow_oidc_auth.utils.workspace_cache import (
+            _get_cache,
+            _make_cache_key,
+            invalidate_user_workspace_entries,
+        )
+
+        invalidate_user_workspace_entries("bob")
+
+        cache = _get_cache()
+        assert cache.get(_make_cache_key("bob", "ws-prod")) is None, "target not invalidated"
+        assert cache.get(_make_cache_key("bob2", "ws-prod")) is not None, "over-deleted bob2"
+        assert cache.get(_make_cache_key("bobby", "ws-prod")) is not None, "over-deleted bobby"

--- a/mlflow_oidc_auth/utils/workspace_cache.py
+++ b/mlflow_oidc_auth/utils/workspace_cache.py
@@ -89,6 +89,11 @@ def invalidate_user_workspace_entries(username: str) -> None:
     membership on every sign-in, so a full flush here would wipe the cache fleet-wide
     on each login.
     """
+    if not config.MLFLOW_ENABLE_WORKSPACES:
+        # Nothing is ever cached with workspaces off, so skip the work entirely —
+        # otherwise every login pays a Redis keyspace SCAN for no benefit. Mirrors
+        # the guard in get_workspace_permission_cached.
+        return
     cache = _get_cache()
     cache.delete_prefix(f"{username}:")
     logger.debug("Workspace cache entries invalidated for user %s", _sanitize(username))
@@ -102,6 +107,11 @@ def invalidate_group_workspace_permission(group_name: str, workspace: str) -> No
     query. Previously these changes invalidated nothing and relied on TTL expiry
     (decision D-15), which left revoked access working for up to the cache TTL.
     """
+    if not config.MLFLOW_ENABLE_WORKSPACES:
+        # Nothing is cached with workspaces off — skip, and in particular skip the
+        # get_group_users lookup, which would otherwise be a wasted query per mutation.
+        return
+
     from mlflow_oidc_auth.store import store
 
     try:

--- a/mlflow_oidc_auth/utils/workspace_cache.py
+++ b/mlflow_oidc_auth/utils/workspace_cache.py
@@ -72,10 +72,59 @@ def invalidate_workspace_permission(username: str, workspace: str) -> None:
     """Remove a specific user+workspace entry from cache (per D-13).
 
     Called by workspace permission router after successful CUD operations.
-    Only invalidates user permission changes; group changes rely on TTL (per D-15).
     """
     cache = _get_cache()
     cache.delete(_make_cache_key(username, workspace))
+
+
+def invalidate_user_workspace_entries(username: str) -> None:
+    """Drop every cached workspace entry for one user.
+
+    Group membership drives the group-scoped branch of workspace resolution, so a
+    membership change can alter this user's permission in ANY workspace — but only
+    this user's. Keys are ``username:workspace``, so a prefix delete is exact and
+    bounded, and leaves every other user's entries warm.
+
+    This matters for throughput as well as correctness: OIDC login re-syncs group
+    membership on every sign-in, so a full flush here would wipe the cache fleet-wide
+    on each login.
+    """
+    cache = _get_cache()
+    cache.delete_prefix(f"{username}:")
+    logger.debug("Workspace cache entries invalidated for user %s", _sanitize(username))
+
+
+def invalidate_group_workspace_permission(group_name: str, workspace: str) -> None:
+    """Drop the cached entry for ``workspace`` for every member of ``group_name``.
+
+    A group-scoped workspace permission change affects exactly the group's members in
+    that one workspace, so invalidating per member is exact and costs one bounded
+    query. Previously these changes invalidated nothing and relied on TTL expiry
+    (decision D-15), which left revoked access working for up to the cache TTL.
+    """
+    from mlflow_oidc_auth.store import store
+
+    try:
+        members = store.get_group_users(group_name)
+    except Exception:
+        # Never let an invalidation failure mask the successful mutation — but do not
+        # leave stale authorization behind either: fall back to a full flush.
+        logger.warning(
+            "Could not list members of group %s for targeted workspace-cache invalidation; flushing instead",
+            _sanitize(group_name),
+        )
+        flush_workspace_cache()
+        return
+
+    cache = _get_cache()
+    for member in members:
+        cache.delete(_make_cache_key(member.username, workspace))
+    logger.debug(
+        "Workspace cache invalidated for %d member(s) of group %s in workspace %s",
+        len(members),
+        _sanitize(group_name),
+        _sanitize(workspace),
+    )
 
 
 def flush_workspace_cache() -> None:


### PR DESCRIPTION
## Summary

Three **fail-open** authorization holes found while researching the #253 N+1 report. All three left **revoked access working for up to 300s** (the workspace cache TTL). Security fix — split out from the perf work so it can be reviewed and shipped on its own.

Reproduced end-to-end on current `main` before the fix:

```
BUG 1: revoke a GROUP-scoped workspace permission
  before revoke : cached=EDIT
  AFTER revoke  : cached=EDIT   <-- DB truth is None   >>> FAIL-OPEN

BUG 2: remove the user from the group entirely
  AFTER removal : cached=EDIT   <-- alice is in NO groups now   >>> FAIL-OPEN
```
…and after the fix, all three report `FAIL-OPEN: False`.

## The three bugs

**1. Group-scoped workspace permission CUD invalidated nothing.** Revoking a group's workspace permission left every member's cached entry intact. This was deliberate — decision **D-15**, *"group changes rely on TTL-based cache expiry"*. **This PR reverses D-15**: TTL is not an acceptable revocation mechanism for authorization data.

**2. Group membership mutations did not touch the workspace cache.** `set_user_groups` / `add_user_to_group` / `remove_user_from_group` were already in `_PERMISSION_CUD_METHODS`, but that wrapper only flushes the *permission* cache — so removing a user from a group left their group-derived workspace permission live.

**3. Workspace permission CUD did not flush the permission cache.** The two caches are separate namespaces; clearing the workspace cache left `resolve_permission` serving the revoked permission from its own entry.

## Design decisions

- **Invalidation moved into the store, not just the routers.** Router-level invalidation was bypassable — any other caller of the store method skipped it, which is precisely how bugs 1 and 3 stayed reachable. (I found this the hard way: my first fix put it in the router and the reproduction still failed.)
- **Targeted, not a full flush.** OIDC login re-syncs group membership on **every sign-in** ([auth.py:585](mlflow_oidc_auth/routers/auth.py)), so flushing there would wipe the workspace cache fleet-wide on each login — trading a security bug for a perf disaster. Adds `CacheBackend.delete_prefix` (keys are `username:workspace`) so exactly one user's entries can be dropped. Group-scoped changes invalidate exactly the group's members via `get_group_users`, falling back to a full flush only if that lookup fails.
- **Redis `delete_prefix` escapes glob metacharacters** so a username cannot widen the `SCAN` match.
- **Invalidation failures are logged, never raised** — a cache problem must not turn a successful permission change into an error.

## Tests
- 6 new regression tests (`TestWorkspaceCacheInvalidationRegressions`) asserting each bug at the store layer, plus that invalidation stays targeted and that failures do not mask the mutation.
- **Inverted `test_no_workspace_methods_included`** → `test_workspace_methods_included`. That test explicitly asserted the behavior causing bug 3.
- **1302 tests pass** across cache, routers, repository, utils, and store-invalidation suites.

## Known limitation (documented, not fixed here)
Under the default **local** backend these fixes are per-process. MLflow runs **4 uvicorn workers per pod** by default, so a 7-replica deployment is ~28 independent caches and the other processes still wait out the TTL. Only the **Redis** backend makes invalidation fleet-wide. Worth a docs note and possibly a shorter default TTL — happy to follow up.

Refs #253 (the perf work follows separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)