### PR TITLE
fix(auth): apply the workspace fallback on artifact-proxy paths (#236)

### DIFF
--- a/mlflow_oidc_auth/tests/validators/test_artifact_proxy_workspace.py
+++ b/mlflow_oidc_auth/tests/validators/test_artifact_proxy_workspace.py
@@ -1,0 +1,161 @@
+"""Artifact-proxy authorization when workspaces are enabled (issue #236).
+
+The artifact proxy is the only authenticated path where the workspace is NOT
+available from the ``X-MLFLOW-WORKSPACE`` header — MLflow's ``http_artifact_repo``
+does not send it. The workspace is in the URL path instead
+("workspaces/{name}/{experiment_id}/..."), so the permission check has to read it
+from there or the workspace fallback never applies.
+
+Two failures came from that, in opposite directions:
+  * a user whose only grant was on the workspace fell through to
+    DEFAULT_MLFLOW_PERMISSION and got 403 on upload (the reported symptom); and
+  * with the shipped default of MANAGE, any authenticated user could upload into
+    ANY workspace's path, including another tenant's — a cross-tenant write.
+"""
+
+import pytest
+from flask import Flask, request
+
+from mlflow_oidc_auth.config import config
+from mlflow_oidc_auth.validators.experiment import (
+    _parse_artifact_path,
+    validate_can_delete_experiment_artifact_proxy,
+    validate_can_read_experiment_artifact_proxy,
+    validate_can_update_experiment_artifact_proxy,
+)
+
+app = Flask(__name__)
+
+_OWNER = "owner@example.com"
+_OWNED_WS = "own-ws"
+
+
+@pytest.fixture(autouse=True)
+def _clean_permission_cache():
+    """The permission cache is keyed by resource+user and outlives a single test."""
+    from mlflow_oidc_auth.utils.permissions import flush_permission_cache
+
+    flush_permission_cache()
+    yield
+    flush_permission_cache()
+
+
+@pytest.fixture
+def ws_enabled(monkeypatch):
+    monkeypatch.setattr(config, "MLFLOW_ENABLE_WORKSPACES", True)
+    monkeypatch.setattr(config, "PERMISSION_SOURCE_ORDER", ["user", "group"])
+
+
+def _probe(validator, artifact_path, username=_OWNER, header_workspace=None):
+    """Run a proxy validator with the given artifact path and bridge auth context."""
+    from mlflow_oidc_auth.bridge.user import AUTH_CONTEXT_KEY, AuthContext
+
+    with app.test_request_context(path="/proxy", method="PUT"):
+        request.view_args = {"artifact_path": artifact_path}
+        request.environ[AUTH_CONTEXT_KEY] = AuthContext(username=username, is_admin=False, workspace=header_workspace)
+        return validator(username)
+
+
+class TestArtifactPathParsing:
+    def test_workspace_path_yields_experiment_and_workspace(self):
+        with app.test_request_context("/"):
+            request.view_args = {"artifact_path": "workspaces/products/8/run1/artifacts/f.json"}
+            assert _parse_artifact_path() == ("8", "products")
+
+    def test_plain_path_yields_experiment_only(self):
+        with app.test_request_context("/"):
+            request.view_args = {"artifact_path": "42/run1/artifacts/f.json"}
+            assert _parse_artifact_path() == ("42", None)
+
+    def test_unparseable_path_yields_nothing(self):
+        with app.test_request_context("/"):
+            request.view_args = {"artifact_path": "not-a-known-shape/f.json"}
+            assert _parse_artifact_path() == (None, None)
+
+
+class TestWorkspaceGrantAllowsUpload:
+    """The reported symptom: MANAGE on the workspace, nothing on the experiment."""
+
+    def test_upload_allowed_without_the_workspace_header(self, ws_enabled, monkeypatch):
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "READ")
+        from mlflow_oidc_auth.permissions import MANAGE
+        from mlflow_oidc_auth.validators import experiment as exp_mod
+
+        monkeypatch.setattr(exp_mod, "get_workspace_permission_cached", lambda u, w: MANAGE if w == _OWNED_WS else None, raising=False)
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            lambda u, w: MANAGE if w == _OWNED_WS else None,
+        )
+
+        assert _probe(validate_can_update_experiment_artifact_proxy, f"workspaces/{_OWNED_WS}/8/r/artifacts/f.json") is True
+
+    def test_read_and_delete_follow_the_same_workspace_grant(self, ws_enabled, monkeypatch):
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "READ")
+        from mlflow_oidc_auth.permissions import MANAGE
+
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            lambda u, w: MANAGE if w == _OWNED_WS else None,
+        )
+        path = f"workspaces/{_OWNED_WS}/8/r/artifacts/f.json"
+
+        assert _probe(validate_can_read_experiment_artifact_proxy, path) is True
+        assert _probe(validate_can_delete_experiment_artifact_proxy, path) is True
+
+
+class TestForgedWorkspacePathIsDenied:
+    """Cross-tenant guard: the path is caller-controlled, so naming a workspace is not enough."""
+
+    @pytest.mark.parametrize("default_permission", ["READ", "MANAGE"])
+    def test_upload_to_another_tenants_workspace_is_denied(self, ws_enabled, monkeypatch, default_permission):
+        """With the shipped MANAGE default this previously allowed a cross-tenant write."""
+        from mlflow_oidc_auth.permissions import MANAGE
+
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", default_permission)
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            lambda u, w: MANAGE if w == _OWNED_WS else None,
+        )
+
+        assert _probe(validate_can_update_experiment_artifact_proxy, "workspaces/victim-ws/9/r/artifacts/f.json") is False
+
+    def test_unknown_workspace_is_denied(self, ws_enabled, monkeypatch):
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "MANAGE")
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            lambda u, w: None,
+        )
+
+        assert _probe(validate_can_update_experiment_artifact_proxy, "workspaces/does-not-exist/8/r/artifacts/f.json") is False
+
+
+class TestNonWorkspacePathsUnchanged:
+    """Deployments without workspaces, and plain paths, must behave exactly as before."""
+
+    def test_plain_path_still_uses_the_global_default(self, ws_enabled, monkeypatch):
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "MANAGE")
+        assert _probe(validate_can_update_experiment_artifact_proxy, "8/r/artifacts/f.json") is True
+
+    def test_workspaces_disabled_ignores_the_path_workspace(self, monkeypatch):
+        monkeypatch.setattr(config, "MLFLOW_ENABLE_WORKSPACES", False)
+        monkeypatch.setattr(config, "PERMISSION_SOURCE_ORDER", ["user", "group"])
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "MANAGE")
+
+        assert _probe(validate_can_update_experiment_artifact_proxy, "workspaces/anything/8/r/artifacts/f.json") is True
+
+    def test_header_workspace_still_takes_precedence(self, ws_enabled, monkeypatch):
+        """When the header IS present, resolve_permission's own fallback handles it."""
+        monkeypatch.setattr(config, "DEFAULT_MLFLOW_PERMISSION", "READ")
+        from mlflow_oidc_auth.permissions import MANAGE
+
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.utils.workspace_cache.get_workspace_permission_cached",
+            lambda u, w: MANAGE if w == _OWNED_WS else None,
+        )
+
+        allowed = _probe(
+            validate_can_update_experiment_artifact_proxy,
+            f"workspaces/{_OWNED_WS}/8/r/artifacts/f.json",
+            header_workspace=_OWNED_WS,
+        )
+        assert allowed is True

--- a/mlflow_oidc_auth/tests/validators/test_experiment.py
+++ b/mlflow_oidc_auth/tests/validators/test_experiment.py
@@ -122,8 +122,8 @@ def test__get_experiment_id_from_view_args_none():
 def test__get_permission_from_experiment_id_artifact_proxy_with_id():
     with (
         patch(
-            "mlflow_oidc_auth.validators.experiment._get_experiment_id_from_view_args",
-            return_value="123",
+            "mlflow_oidc_auth.validators.experiment._parse_artifact_path",
+            return_value=("123", None),
         ),
         patch(
             "mlflow_oidc_auth.validators.experiment.effective_experiment_permission",
@@ -138,8 +138,8 @@ def test__get_permission_from_experiment_id_artifact_proxy_no_id():
     dummy_perm = DummyPermission(can_read=True)
     with (
         patch(
-            "mlflow_oidc_auth.validators.experiment._get_experiment_id_from_view_args",
-            return_value=None,
+            "mlflow_oidc_auth.validators.experiment._parse_artifact_path",
+            return_value=(None, None),
         ),
         patch("mlflow_oidc_auth.validators.experiment.config") as mock_config,
         patch(

--- a/mlflow_oidc_auth/validators/experiment.py
+++ b/mlflow_oidc_auth/validators/experiment.py
@@ -4,7 +4,7 @@ from flask import request
 from mlflow.server.handlers import _get_tracking_store
 
 from mlflow_oidc_auth.config import config
-from mlflow_oidc_auth.permissions import Permission, get_permission
+from mlflow_oidc_auth.permissions import NO_PERMISSIONS, Permission, get_permission
 from mlflow_oidc_auth.utils import (
     effective_experiment_permission,
     effective_new_experiment_permission,
@@ -42,20 +42,57 @@ def _get_experiment_id_from_view_args():
     # replaced with get_request_param("artifact_path") because we need to
     # *parse* the experiment_id out of the composite path value, not just read
     # the parameter verbatim.
+    experiment_id, _ = _parse_artifact_path()
+    return experiment_id
+
+
+def _parse_artifact_path() -> tuple[str | None, str | None]:
+    """Return ``(experiment_id, workspace)`` parsed from the artifact proxy path.
+
+    Workspace-scoped artifact paths carry the workspace themselves
+    ("workspaces/{name}/{experiment_id}/..."), which matters because the artifact
+    proxy is the one authenticated path where the workspace is NOT available from
+    the ``X-MLFLOW-WORKSPACE`` header — MLflow's ``http_artifact_repo`` does not
+    send it (issue #236). ``workspace`` is None for non-workspace paths.
+    """
     view_args = request.view_args
     if view_args is not None and (artifact_path := view_args.get("artifact_path")):
         if m := _EXPERIMENT_ID_PATTERN.match(artifact_path):
-            return m.group(1)
+            return m.group(1), None
         if m := _WORKSPACES_EXPERIMENT_ID_PATTERN.match(artifact_path):
-            # Group 1: workspace, Group 2: {workspace_name}, Group 3: experiment-id
-            return m.group(3)
-    return None
+            # Group 1: literal "workspaces", Group 2: {workspace_name}, Group 3: experiment-id
+            return m.group(3), m.group(2)
+    return None, None
 
 
 def _get_permission_from_experiment_id_artifact_proxy(username: str) -> Permission:
-    if experiment_id := _get_experiment_id_from_view_args():
-        return effective_experiment_permission(experiment_id, username).permission
-    return get_permission(config.DEFAULT_MLFLOW_PERMISSION)
+    experiment_id, path_workspace = _parse_artifact_path()
+    if not experiment_id:
+        return get_permission(config.DEFAULT_MLFLOW_PERMISSION)
+
+    result = effective_experiment_permission(experiment_id, username)
+
+    # Apply the workspace fallback using the workspace named in the PATH.
+    #
+    # Everywhere else the workspace arrives in the X-MLFLOW-WORKSPACE header, so
+    # resolve_permission's own fallback covers it. MLflow's proxied-artifact client
+    # does not send that header, so without this a user whose only grant is on the
+    # workspace fell through to DEFAULT_MLFLOW_PERMISSION and got 403 on upload
+    # (issue #236). The workspace is taken from the same path segment the
+    # experiment_id is taken from, and is the workspace MLflow will itself resolve
+    # the storage location from, so the two checks cannot disagree.
+    if result.kind == "fallback" and config.MLFLOW_ENABLE_WORKSPACES and path_workspace:
+        from mlflow_oidc_auth.bridge.user import get_request_workspace
+        from mlflow_oidc_auth.utils.workspace_cache import get_workspace_permission_cached
+
+        if not get_request_workspace():
+            ws_perm = get_workspace_permission_cached(username, path_workspace)
+            # Deny when the user holds nothing on the workspace, matching
+            # _apply_workspace_fallback's "workspace-deny" rather than silently
+            # falling back to the global default.
+            return ws_perm if ws_perm is not None else NO_PERMISSIONS
+
+    return result.permission
 
 
 def validate_can_read_experiment(username: str) -> bool:


### PR DESCRIPTION
Fixes #236 — 403 on artifact upload for users whose grant is on the **workspace**. While reproducing it I found the same root cause also permits a **cross-tenant write**, so this is more than a usability fix.

## Root cause

The artifact proxy is the only authenticated path where the workspace is **not** available from the `X-MLFLOW-WORKSPACE` header — MLflow's `http_artifact_repo` never sends it (verified: the module does not reference workspaces at all). The workspace is in the URL instead:

```
/api/2.0/mlflow-artifacts/artifacts/workspaces/products/8/<run_id>/artifacts/file.json
                                     ^^^^^^^^^^^^^^^^^^^^
```

The permission check read the workspace only from the header, so `get_request_workspace()` returned `None`, the workspace fallback was skipped, and resolution fell through to `DEFAULT_MLFLOW_PERMISSION`.

The reporter's hypothesis pointed at `_get_experiment_id_from_view_args`; that part was already fixed by #237 six days after filing. The remaining gap was the **fallback**, which is why the symptom persisted.

## Two failures, opposite directions

Reproduced on `main`, user holding permission only on `own-ws`:

| Request | main | this PR |
|---|---|---|
| upload to own workspace (only a **workspace** grant) | ❌ **403** — the reported bug | ✅ allowed |
| upload to `workspaces/victim-ws/...` (forged path) | ⚠️ **allowed** — cross-tenant write | ✅ **denied** |
| unknown workspace | ⚠️ allowed | ✅ denied |
| plain non-workspace path | allowed | allowed (unchanged) |

The cross-tenant row uses the **shipped default** (`DEFAULT_MLFLOW_PERMISSION=MANAGE`), so it applies out of the box.

## Fix

Parse the workspace out of the artifact path alongside the experiment id — the regex already captured it — and use it for the fallback when the header is absent. Deny when the user holds nothing on that workspace, matching `_apply_workspace_fallback`'s `workspace-deny` rather than falling back to the global default.

The path is caller-controlled, but naming a workspace grants nothing by itself: the check is whether **this** user holds permission on **that** workspace, and MLflow resolves the storage location from the same path, so the check and the write cannot disagree. Only the fallback branch is affected — an explicit experiment-level grant still wins.

## Compatibility
This **tightens** behaviour for deployments on the permissive default: uploads into a workspace path now require a workspace grant. That is the intended isolation property, but it is a behaviour change for anyone relying on `DEFAULT_MLFLOW_PERMISSION=MANAGE`. Flagging explicitly for the release note.

## Tests
11 tests covering both directions plus the unchanged paths (non-workspace, workspaces-disabled, header-present). Mutation-verified: reverting the fallback, making the miss fail open to the default, and dropping the workspaces-disabled guard each fail the suite. Full suite 2952 passing.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)