### PR TITLE
docs(auth): announce and document the deny-by-default migration (#293)

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -202,6 +202,68 @@ PERMISSION_SOURCE_ORDER=regex,group-regex,user,group
 DEFAULT_MLFLOW_PERMISSION=READ
 ```
 
+## Migrating to deny-by-default
+
+> **The shipped `DEFAULT_MLFLOW_PERMISSION` changes from `MANAGE` to `NO_PERMISSIONS` in the next major version** ([#293](https://github.com/mlflow-oidc/mlflow-oidc-auth/issues/293)).
+
+### What changes, and for whom
+
+`DEFAULT_MLFLOW_PERMISSION` decides access when a resource has **no** user, group, regex or group-regex grant. Today it ships as `MANAGE`, so a fresh install is open by default: every authenticated user can read, edit and delete every experiment and registered model until grants exist.
+
+You are affected only if **all** of the following hold:
+
+- you do **not** set `DEFAULT_MLFLOW_PERMISSION` explicitly, **and**
+- workspaces are disabled (`MLFLOW_ENABLE_WORKSPACES=false`), **and**
+- some users reach resources through the fallback rather than through a grant
+
+With workspaces enabled the global default is not used as a resource fallback at all — workspace permissions take that role — so workspace deployments are unaffected.
+
+### Pinning current behaviour
+
+If you want no change at all, set the value explicitly before upgrading:
+
+```bash
+DEFAULT_MLFLOW_PERMISSION=MANAGE
+```
+
+This is supported and will keep working. The change is to the *default*, not to the option.
+
+### Migrating properly (recommended)
+
+**1. Find out how much access is coming from the fallback.** Every permission decision made by the default is logged, and grants are warned about:
+
+```
+WARNING DEFAULT_MLFLOW_PERMISSION granted MANAGE on experiment=12 to alice
+        because no explicit permission exists (1 such grants for experiment so far)
+```
+
+Warnings are throttled (occurrences 1, 10, 100, 1000, …), so treat them as a signal to investigate, not a count. Enable `DEBUG` logging to see every occurrence with its resource and user.
+
+**2. Create the grants those users actually need.** For each resource that showed up, grant explicitly — to a user, a group, or a name-regex rule. Group and regex grants scale better than per-user ones:
+
+```bash
+# via the UI:  Permissions → Experiments / Models
+# or the REST API under /oidc/api/
+```
+
+**3. Verify with the default already lowered**, in staging:
+
+```bash
+DEFAULT_MLFLOW_PERMISSION=NO_PERMISSIONS
+```
+
+Anything still reachable is reachable because of a real grant. Anything that breaks was relying on the fallback and needs a grant from step 2.
+
+**4. Upgrade.** With the value set explicitly, or with the grants in place, the new default is a no-op for you.
+
+### If you upgrade without migrating
+
+Users lose access to resources they had no explicit grant for, and see `403`. Nothing is deleted and no permission records change — set `DEFAULT_MLFLOW_PERMISSION=MANAGE` to restore the previous behaviour immediately while you work through the steps above.
+
+### Why this is changing
+
+Open-by-default is a reasonable *adoption* choice — install the plugin and nothing breaks — but it is the wrong default for a plugin whose purpose is multi-tenant isolation. It also silently defeats `RESTRICT_RESOURCE_CREATION`: with a permissive default, that flag denies nothing (the plugin now warns at startup when this combination is configured).
+
 ## Examples
 
 ### Direct User Permission

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -200,8 +200,48 @@ class AppConfig:
         # API documentation settings
         self.ENABLE_API_DOCS = config_manager.get_bool("ENABLE_API_DOCS", default=False)
 
-        # Runs last: it reads settings loaded above.
+        # Run last: these read settings loaded above.
         self._warn_if_resource_creation_restriction_is_inert()
+        self._warn_if_default_permission_is_permissive()
+
+    def _warn_if_default_permission_is_permissive(self) -> None:
+        """Announce that an open-by-default deployment will change on the next major.
+
+        DEFAULT_MLFLOW_PERMISSION decides access when a resource has no user, group, regex
+        or group-regex grant. Shipping MANAGE means a fresh install is open by default:
+        every authenticated user can read, edit and delete every experiment and model
+        until grants exist. That default is changing to NO_PERMISSIONS (issue #293), which
+        is a breaking change for anyone relying on it.
+
+        Warned at startup so the change is not a surprise on upgrade, and so operators can
+        act on it while the current release still behaves permissively. The counters added
+        alongside this (get_permission_fallback_counts) show how much access is actually
+        coming from the fallback in a running deployment.
+
+        Silent when the deployment is unaffected: a default that grants nothing, or
+        workspaces enabled — with workspaces, workspace permissions take the fallback role
+        and the global default is not consulted as a resource fallback at all.
+        """
+        if self.MLFLOW_ENABLE_WORKSPACES:
+            return
+
+        from mlflow_oidc_auth.permissions import get_permission
+
+        try:
+            default_permission = get_permission(self.DEFAULT_MLFLOW_PERMISSION)
+        except Exception:
+            return
+
+        if not default_permission.can_read:
+            return
+
+        logger.warning(
+            f"DEFAULT_MLFLOW_PERMISSION={self.DEFAULT_MLFLOW_PERMISSION} grants access to every resource that has no "
+            "explicit permission, so any authenticated user can reach resources nobody granted them. "
+            "This default becomes NO_PERMISSIONS in the next major version (issue #293). "
+            "See docs/permissions.md 'Migrating to deny-by-default' — set the value explicitly now to pin "
+            "current behaviour, or create the grants your users rely on before upgrading."
+        )
 
     def _warn_if_resource_creation_restriction_is_inert(self) -> None:
         """Warn when RESTRICT_RESOURCE_CREATION is enabled but cannot deny anything.

--- a/mlflow_oidc_auth/tests/test_config.py
+++ b/mlflow_oidc_auth/tests/test_config.py
@@ -348,9 +348,13 @@ class TestAppConfig(unittest.TestCase):
 
         with patch("mlflow_oidc_auth.config.logger") as mock_logger:
             config = AppConfig()
-            mock_logger.warning.assert_called_once()
-            warning_msg = mock_logger.warning.call_args[0][0]
-            self.assertIn("SECRET_KEY is not configured", warning_msg)
+            # Assert on THIS warning, not on the total count. AppConfig emits other
+            # startup warnings (an inert RESTRICT_RESOURCE_CREATION, a permissive
+            # DEFAULT_MLFLOW_PERMISSION), and whether they fire depends on the ambient
+            # environment — a local .env can silence them while CI, which has none,
+            # sees them. Counting warnings made this test pass locally and fail in CI.
+            secret_key_warnings = [call.args[0] for call in mock_logger.warning.call_args_list if "SECRET_KEY is not configured" in call.args[0]]
+            self.assertEqual(len(secret_key_warnings), 1)
             # Should still generate a usable key
             self.assertEqual(len(config.SECRET_KEY), 32)
 
@@ -359,7 +363,8 @@ class TestAppConfig(unittest.TestCase):
         with patch.dict(os.environ, {"SECRET_KEY": "my-production-secret"}):
             with patch("mlflow_oidc_auth.config.logger") as mock_logger:
                 config = AppConfig()
-                mock_logger.warning.assert_not_called()
+                secret_key_warnings = [call.args[0] for call in mock_logger.warning.call_args_list if "SECRET_KEY" in call.args[0]]
+                self.assertEqual(secret_key_warnings, [], "a configured SECRET_KEY must not warn about SECRET_KEY")
                 self.assertEqual(config.SECRET_KEY, "my-production-secret")
 
     def test_session_cookie_defaults(self):

--- a/mlflow_oidc_auth/tests/test_restrict_creation_warning.py
+++ b/mlflow_oidc_auth/tests/test_restrict_creation_warning.py
@@ -66,3 +66,42 @@ def test_the_check_runs_during_config_construction():
         config_module.AppConfig()
 
     check.assert_called_once()
+
+
+class TestPermissiveDefaultAnnouncement:
+    """An open-by-default deployment must be told the default is changing (#293)."""
+
+    @staticmethod
+    def _warn_for(default_permission, workspaces):
+        stub = MagicMock()
+        stub.MLFLOW_ENABLE_WORKSPACES = workspaces
+        stub.DEFAULT_MLFLOW_PERMISSION = default_permission
+
+        with patch.object(config_module, "logger") as logger:
+            config_module.AppConfig._warn_if_default_permission_is_permissive(stub)
+
+        return logger.warning.call_args.args[0] if logger.warning.called else None
+
+    @pytest.mark.parametrize("default_permission", ["MANAGE", "EDIT", "READ"])
+    def test_a_granting_default_is_announced(self, default_permission):
+        warning = self._warn_for(default_permission, workspaces=False)
+
+        assert warning is not None
+        assert "becomes NO_PERMISSIONS in the next major version" in warning
+        assert "docs/permissions.md" in warning, "the warning must point at the migration"
+
+    def test_a_denying_default_is_already_migrated(self):
+        assert self._warn_for("NO_PERMISSIONS", workspaces=False) is None
+
+    def test_workspace_deployments_are_unaffected(self):
+        """With workspaces, workspace permissions take the fallback role entirely."""
+        assert self._warn_for("MANAGE", workspaces=True) is None
+
+    def test_an_unparseable_default_is_reported_elsewhere(self):
+        assert self._warn_for("NOT_A_PERMISSION", workspaces=False) is None
+
+    def test_the_announcement_runs_during_config_construction(self):
+        with patch.object(config_module.AppConfig, "_warn_if_default_permission_is_permissive") as check:
+            config_module.AppConfig()
+
+        check.assert_called_once()


### PR DESCRIPTION
Step **C** of #293. Stacked on #295 — merge #294 → #295 → this.

**No behaviour change.** This is what makes step D safe to ship.

## Startup announcement

Deployments that are open by default now get told, at startup, that the default is changing — while the current release still behaves permissively, so it isn't discovered on upgrade:

```
WARNING DEFAULT_MLFLOW_PERMISSION=MANAGE grants access to every resource that has no
        explicit permission, so any authenticated user can reach resources nobody granted
        them. This default becomes NO_PERMISSIONS in the next major version (issue #293).
        See docs/permissions.md 'Migrating to deny-by-default' ...
```

The warning points at the guide rather than restating it. Silent for deployments already unaffected: a default that grants nothing, or workspaces enabled (workspace permissions take the fallback role, and the global default isn't consulted as a resource fallback at all).

## The migration guide

New `docs/permissions.md` section covering:

- **Who is actually affected** — all three conditions must hold (no explicit setting, workspaces off, users relying on the fallback). Workspace deployments are unaffected, and saying so plainly avoids needless churn.
- **Pinning current behaviour** — `DEFAULT_MLFLOW_PERMISSION=MANAGE` stays supported. The change is to the *default*, not the option.
- **A four-step migration** — use the fallback logging from #294 to find which access comes from the default, create those grants (group/regex scale better than per-user), verify in staging with the default already lowered, then upgrade.
- **What happens if you upgrade without migrating** — 403s, nothing deleted, one setting restores the old behaviour. Worth stating explicitly so nobody panics mid-incident.
- **Why** — open-by-default is a reasonable adoption choice but the wrong default for a multi-tenant isolation plugin, and it silently defeats `RESTRICT_RESOURCE_CREATION`.

## Verification

Tested against a real `AppConfig` as well as unit stubs, including the wiring assertion that the check is actually called during construction. **3070 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)