### PR TITLE
feat(auth): add an admin endpoint to create groups

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -239,7 +239,17 @@ Base path: `/api/2.0/mlflow/permissions/groups`
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
 | GET | `/api/2.0/mlflow/permissions/groups` | Authenticated | List all groups |
+| POST | `/api/2.0/mlflow/permissions/groups` | Admin | Create a group |
 | GET | `/api/2.0/mlflow/permissions/groups/{group_name}/users` | Admin | List group members |
+
+**`POST /api/2.0/mlflow/permissions/groups` request:**
+```json
+{
+  "group_name": "data-team"
+}
+```
+
+Groups are otherwise created from the identity provider claims when a member signs in, so a group cannot be granted permissions before its first login. Creating a group up front lifts that ordering constraint for automated provisioning. The call is idempotent: it returns `201` when the group is created and `200` when it already exists.
 
 ### Group Direct Permissions
 
@@ -262,7 +272,7 @@ Same CRUD pattern as user permissions, but scoped to groups:
 | PATCH | `/{group_name}/{resource-type}-patterns/{id}` | Admin | Update pattern permission |
 | DELETE | `/{group_name}/{resource-type}-patterns/{id}` | Admin | Delete pattern permission |
 
-**Total: 69 group permission endpoints** (2 group-level + 7 resource types x ~9.5 operations each)
+**Total: 70 group permission endpoints** (3 group-level + 7 resource types x ~9.5 operations each)
 
 ---
 

--- a/mlflow_oidc_auth/models/__init__.py
+++ b/mlflow_oidc_auth/models/__init__.py
@@ -13,6 +13,7 @@ from mlflow_oidc_auth.models.experiment import (
 )
 from mlflow_oidc_auth.models.gateway import GatewayPermission, GatewayRegexCreate
 from mlflow_oidc_auth.models.group import (
+    CreateGroupRequest,
     GroupExperimentPermission,
     GroupExperimentPermissionItem,
     GroupExperimentRegexPermissionItem,
@@ -86,6 +87,7 @@ __all__ = [
     "ExperimentPermissionSummary",
     "ExperimentSummary",
     "ExperimentRegexPermission",
+    "CreateGroupRequest",
     "GroupUser",
     "GroupExperimentPermission",
     "GroupListResponse",

--- a/mlflow_oidc_auth/models/group.py
+++ b/mlflow_oidc_auth/models/group.py
@@ -3,6 +3,12 @@ from typing import List, Literal, Optional
 from pydantic import BaseModel, Field, RootModel
 
 
+class CreateGroupRequest(BaseModel):
+    """Request model for creating groups."""
+
+    group_name: str = Field(..., description="Name of the group to create")
+
+
 class GroupUser(BaseModel):
     """
     User information within a group.

--- a/mlflow_oidc_auth/routers/group_permissions.py
+++ b/mlflow_oidc_auth/routers/group_permissions.py
@@ -8,12 +8,14 @@ experiment, model, and prompt permissions at the group level.
 from typing import List
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
+from fastapi.responses import JSONResponse
 from mlflow.server.handlers import _get_tracking_store
 
 from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.dependencies import check_admin_permission, check_experiment_manage_permission
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.models import (
+    CreateGroupRequest,
     ExperimentPermission,
     ExperimentRegexCreate,
     GatewayPermission,
@@ -57,7 +59,7 @@ group_permissions_router = APIRouter(
     },
 )
 
-LIST_GROUPS = ""
+GROUPS_ROOT = ""
 
 GROUP_EXPERIMENT_PERMISSIONS = "/{group_name:path}/experiments"
 GROUP_EXPERIMENT_PERMISSION_DETAIL = "/{group_name:path}/experiments/{experiment_id}"
@@ -103,7 +105,7 @@ GROUP_GATEWAY_SECRET_PATTERN_PERMISSION_DETAIL = "/{group_name:path}/gateways/se
 
 
 @group_permissions_router.get(
-    LIST_GROUPS,
+    GROUPS_ROOT,
     summary="List groups",
     description="Retrieves a list of all groups in the system.",
     response_model=GroupListResponse,
@@ -139,6 +141,66 @@ async def list_groups(username: str = Depends(get_username)) -> GroupListRespons
     except Exception as e:
         logger.error(f"Error listing groups: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to retrieve groups")
+
+
+@group_permissions_router.post(
+    GROUPS_ROOT,
+    summary="Create a group",
+    description="Creates a group in the system. Only admins can create groups. Creating a group that already exists is a no-op.",
+    tags=["groups"],
+)
+async def create_group(
+    group_request: CreateGroupRequest = Body(..., description="Group creation details"),
+    admin_username: str = Depends(check_admin_permission),
+) -> JSONResponse:
+    """
+    Create a group in the system.
+
+    Only administrators can create groups. Groups are otherwise created from the identity
+    provider claims when a member signs in, which means a group cannot be granted
+    permissions before its first login. This endpoint creates the group up front so that
+    permission provisioning can be automated.
+
+    Parameters:
+    -----------
+    group_request : CreateGroupRequest
+        The group creation request containing the group name.
+    admin_username : str
+        The authenticated admin username (injected by dependency).
+
+    Returns:
+    --------
+    JSONResponse
+        A JSON response reporting whether the group was created or already existed.
+
+    Raises:
+    -------
+    HTTPException
+        If the group name is empty or there is an error creating the group.
+    """
+    group_name = group_request.group_name.strip()
+    if not group_name:
+        raise HTTPException(status_code=400, detail="Group name must not be empty")
+
+    try:
+        if group_name in store.get_groups():
+            return JSONResponse(content={"message": f"Group {group_name} already exists"})
+
+        # Same idempotent upsert the login flow uses, so a group created concurrently
+        # between the lookup above and this call is not an error.
+        store.populate_groups([group_name])
+        emit_audit_event(
+            "group.create",
+            actor=admin_username,
+            resource_type="group",
+            resource_id=group_name,
+        )
+
+        return JSONResponse(content={"message": f"Group {group_name} successfully created"}, status_code=201)
+
+    except Exception as e:
+        logger.error(f"Error creating group: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to create group")
 
 
 @group_permissions_router.get(

--- a/mlflow_oidc_auth/tests/routers/test_group_permissions_nongateway.py
+++ b/mlflow_oidc_auth/tests/routers/test_group_permissions_nongateway.py
@@ -116,6 +116,50 @@ class TestListGroups:
 
 
 # ========================================================================================
+# GROUP CREATION
+# ========================================================================================
+
+
+@pytest.mark.usefixtures("authenticated_session", "override_admin")
+class TestCreateGroup:
+    """Tests for create_group endpoint."""
+
+    def test_create_group_success(self, authenticated_client, mock_store):
+        """Test creating a group that does not exist yet."""
+        mock_store.get_groups.return_value = ["devs"]
+        resp = authenticated_client.post(GROUP_BASE, json={"group_name": "analysts"})
+        assert resp.status_code == 201
+        mock_store.populate_groups.assert_called_once_with(["analysts"])
+
+    def test_create_group_already_exists(self, authenticated_client, mock_store):
+        """Test creating a group that already exists leaves it untouched."""
+        mock_store.get_groups.return_value = ["devs"]
+        resp = authenticated_client.post(GROUP_BASE, json={"group_name": "devs"})
+        assert resp.status_code == 200
+        mock_store.populate_groups.assert_not_called()
+
+    def test_create_group_strips_surrounding_whitespace(self, authenticated_client, mock_store):
+        """Test the group name is trimmed before it reaches the store."""
+        mock_store.get_groups.return_value = []
+        resp = authenticated_client.post(GROUP_BASE, json={"group_name": "  analysts  "})
+        assert resp.status_code == 201
+        mock_store.populate_groups.assert_called_once_with(["analysts"])
+
+    def test_create_group_blank_name(self, authenticated_client, mock_store):
+        """Test rejecting a group name that is empty once trimmed."""
+        resp = authenticated_client.post(GROUP_BASE, json={"group_name": "   "})
+        assert resp.status_code == 400
+        mock_store.populate_groups.assert_not_called()
+
+    def test_create_group_error(self, authenticated_client, mock_store):
+        """Test error handling when group creation fails."""
+        mock_store.get_groups.return_value = []
+        mock_store.populate_groups.side_effect = Exception("DB error")
+        resp = authenticated_client.post(GROUP_BASE, json={"group_name": "analysts"})
+        assert resp.status_code == 500
+
+
+# ========================================================================================
 # GROUP USERS
 # ========================================================================================
 


### PR DESCRIPTION
## Problem

Group rows are only ever created as a side effect of a login: the OIDC callback calls `store.populate_groups()` with the claims of the user who just signed in. A group therefore exists in the `groups` table only after at least one of its members has signed in at least once.

That makes it impossible to grant a permission to a group ahead of time. `store.create_workspace_group_permission()` — and every other group grant that resolves through `repository/utils.get_group()` — raises `Group '<name>' not found` for a group nobody has logged in with yet.

For anyone provisioning permissions declaratively (a CI job reconciling workspaces and group grants from a config file, a bootstrap script, Terraform) this is an ordering constraint that cannot be satisfied automatically: the job has to wait for a human from each group to log in before it can grant that group anything, and it fails until that happens.

## Change

Adds `POST /api/2.0/mlflow/permissions/groups` to the existing `group_permissions_router`, on the same collection URI as the `GET` that already lists groups.

- Admin only, via `Depends(check_admin_permission)`.
- Idempotent. It reuses `store.populate_groups()` — the same upsert the login flow uses — rather than `store.create_group()`, which raises `RESOURCE_ALREADY_EXISTS`. Returns `201` when the group is created and `200` when it already existed, so a reconciliation job can call it unconditionally on every run.
- Emits a `group.create` audit event.
- Returns `400` for a name that is empty once trimmed, and trims surrounding whitespace otherwise.

```bash
curl -u admin:token -X POST https://mlflow.example.com/api/2.0/mlflow/permissions/groups \
  -H 'Content-Type: application/json' \
  -d '{"group_name": "data-team"}'
```

The handler deliberately mirrors `create_new_user` in `routers/users.py`, which is the existing idempotent-create endpoint in this codebase, so the response shape and the 201/200 split stay consistent with it.

The empty-path constant `LIST_GROUPS` is renamed to `GROUPS_ROOT` now that `GET` and `POST` share it, matching `USERS_ROOT` in the users router. That rename is the only change to existing code.

I am happy to move this to a separate `/api/2.0/mlflow/groups` router if you would rather keep group lifecycle management out of the `permissions` path — I put it on the existing collection because that is where `GET /permissions/groups` already lives.

## Tests

Five tests in `mlflow_oidc_auth/tests/routers/test_group_permissions_nongateway.py`, covering create, already-exists, whitespace trimming, blank name and store failure. The full backend suite passes locally (3135 passed) and Black is clean.

## Docs

`docs/api-reference.md`: new row in the Group Listing table, a request example, a note on why the endpoint exists and its idempotency, and the group endpoint total bumped from 69 to 70.

Made with [Cursor](https://cursor.com)