### PR TITLE
fix(auth): warn when RESTRICT_RESOURCE_CREATION cannot deny anything (#293)

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -200,6 +200,50 @@ class AppConfig:
         # API documentation settings
         self.ENABLE_API_DOCS = config_manager.get_bool("ENABLE_API_DOCS", default=False)
 
+        # Runs last: it reads settings loaded above.
+        self._warn_if_resource_creation_restriction_is_inert()
+
+    def _warn_if_resource_creation_restriction_is_inert(self) -> None:
+        """Warn when RESTRICT_RESOURCE_CREATION is enabled but cannot deny anything.
+
+        The creation validators require EDIT+ on the resource NAME, resolved from name
+        regex and group-regex rules with a workspace fallback. When workspaces are off and
+        no regex matches, that resolution lands on DEFAULT_MLFLOW_PERMISSION — which ships
+        as MANAGE, and MANAGE grants can_update. So enabling the flag on a default install
+        denies nothing at all: every user can still create every experiment and registered
+        model, exactly as before.
+
+        A flag that silently does nothing is worse than no flag, because operators
+        reasonably read "RESTRICT_RESOURCE_CREATION=true" as "creation is restricted" and
+        stop looking. This is documented in docs/permissions.md, and the documentation
+        evidently was not enough — hence a startup warning (issue #293).
+
+        Warn rather than refuse to start: this combination is not dangerous in itself, and
+        refusing would take down running deployments on upgrade over a configuration that
+        was already ineffective.
+        """
+        if not self.RESTRICT_RESOURCE_CREATION or self.MLFLOW_ENABLE_WORKSPACES:
+            return
+
+        # Imported here: mlflow_oidc_auth.permissions imports this module, so a top-level
+        # import would be circular.
+        from mlflow_oidc_auth.permissions import get_permission
+
+        try:
+            default_permission = get_permission(self.DEFAULT_MLFLOW_PERMISSION)
+        except Exception:
+            # An invalid value is reported elsewhere; nothing useful to say here.
+            return
+
+        if default_permission.can_update:
+            logger.warning(
+                f"RESTRICT_RESOURCE_CREATION is enabled but has no effect: workspaces are disabled and "
+                f"DEFAULT_MLFLOW_PERMISSION={self.DEFAULT_MLFLOW_PERMISSION} already grants create rights, "
+                "so a name matching no regex rule can still be created by anyone. "
+                "Set DEFAULT_MLFLOW_PERMISSION below EDIT (e.g. NO_PERMISSIONS) so only regex or "
+                "group-regex matches may create, or enable workspaces and use the workspace creation gate."
+            )
+
     def refresh(self) -> None:
         """Reload configuration from all providers.
 

--- a/mlflow_oidc_auth/tests/test_restrict_creation_warning.py
+++ b/mlflow_oidc_auth/tests/test_restrict_creation_warning.py
@@ -1,0 +1,68 @@
+"""RESTRICT_RESOURCE_CREATION must not silently do nothing (#293).
+
+The creation validators require EDIT+ on the resource NAME, resolved from regex rules with
+a workspace fallback. With workspaces off and no regex match, that lands on
+DEFAULT_MLFLOW_PERMISSION — which ships as MANAGE, and MANAGE grants create rights. So the
+flag denies nothing on a default install while reading as though it locked things down.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow_oidc_auth import config as config_module
+
+
+def _warn_for(default_permission, restrict, workspaces):
+    """Run the check in isolation against a stub config, returning the warning or None."""
+    stub = MagicMock()
+    stub.RESTRICT_RESOURCE_CREATION = restrict
+    stub.MLFLOW_ENABLE_WORKSPACES = workspaces
+    stub.DEFAULT_MLFLOW_PERMISSION = default_permission
+
+    with patch.object(config_module, "logger") as logger:
+        config_module.AppConfig._warn_if_resource_creation_restriction_is_inert(stub)
+
+    return logger.warning.call_args.args[0] if logger.warning.called else None
+
+
+class TestInertCombinationWarns:
+    @pytest.mark.parametrize("default_permission", ["MANAGE", "EDIT"])
+    def test_permissive_default_without_workspaces_warns(self, default_permission):
+        """These grant can_update, so a name matching no regex is still creatable."""
+        warning = _warn_for(default_permission, restrict=True, workspaces=False)
+
+        assert warning is not None, f"{default_permission} grants create rights; the flag is inert"
+        assert "RESTRICT_RESOURCE_CREATION is enabled but has no effect" in warning
+        assert default_permission in warning
+
+    def test_the_shipped_default_is_the_case_that_warns(self):
+        """Guards the premise: if MANAGE ever stops granting create, this test should fail."""
+        from mlflow_oidc_auth.permissions import get_permission
+
+        assert get_permission("MANAGE").can_update is True
+
+
+class TestEffectiveCombinationsAreSilent:
+    @pytest.mark.parametrize("default_permission", ["NO_PERMISSIONS", "READ"])
+    def test_a_default_below_edit_is_effective(self, default_permission):
+        """Only regex or group-regex matches can create, which is the intended setup."""
+        assert _warn_for(default_permission, restrict=True, workspaces=False) is None
+
+    def test_workspaces_enabled_is_effective(self):
+        """The workspace creation gate does the enforcing; the global default is bypassed."""
+        assert _warn_for("MANAGE", restrict=True, workspaces=True) is None
+
+    def test_the_flag_being_off_is_not_worth_warning_about(self):
+        assert _warn_for("MANAGE", restrict=False, workspaces=False) is None
+
+    def test_an_unparseable_default_is_reported_elsewhere(self):
+        assert _warn_for("NOT_A_PERMISSION", restrict=True, workspaces=False) is None
+
+
+def test_the_check_runs_during_config_construction():
+    """Wiring: the warning is useless if nothing calls it."""
+    with patch.object(config_module.AppConfig, "_warn_if_resource_creation_restriction_is_inert") as check:
+        config_module.AppConfig()
+
+    check.assert_called_once()

--- a/mlflow_oidc_auth/tests/utils/test_permission_fallback_observability.py
+++ b/mlflow_oidc_auth/tests/utils/test_permission_fallback_observability.py
@@ -1,0 +1,126 @@
+"""A permission decision that came from the configured default must be visible (#293).
+
+`DEFAULT_MLFLOW_PERMISSION` ships as MANAGE, so on a fresh install every resource with no
+explicit grant is handed out by configuration. Nothing recorded that, which is why the
+exposure was invisible in running deployments. It is surfaced before the default changes.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mlflow_oidc_auth.models import PermissionResult
+from mlflow_oidc_auth.permissions import get_permission
+from mlflow_oidc_auth.utils import permissions as P
+from mlflow_oidc_auth.utils.batch_permissions import (
+    UserPermissionContext,
+    resolve_model_permission_from_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_counters():
+    """Counters are module-level, and every test in the suite can add to them."""
+    P.reset_permission_fallback_counts()
+    yield
+    P.reset_permission_fallback_counts()
+
+
+@pytest.fixture
+def captured_logger(monkeypatch):
+    """Assert against a mocked module logger.
+
+    Other tests in this suite mock the logging machinery globally, so asserting on real
+    log records passed in isolation and captured nothing once the whole suite ran. The
+    behaviour under test is "does it warn", not "does the logging framework work".
+    """
+    logger = MagicMock()
+    monkeypatch.setattr(P, "logger", logger)
+    return logger
+
+
+def _empty_context(username="alice"):
+    return UserPermissionContext(
+        username=username,
+        group_ids=[],
+        user_experiment_permissions={},
+        group_experiment_permissions={},
+        experiment_regex_permissions=[],
+        group_experiment_regex_permissions=[],
+        user_model_permissions={},
+        group_model_permissions={},
+        model_regex_permissions=[],
+        group_model_regex_permissions=[],
+        prompt_regex_permissions=[],
+        group_prompt_regex_permissions=[],
+    )
+
+
+class TestFallbackRecording:
+    def test_a_granting_fallback_warns(self, captured_logger):
+        P.record_permission_fallback("experiment", "12", "alice", get_permission("MANAGE"))
+
+        captured_logger.warning.assert_called_once()
+        message = captured_logger.warning.call_args.args[0]
+        assert "DEFAULT_MLFLOW_PERMISSION granted MANAGE" in message
+        assert "experiment=12" in message
+        assert "alice" in message
+
+    def test_a_denying_fallback_never_warns(self, captured_logger):
+        """No access was handed out, so there is nothing for an operator to act on."""
+        for i in range(50):
+            P.record_permission_fallback("experiment", f"exp-{i}", "alice", get_permission("NO_PERMISSIONS"))
+
+        captured_logger.warning.assert_not_called()
+        assert P.get_permission_fallback_counts() == {"experiment": 50}, "it must still be counted"
+
+    def test_warnings_are_throttled_but_never_stop(self, captured_logger):
+        """The batch filters resolve one permission per resource.
+
+        Listing a few thousand experiments must not emit a few thousand identical
+        warnings — but the process must not go silent after startup either.
+        """
+        for i in range(1000):
+            P.record_permission_fallback("experiment", f"exp-{i}", "alice", get_permission("MANAGE"))
+
+        # Occurrences 1, 10, 100 and 1000 — four warnings for a thousand grants.
+        assert captured_logger.warning.call_count == 4
+        assert P.get_permission_fallback_counts() == {"experiment": 1000}
+
+    def test_counts_are_kept_per_resource_type(self):
+        P.record_permission_fallback("experiment", "1", "alice", get_permission("READ"))
+        P.record_permission_fallback("registered_model", "m", "alice", get_permission("READ"))
+        P.record_permission_fallback("registered_model", "m2", "alice", get_permission("READ"))
+
+        assert P.get_permission_fallback_counts() == {"experiment": 1, "registered_model": 2}
+
+
+class TestResolutionPathsRecord:
+    """Both resolution paths must report — the batch one bypasses resolve_permission."""
+
+    def test_single_resource_resolution_records_the_fallback(self, monkeypatch):
+        monkeypatch.setattr(P, "get_permission_from_store_or_default", lambda cfg: PermissionResult(get_permission("MANAGE"), "fallback"))
+        monkeypatch.setattr(P, "_apply_workspace_fallback", lambda result, username: result)
+        monkeypatch.setitem(P.PERMISSION_REGISTRY, "experiment", lambda resource_id, username, **kw: {})
+        P.flush_permission_cache()
+
+        P.resolve_permission("experiment", "42", "alice")
+
+        assert P.get_permission_fallback_counts() == {"experiment": 1}
+
+    def test_a_real_grant_is_not_recorded_as_a_fallback(self, monkeypatch):
+        monkeypatch.setattr(P, "get_permission_from_store_or_default", lambda cfg: PermissionResult(get_permission("READ"), "user"))
+        monkeypatch.setattr(P, "_apply_workspace_fallback", lambda result, username: result)
+        monkeypatch.setitem(P.PERMISSION_REGISTRY, "experiment", lambda resource_id, username, **kw: {})
+        P.flush_permission_cache()
+
+        P.resolve_permission("experiment", "43", "alice")
+
+        assert P.get_permission_fallback_counts() == {}, "an explicit grant is not a fallback"
+
+    def test_batch_resolution_records_the_fallback(self):
+        """filter_manageable_* run entirely off pre-fetched context, bypassing resolve_permission."""
+        result = resolve_model_permission_from_context(_empty_context(), "some-model")
+
+        assert result.kind == "fallback", "precondition: an empty context must fall back"
+        assert P.get_permission_fallback_counts() == {"registered_model": 1}

--- a/mlflow_oidc_auth/tests/utils/test_permission_fallback_observability.py
+++ b/mlflow_oidc_auth/tests/utils/test_permission_fallback_observability.py
@@ -63,8 +63,10 @@ class TestFallbackRecording:
         captured_logger.warning.assert_called_once()
         message = captured_logger.warning.call_args.args[0]
         assert "DEFAULT_MLFLOW_PERMISSION granted MANAGE" in message
-        assert "experiment=12" in message
+        assert "experiment" in message, "the resource TYPE tells the operator where to look"
         assert "alice" in message
+        # The resource id is deliberately absent — see TestResourceIdsStayOutOfLogs.
+        assert "12" not in message.replace("#293", "")
 
     def test_a_denying_fallback_never_warns(self, captured_logger):
         """No access was handed out, so there is nothing for an operator to act on."""
@@ -124,3 +126,40 @@ class TestResolutionPathsRecord:
 
         assert result.kind == "fallback", "precondition: an empty context must fall back"
         assert P.get_permission_fallback_counts() == {"registered_model": 1}
+
+
+class TestResourceIdsStayOutOfLogs:
+    """Identifiers are recorded in-process, not written to the log (CodeQL, #294).
+
+    One resource type here is the gateway SECRET, whose id is the secret's name. Not its
+    value — but a name like "openai-prod-key" still should not land in a log aggregator by
+    default, and an operator can get the same detail on demand.
+    """
+
+    def test_the_warning_does_not_contain_the_resource_id(self, captured_logger):
+        P.record_permission_fallback("gateway_secret", "openai-prod-key", "alice", get_permission("MANAGE"))
+
+        message = captured_logger.warning.call_args.args[0]
+        assert "openai-prod-key" not in message
+        assert "gateway_secret" in message, "the resource TYPE is still actionable"
+
+    def test_the_debug_line_does_not_contain_the_resource_id(self, captured_logger):
+        P.record_permission_fallback("gateway_secret", "openai-prod-key", "alice", get_permission("MANAGE"))
+
+        rendered = " ".join(str(part) for call in captured_logger.debug.call_args_list for part in call.args)
+        assert "openai-prod-key" not in rendered
+
+    def test_ids_are_available_on_demand(self):
+        P.record_permission_fallback("experiment", "12", "alice", get_permission("MANAGE"))
+        P.record_permission_fallback("experiment", "13", "alice", get_permission("MANAGE"))
+        P.record_permission_fallback("experiment", "12", "bob", get_permission("MANAGE"))
+
+        assert P.get_permission_fallback_samples() == {"experiment": ["12", "13"]}, "deduplicated, in order"
+
+    def test_the_sample_is_bounded(self):
+        """Never drained, and keyed on caller-supplied ids — unbounded would be a leak."""
+        for i in range(500):
+            P.record_permission_fallback("experiment", f"exp-{i}", "alice", get_permission("MANAGE"))
+
+        assert len(P.get_permission_fallback_samples()["experiment"]) == P._FALLBACK_SAMPLE_LIMIT
+        assert P.get_permission_fallback_counts() == {"experiment": 500}, "counting is not capped"

--- a/mlflow_oidc_auth/utils/batch_permissions.py
+++ b/mlflow_oidc_auth/utils/batch_permissions.py
@@ -24,6 +24,7 @@ from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.models import PermissionResult
 from mlflow_oidc_auth.permissions import NO_PERMISSIONS, compare_permissions, get_permission
 from mlflow_oidc_auth.store import store
+from mlflow_oidc_auth.utils.permissions import EXPERIMENT, PROMPT, REGISTERED_MODEL, record_permission_fallback
 
 logger = get_logger()
 
@@ -196,6 +197,18 @@ def _resolve_permission_from_context(
     return PermissionResult(get_permission(config.DEFAULT_MLFLOW_PERMISSION), "fallback")
 
 
+def _record_if_fallback(result: PermissionResult, resource_type: str, resource_id: str, username: str) -> PermissionResult:
+    """Surface a batch-path fallback the same way the single-resource path does.
+
+    The batch resolvers bypass resolve_permission entirely (that is their point — no DB
+    queries), so without this the listing endpoints would grant access from the configured
+    default with no record of it anywhere (issue #293).
+    """
+    if result.kind == "fallback":
+        record_permission_fallback(resource_type, resource_id, username, result.permission)
+    return result
+
+
 def _apply_workspace_fallback(result: PermissionResult, username: str, ctx: Optional["UserPermissionContext"] = None) -> PermissionResult:
     """Apply workspace-level permission fallback when no resource-level permission exists.
 
@@ -297,6 +310,7 @@ def resolve_experiment_permission_from_context(
         user_regex,
         group_regex,
     )
+    result = _record_if_fallback(result, EXPERIMENT, experiment_id, ctx.username)
     return _apply_workspace_fallback(result, ctx.username, ctx)
 
 
@@ -322,6 +336,7 @@ def resolve_model_permission_from_context(ctx: UserPermissionContext, model_name
         user_regex,
         group_regex,
     )
+    result = _record_if_fallback(result, REGISTERED_MODEL, model_name, ctx.username)
     return _apply_workspace_fallback(result, ctx.username, ctx)
 
 
@@ -351,6 +366,7 @@ def resolve_prompt_permission_from_context(ctx: UserPermissionContext, prompt_na
         user_regex,
         group_regex,
     )
+    result = _record_if_fallback(result, PROMPT, prompt_name, ctx.username)
     return _apply_workspace_fallback(result, ctx.username, ctx)
 
 

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -321,6 +321,65 @@ def _apply_workspace_fallback(result: PermissionResult, username: str) -> Permis
     return PermissionResult(NO_PERMISSIONS, "workspace-deny")
 
 
+_FALLBACK_COUNTS: Dict[str, int] = {}
+
+# Warn on these occurrence numbers, then every _FALLBACK_WARN_EVERY after that. The
+# batch filters resolve one permission per resource, so a listing of a few thousand
+# experiments would otherwise emit a few thousand identical warnings.
+_FALLBACK_WARN_AT = frozenset((1, 10, 100, 1_000))
+_FALLBACK_WARN_EVERY = 10_000
+
+
+def get_permission_fallback_counts() -> Dict[str, int]:
+    """How many times each resource type has fallen back to the configured default.
+
+    Exposed for diagnostics and tests. Counts are per process and reset on restart.
+    """
+    return dict(_FALLBACK_COUNTS)
+
+
+def reset_permission_fallback_counts() -> None:
+    """Clear the counters (tests)."""
+    _FALLBACK_COUNTS.clear()
+
+
+def record_permission_fallback(resource_type: str, resource_id: str, username: str, permission) -> None:
+    """Record that a permission decision came from ``DEFAULT_MLFLOW_PERMISSION``.
+
+    A fallback means the resource has no user, group, regex or group-regex grant for this
+    user, so the configured default decided the outcome. That is unremarkable when the
+    default DENIES — the user simply has no access. It is worth surfacing when the default
+    GRANTS, because then access is being handed out by configuration rather than by an
+    explicit permission record, and nothing in the system says who intended it.
+
+    The shipped default is ``MANAGE``, so on a fresh install this is the granting case for
+    every resource, which is exactly the exposure operators should be able to see before
+    the default changes (issue #293). Only the granting case warns; both cases are counted
+    and logged at debug.
+
+    Warnings are throttled by occurrence count rather than suppressed, so a long-running
+    process keeps reporting at a decreasing rate instead of going quiet after startup.
+    The counter is not synchronized: concurrent requests may race and skip a warning
+    threshold, which affects log cadence only, never an authorization outcome.
+    """
+    count = _FALLBACK_COUNTS.get(resource_type, 0) + 1
+    _FALLBACK_COUNTS[resource_type] = count
+
+    logger.debug(f"Permission fallback: {resource_type}={resource_id} user={username} -> {permission.name} (occurrence {count})")
+
+    if not permission.can_read:
+        # A fallback that grants nothing is the safe, expected shape.
+        return
+
+    if count in _FALLBACK_WARN_AT or count % _FALLBACK_WARN_EVERY == 0:
+        logger.warning(
+            f"DEFAULT_MLFLOW_PERMISSION granted {permission.name} on {resource_type}={resource_id} to {username} "
+            f"because no explicit permission exists ({count} such grants for {resource_type} so far). "
+            "Access is coming from configuration rather than a permission record. "
+            "See issue #293: this default is changing to NO_PERMISSIONS in a future major version."
+        )
+
+
 def resolve_permission(resource_type: str, resource_id: str, username: str, **kwargs) -> PermissionResult:
     """Single entry point for all permission resolution. Per D-01 (REFAC-01).
 
@@ -338,6 +397,12 @@ def resolve_permission(resource_type: str, resource_id: str, username: str, **kw
     sources_config = builder(resource_id, username, **kwargs)
     result = get_permission_from_store_or_default(sources_config)
     result = _apply_workspace_fallback(result, username)
+
+    # Recorded here rather than where the fallback is constructed, because this is the
+    # only layer that knows WHICH resource and user it was for. Checked after the
+    # workspace fallback, which may already have replaced it with a real decision.
+    if result.kind == "fallback":
+        record_permission_fallback(resource_type, resource_id, username, result.permission)
 
     cache.set(cache_key, result)
     return result

--- a/mlflow_oidc_auth/utils/permissions.py
+++ b/mlflow_oidc_auth/utils/permissions.py
@@ -329,6 +329,12 @@ _FALLBACK_COUNTS: Dict[str, int] = {}
 _FALLBACK_WARN_AT = frozenset((1, 10, 100, 1_000))
 _FALLBACK_WARN_EVERY = 10_000
 
+# A bounded, in-process sample of which resources were reached through the default.
+# Bounded because it is never drained: an unbounded set keyed on caller-supplied ids
+# would be a memory leak on a busy server.
+_FALLBACK_SAMPLES: Dict[str, list] = {}
+_FALLBACK_SAMPLE_LIMIT = 50
+
 
 def get_permission_fallback_counts() -> Dict[str, int]:
     """How many times each resource type has fallen back to the configured default.
@@ -338,9 +344,19 @@ def get_permission_fallback_counts() -> Dict[str, int]:
     return dict(_FALLBACK_COUNTS)
 
 
+def get_permission_fallback_samples() -> Dict[str, list]:
+    """Which resources were reached through the configured default, per resource type.
+
+    Capped at _FALLBACK_SAMPLE_LIMIT ids per type — enough to start a migration, small
+    enough not to grow without bound. Deliberately not logged: see record_permission_fallback.
+    """
+    return {resource_type: list(ids) for resource_type, ids in _FALLBACK_SAMPLES.items()}
+
+
 def reset_permission_fallback_counts() -> None:
-    """Clear the counters (tests)."""
+    """Clear the counters and samples (tests)."""
     _FALLBACK_COUNTS.clear()
+    _FALLBACK_SAMPLES.clear()
 
 
 def record_permission_fallback(resource_type: str, resource_id: str, username: str, permission) -> None:
@@ -365,7 +381,17 @@ def record_permission_fallback(resource_type: str, resource_id: str, username: s
     count = _FALLBACK_COUNTS.get(resource_type, 0) + 1
     _FALLBACK_COUNTS[resource_type] = count
 
-    logger.debug(f"Permission fallback: {resource_type}={resource_id} user={username} -> {permission.name} (occurrence {count})")
+    # Resource ids are recorded in-process rather than written to the log. One of the
+    # resource types here is the GATEWAY SECRET, whose id is the secret's NAME — not its
+    # value, but a name like "openai-prod-key" is still something that does not belong in
+    # a log aggregator, and CodeQL flags the whole parameter as tainted for exactly that
+    # reason. get_permission_fallback_samples() gives an operator the same detail on
+    # demand, without every deployment shipping identifiers off-host by default.
+    samples = _FALLBACK_SAMPLES.setdefault(resource_type, [])
+    if len(samples) < _FALLBACK_SAMPLE_LIMIT and resource_id not in samples:
+        samples.append(resource_id)
+
+    logger.debug("Permission fallback: %s granted %s to %s (occurrence %d)", resource_type, permission.name, username, count)
 
     if not permission.can_read:
         # A fallback that grants nothing is the safe, expected shape.
@@ -373,9 +399,10 @@ def record_permission_fallback(resource_type: str, resource_id: str, username: s
 
     if count in _FALLBACK_WARN_AT or count % _FALLBACK_WARN_EVERY == 0:
         logger.warning(
-            f"DEFAULT_MLFLOW_PERMISSION granted {permission.name} on {resource_type}={resource_id} to {username} "
+            f"DEFAULT_MLFLOW_PERMISSION granted {permission.name} on a {resource_type} to {username} "
             f"because no explicit permission exists ({count} such grants for {resource_type} so far). "
             "Access is coming from configuration rather than a permission record. "
+            "Call get_permission_fallback_samples() for the affected resource ids, or enable DEBUG logging. "
             "See issue #293: this default is changing to NO_PERMISSIONS in a future major version."
         )
 


### PR DESCRIPTION
Step **B** of #293. Stacked on #294 — merge that first.

## The bug

`RESTRICT_RESOURCE_CREATION=true` on a default install **denies nothing**.

The creation validators require EDIT+ on the resource *name*, resolved from name regex and group-regex rules with a workspace fallback. With workspaces disabled and no regex match, that resolution lands on `DEFAULT_MLFLOW_PERMISSION` — which ships as `MANAGE`, and `MANAGE` grants `can_update`. Every user can still create every experiment and registered model, exactly as before, while the configuration reads as though creation were locked down.

`docs/permissions.md` already documents this. The documentation was evidently not enough — which is the argument for a startup warning rather than more prose.

## Why warn rather than refuse

The combination isn't *dangerous*, it's *ineffective*. Refusing to start would take down running deployments on upgrade over a setting that was already doing nothing. The message names both ways out: lower the default below `EDIT` so only regex matches may create, or enable workspaces and use the workspace creation gate.

Silent when the setup actually enforces something — a default below EDIT, workspaces enabled, the flag off, or an unparseable default (reported elsewhere).

## Verification

Checked against a **real `AppConfig`**, not just the unit stub. Worth noting: the repo's own `.env` enables workspaces, so my first probe correctly stayed silent — the warning only appears once workspaces are off. That's the check working, and it's the kind of thing a stub-only test would have hidden.

```
RESTRICT_RESOURCE_CREATION=true DEFAULT_MLFLOW_PERMISSION=MANAGE MLFLOW_ENABLE_WORKSPACES=false
  → WARNING RESTRICT_RESOURCE_CREATION is enabled but has no effect: ...

RESTRICT_RESOURCE_CREATION=true DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS MLFLOW_ENABLE_WORKSPACES=false
  → (silent)
```

One test pins the premise that `MANAGE` grants `can_update` — if that ever changes, this stops being a valid warning and the test says so. Another pins that the check is actually *called* during config construction, since a warning nothing invokes is worthless.

**3070 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)