### PR TITLE
feat(auth): filter OpenAI model discovery by gateway permission

### DIFF
--- a/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
@@ -12,6 +12,7 @@ It mirrors the upstream ``add_fastapi_permission_middleware`` from
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -23,6 +24,8 @@ from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.utils.permissions import can_use_gateway_endpoint
 
 logger = get_logger()
+
+_MLFLOW_MODELS_PATH = "/gateway/mlflow/v1/models"
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +94,9 @@ def _get_gateway_validator(
 
     Validates that the user has USE permission on the target gateway endpoint.
     """
+
+    if path == _MLFLOW_MODELS_PATH:
+        return _get_require_authentication_validator()
 
     async def validator(username: str, request: Request) -> bool:
         body: dict[str, Any] | None = None
@@ -170,6 +176,50 @@ def _find_fastapi_validator(
     return None
 
 
+async def _filter_gateway_models_response(response, username: str):
+    """Keep only models backed by gateway endpoints the user can USE."""
+    if response.status_code != 200:
+        return response
+
+    try:
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk.encode() if isinstance(chunk, str) else bytes(chunk))
+
+        data = json.loads(b"".join(chunks))
+        models = data.get("data")
+        if not isinstance(models, list):
+            raise ValueError("Models response does not contain a data list")
+
+        visible_models = []
+        for model in models:
+            endpoint_name = model.get("id") if isinstance(model, dict) else None
+            if not isinstance(endpoint_name, str):
+                continue
+            try:
+                if can_use_gateway_endpoint(endpoint_name, username):
+                    visible_models.append(model)
+            except Exception as e:
+                logger.error(
+                    "Gateway models permission check failed for endpoint %s: %s",
+                    endpoint_name,
+                    type(e).__name__,
+                )
+
+        data["data"] = visible_models
+    except Exception as e:
+        logger.error("Gateway models response filtering failed: %s", type(e).__name__)
+        return PlainTextResponse("Permission denied", status_code=500)
+
+    headers = {key: value for key, value in response.headers.items() if key.lower() not in {"content-length", "content-type"}}
+    return JSONResponse(
+        content=data,
+        status_code=response.status_code,
+        headers=headers,
+        background=response.background,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Middleware registration
 # ---------------------------------------------------------------------------
@@ -223,4 +273,7 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
                 status_code=403,
             )
 
-        return await call_next(request)
+        response = await call_next(request)
+        if request.method == "GET" and path == _MLFLOW_MODELS_PATH:
+            return await _filter_gateway_models_response(response, username)
+        return response

--- a/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
@@ -209,15 +209,15 @@ async def _filter_gateway_models_response(response, username: str):
         data["data"] = visible_models
     except Exception as e:
         logger.error("Gateway models response filtering failed: %s", type(e).__name__)
-        return PlainTextResponse("Permission denied", status_code=500)
+        return PlainTextResponse("Internal server error", status_code=500)
 
-    headers = {key: value for key, value in response.headers.items() if key.lower() not in {"content-length", "content-type"}}
-    return JSONResponse(
+    filtered_response = JSONResponse(
         content=data,
         status_code=response.status_code,
-        headers=headers,
         background=response.background,
     )
+    filtered_response.raw_headers.extend((key, value) for key, value in response.raw_headers if key.lower() not in {b"content-length", b"content-type"})
+    return filtered_response
 
 
 # ---------------------------------------------------------------------------

--- a/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
@@ -6,7 +6,7 @@ This module tests the OIDC-aware permission middleware for FastAPI-native routes
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
@@ -311,6 +311,16 @@ def _create_app_with_auth(username=None, is_admin=False):
     async def gateway_invocations(endpoint_name: str):
         return {"endpoint": endpoint_name}
 
+    @app.get("/gateway/mlflow/v1/models")
+    async def list_gateway_models():
+        return {
+            "object": "list",
+            "data": [
+                {"id": "allowed-endpoint", "object": "model", "created": 1, "owned_by": "mlflow"},
+                {"id": "denied-endpoint", "object": "model", "created": 2, "owned_by": "mlflow"},
+            ],
+        }
+
     @app.get("/v1/traces")
     async def otel_traces():
         return {"traces": []}
@@ -361,6 +371,13 @@ class TestFastapiPermissionMiddlewareIntegration:
         response = client.get("/gateway/my-ep/mlflow/invocations")
         assert response.status_code == 401
 
+    def test_unauthenticated_models_returns_401(self):
+        """Test that the models route requires authentication."""
+        app = self._create_app_with_middleware()
+        client = TestClient(app)
+        response = client.get("/gateway/mlflow/v1/models")
+        assert response.status_code == 401
+
     def test_unauthenticated_otel_returns_401(self):
         """Test that OTel route without auth returns 401."""
         app = self._create_app_with_middleware()
@@ -389,6 +406,20 @@ class TestFastapiPermissionMiddlewareIntegration:
         response = client.get("/gateway/my-ep/mlflow/invocations")
         assert response.status_code == 200
         assert response.json() == {"endpoint": "my-ep"}
+
+    @patch("mlflow_oidc_auth.middleware.fastapi_permission_middleware.can_use_gateway_endpoint")
+    def test_admin_models_returns_all_endpoints(self, mock_can_use):
+        """Test that admins receive the complete models list without per-endpoint checks."""
+        app = _create_app_with_auth(username="admin@example.com", is_admin=True)
+        client = TestClient(app)
+        response = client.get("/gateway/mlflow/v1/models")
+
+        assert response.status_code == 200
+        assert [model["id"] for model in response.json()["data"]] == [
+            "allowed-endpoint",
+            "denied-endpoint",
+        ]
+        mock_can_use.assert_not_called()
 
     def test_admin_otel_passes(self):
         """Test that admin user passes OTel check."""
@@ -422,6 +453,43 @@ class TestFastapiPermissionMiddlewareIntegration:
         client = TestClient(app)
         response = client.get("/gateway/my-ep/mlflow/invocations")
         assert response.status_code == 403
+
+    @patch("mlflow_oidc_auth.middleware.fastapi_permission_middleware.can_use_gateway_endpoint")
+    def test_regular_user_models_returns_only_usable_endpoints(self, mock_can_use):
+        """Test that non-admin users only receive endpoints they can USE."""
+        mock_can_use.side_effect = lambda endpoint_name, username: endpoint_name == "allowed-endpoint"
+        app = _create_app_with_auth(username="user@example.com", is_admin=False)
+        client = TestClient(app)
+        response = client.get("/gateway/mlflow/v1/models")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "object": "list",
+            "data": [{"id": "allowed-endpoint", "object": "model", "created": 1, "owned_by": "mlflow"}],
+        }
+        mock_can_use.assert_has_calls(
+            [
+                call("allowed-endpoint", "user@example.com"),
+                call("denied-endpoint", "user@example.com"),
+            ]
+        )
+
+    @patch("mlflow_oidc_auth.middleware.fastapi_permission_middleware.can_use_gateway_endpoint")
+    def test_models_permission_error_excludes_endpoint(self, mock_can_use):
+        """Test that a failed permission lookup cannot expose its endpoint."""
+
+        def check_permission(endpoint_name, username):
+            if endpoint_name == "denied-endpoint":
+                raise RuntimeError("permission backend unavailable")
+            return True
+
+        mock_can_use.side_effect = check_permission
+        app = _create_app_with_auth(username="user@example.com", is_admin=False)
+        client = TestClient(app)
+        response = client.get("/gateway/mlflow/v1/models")
+
+        assert response.status_code == 200
+        assert [model["id"] for model in response.json()["data"]] == ["allowed-endpoint"]
 
     def test_flask_route_passes_through(self):
         """Test that Flask-handled routes pass through without permission check."""

--- a/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from starlette.responses import PlainTextResponse
+from starlette.responses import JSONResponse, PlainTextResponse
 
 # ---------------------------------------------------------------------------
 # Unit tests: _extract_gateway_endpoint_name
@@ -313,13 +313,17 @@ def _create_app_with_auth(username=None, is_admin=False):
 
     @app.get("/gateway/mlflow/v1/models")
     async def list_gateway_models():
-        return {
-            "object": "list",
-            "data": [
-                {"id": "allowed-endpoint", "object": "model", "created": 1, "owned_by": "mlflow"},
-                {"id": "denied-endpoint", "object": "model", "created": 2, "owned_by": "mlflow"},
-            ],
-        }
+        response = JSONResponse(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "allowed-endpoint", "object": "model", "created": 1, "owned_by": "mlflow"},
+                    {"id": "denied-endpoint", "object": "model", "created": 2, "owned_by": "mlflow"},
+                ],
+            }
+        )
+        response.raw_headers.extend([(b"x-model-metadata", b"first"), (b"x-model-metadata", b"second")])
+        return response
 
     @app.get("/v1/traces")
     async def otel_traces():
@@ -467,6 +471,7 @@ class TestFastapiPermissionMiddlewareIntegration:
             "object": "list",
             "data": [{"id": "allowed-endpoint", "object": "model", "created": 1, "owned_by": "mlflow"}],
         }
+        assert response.headers.get_list("x-model-metadata") == ["first", "second"]
         mock_can_use.assert_has_calls(
             [
                 call("allowed-endpoint", "user@example.com"),


### PR DESCRIPTION
## Summary

Add OIDC-aware support for MLflow's OpenAI-compatible gateway model discovery route.

- allow authenticated requests to `GET /gateway/mlflow/v1/models`
- return all gateway endpoints to admins
- filter non-admin responses to endpoints the user can `USE`
- fail closed when an endpoint permission lookup fails
- preserve response metadata while rebuilding the filtered JSON response

## Context

This is a companion change for MLflow issue https://github.com/mlflow/mlflow/issues/24164.

It also relates to the already merged MLflow WebSocket compatibility fix https://github.com/mlflow/mlflow/pull/24274, whose description identifies `GET .../v1/models` as a separate discovery gap.

The upstream MLflow PR is waiting for the issue's `ready` label. This PR is opened as a draft until that contract is accepted.

## Tests

- `pytest -q mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py`
  - 49 passed
- `black --check mlflow_oidc_auth/middleware/fastapi_permission_middleware.py mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py`
