### PR TITLE
fix(routers): serve plugin endpoints under /ajax-api as well as /api

### DIFF
--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -8,7 +8,7 @@ to the default MLflow server when OIDC authentication is required.
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from mlflow.server import app
 from mlflow.version import VERSION
 from starlette.middleware.sessions import (
@@ -28,7 +28,7 @@ from mlflow_oidc_auth.middleware import (
     add_fastapi_permission_middleware,
 )
 from mlflow_oidc_auth.oauth import ensure_oidc_client_registered
-from mlflow_oidc_auth.routers import get_all_routers
+from mlflow_oidc_auth.routers import ajax_alias_router, get_all_routers
 
 logger = get_logger()
 
@@ -101,6 +101,19 @@ def _seed_default_workspace() -> None:
             logger.info(f"Default workspace '{DEFAULT_WORKSPACE}' created")
     except Exception as e:
         logger.warning(f"Could not seed default workspace: {e}")
+
+
+def _include_router(oidc_app: FastAPI, router: APIRouter) -> None:
+    """Register a router, plus the "/ajax-api" twins of its "/api" routes.
+
+    MLflow's web UI calls "/ajax-api/..." while API clients call "/api/...".
+    Registering both keeps UI-facing endpoints reachable; see
+    `mlflow_oidc_auth.routers.ajax_alias_router`.
+    """
+    oidc_app.include_router(router)
+    alias = ajax_alias_router(router)
+    if alias.routes:
+        oidc_app.include_router(alias)
 
 
 def _include_mlflow_fastapi_routers(oidc_app: FastAPI) -> None:
@@ -191,7 +204,7 @@ def create_app() -> FastAPI:
     )
 
     for router in get_all_routers():
-        oidc_app.include_router(router)
+        _include_router(oidc_app, router)
 
     # Inject into MLflow's index.html when the menu links or the re-auth helper
     # are enabled. Both live in the same hack module to keep injection ordering
@@ -219,8 +232,8 @@ def create_app() -> FastAPI:
             workspace_regex_permissions_router,
         )
 
-        oidc_app.include_router(workspace_permissions_router)
-        oidc_app.include_router(workspace_regex_permissions_router)
+        _include_router(oidc_app, workspace_permissions_router)
+        _include_router(oidc_app, workspace_regex_permissions_router)
 
     # ---------------------------------------------------------------------------
     # Include MLflow's FastAPI-native routers (GAP-ARCH-01 fix)

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -18,6 +18,7 @@ from starlette.types import ASGIApp
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
 from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.routers._prefix import API_PATH_PREFIXES
 from mlflow_oidc_auth.auth import validate_token
 from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils.oidc_field_extraction import extract_username, extract_display_name, BEARER_TOKEN_SOURCE
@@ -401,7 +402,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             logger.info(f"Authentication failed for {path}: {error_msg}")
             # Treat certain non-/api routes as API-style endpoints (no redirects)
             # so callers get an HTTP error instead of a redirected 200.
-            if path.startswith("/api"):
+            # "/ajax-api" is the same REST surface under the prefix the web UI
+            # calls; it must 401 rather than redirect, just like "/api".
+            if path.startswith(API_PATH_PREFIXES):
                 return JSONResponse(status_code=401, content={"detail": "Authentication required"})
             if path.startswith("/oidc/trash"):
                 return JSONResponse(

--- a/mlflow_oidc_auth/routers/__init__.py
+++ b/mlflow_oidc_auth/routers/__init__.py
@@ -63,6 +63,60 @@ __all__ = [
 ]
 
 
+# Every ``add_api_route`` keyword that describes the route itself rather than
+# where it is mounted. A twin must carry all of them, or it silently behaves
+# differently from its "/api" original - ``response_model_exclude_none``, for
+# one, changes the JSON the UI receives. The remaining keywords are supplied
+# explicitly by ``ajax_alias_router`` (see ``_MOUNT_ROUTE_FIELDS`` in the tests,
+# which asserts the two sets together still cover the whole signature).
+_COPIED_ROUTE_FIELDS = (
+    "response_model",
+    "status_code",
+    "tags",
+    "dependencies",
+    "summary",
+    "description",
+    "response_description",
+    "responses",
+    "deprecated",
+    "operation_id",
+    "response_model_include",
+    "response_model_exclude",
+    "response_model_by_alias",
+    "response_model_exclude_unset",
+    "response_model_exclude_defaults",
+    "response_model_exclude_none",
+    "response_class",
+    "callbacks",
+    "openapi_extra",
+    "generate_unique_id_function",
+    "strict_content_type",
+)
+
+# Suffix appended to a twin's route name so ``url_path_for()`` stays unambiguous.
+AJAX_ROUTE_NAME_SUFFIX = "_ajax"
+
+
+def _copied_route_kwargs(route: APIRoute) -> dict:
+    """Collect the route-describing keywords to carry over to a twin.
+
+    Fields absent from the installed FastAPI version are skipped, so this keeps
+    working across versions that add or drop route options.
+    """
+    kwargs = {}
+    for field in _COPIED_ROUTE_FIELDS:
+        if not hasattr(route, field):
+            continue
+        value = getattr(route, field)
+        # Copy the mutable containers so the twin can never mutate the original.
+        if isinstance(value, list):
+            value = list(value)
+        elif isinstance(value, dict):
+            value = dict(value)
+        kwargs[field] = value
+    return kwargs
+
+
 def ajax_alias_router(router: APIRouter) -> APIRouter:
     """Mirror a router's "/api" routes onto MLflow's "/ajax-api" prefix.
 
@@ -96,18 +150,15 @@ def ajax_alias_router(router: APIRouter) -> APIRouter:
             ajax_path,
             route.endpoint,
             methods=sorted(route.methods),
-            response_model=route.response_model,
-            status_code=route.status_code,
-            dependencies=list(route.dependencies),
-            summary=route.summary,
-            description=route.description,
-            tags=list(route.tags),
-            response_class=route.response_class,
+            # Preserve a custom route class (request/response handling lives
+            # there) instead of falling back to the plain APIRoute.
+            route_class_override=type(route),
             # The canonical "/api" paths are the documented ones; keeping the
             # twins out of the schema avoids listing every endpoint twice. The
             # distinct name keeps url_path_for() unambiguous.
-            name=f"{route.name}_ajax",
+            name=f"{route.name}{AJAX_ROUTE_NAME_SUFFIX}",
             include_in_schema=False,
+            **_copied_route_kwargs(route),
         )
     return alias
 

--- a/mlflow_oidc_auth/routers/__init__.py
+++ b/mlflow_oidc_auth/routers/__init__.py
@@ -8,7 +8,9 @@ Each router is responsible for a specific set of endpoints.
 from typing import List
 
 from fastapi import APIRouter
+from fastapi.routing import APIRoute
 
+from mlflow_oidc_auth.routers._prefix import to_ajax_path
 from mlflow_oidc_auth.routers.auth import auth_router
 from mlflow_oidc_auth.routers.experiment_permissions import (
     experiment_permissions_router,
@@ -40,6 +42,7 @@ from mlflow_oidc_auth.routers.workspace_regex_permissions import (
 )
 
 __all__ = [
+    "ajax_alias_router",
     "auth_router",
     "experiment_permissions_router",
     "group_permissions_router",
@@ -58,6 +61,55 @@ __all__ = [
     "workspace_permissions_router",
     "workspace_regex_permissions_router",
 ]
+
+
+def ajax_alias_router(router: APIRouter) -> APIRouter:
+    """Mirror a router's "/api" routes onto MLflow's "/ajax-api" prefix.
+
+    MLflow registers every one of its own REST handlers under both "/api/..."
+    and "/ajax-api/...", and its web UI calls the "/ajax-api" variants. This
+    plugin's routers were registered under "/api" only, so UI calls such as
+    ``GET /ajax-api/2.0/mlflow/users/current`` matched no FastAPI route, fell
+    through to the mounted Flask app and returned 404. The UI reads that failure
+    as "not authenticated" (its current-user query runs with ``retry: false``,
+    after which ``is_admin`` is false and ``username`` empty), so it hides the
+    edit affordances even for admins.
+
+    Routes outside the REST prefix - health checks and the "/oidc/*" routes -
+    have no UI-facing twin and are left alone.
+
+    Args:
+        router: The router whose API routes should be mirrored.
+
+    Returns:
+        APIRouter: A router holding the "/ajax-api" twins. Empty when `router`
+        exposes no routes under the REST prefix.
+    """
+    alias = APIRouter()
+    for route in router.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        ajax_path = to_ajax_path(route.path)
+        if ajax_path is None:
+            continue
+        alias.add_api_route(
+            ajax_path,
+            route.endpoint,
+            methods=sorted(route.methods),
+            response_model=route.response_model,
+            status_code=route.status_code,
+            dependencies=list(route.dependencies),
+            summary=route.summary,
+            description=route.description,
+            tags=list(route.tags),
+            response_class=route.response_class,
+            # The canonical "/api" paths are the documented ones; keeping the
+            # twins out of the schema avoids listing every endpoint twice. The
+            # distinct name keeps url_path_for() unambiguous.
+            name=f"{route.name}_ajax",
+            include_in_schema=False,
+        )
+    return alias
 
 
 def get_all_routers() -> List[APIRouter]:

--- a/mlflow_oidc_auth/routers/_prefix.py
+++ b/mlflow_oidc_auth/routers/_prefix.py
@@ -1,4 +1,6 @@
-from mlflow.server.handlers import _get_rest_path
+from typing import Optional
+
+from mlflow.server.handlers import _get_ajax_path, _get_rest_path
 
 """
 Router prefix constants for the FastAPI application.
@@ -6,6 +8,31 @@ Router prefix constants for the FastAPI application.
 This module defines all router prefixes used throughout the application
 to ensure consistency and easy maintenance of URL structures.
 """
+
+# MLflow serves every REST handler under two prefixes: "/api/..." for API clients
+# and "/ajax-api/..." for its own web UI. Derive both leading segments from
+# MLflow instead of hardcoding them, so an upstream rename cannot silently
+# desynchronise this plugin's routes from the paths the UI calls.
+_REST_SEGMENT = _get_rest_path("/probe").split("/")[1]
+_AJAX_SEGMENT = _get_ajax_path("/probe").split("/")[1]
+
+
+def to_ajax_path(path: str) -> Optional[str]:
+    """Return the "/ajax-api" twin of an "/api" path.
+
+    Args:
+        path: A route path, e.g. "/api/2.0/mlflow/users/current".
+
+    Returns:
+        The equivalent "/ajax-api" path, or None when `path` is not under the
+        REST prefix at all (health checks and the "/oidc/*" routes), since those
+        have no UI-facing twin.
+    """
+    rest_prefix = f"/{_REST_SEGMENT}/"
+    if not path.startswith(rest_prefix):
+        return None
+    return f"/{_AJAX_SEGMENT}/{path[len(rest_prefix):]}"
+
 
 EXPERIMENT_PERMISSIONS_ROUTER_PREFIX = _get_rest_path("/mlflow/permissions/experiments")
 GROUP_PERMISSIONS_ROUTER_PREFIX = _get_rest_path("/mlflow/permissions/groups")

--- a/mlflow_oidc_auth/routers/_prefix.py
+++ b/mlflow_oidc_auth/routers/_prefix.py
@@ -1,7 +1,3 @@
-from typing import Optional
-
-from mlflow.server.handlers import _get_ajax_path, _get_rest_path
-
 """
 Router prefix constants for the FastAPI application.
 
@@ -9,12 +5,24 @@ This module defines all router prefixes used throughout the application
 to ensure consistency and easy maintenance of URL structures.
 """
 
+from typing import Optional
+
+from mlflow.server.handlers import _get_ajax_path, _get_rest_path
+
 # MLflow serves every REST handler under two prefixes: "/api/..." for API clients
 # and "/ajax-api/..." for its own web UI. Derive both leading segments from
 # MLflow instead of hardcoding them, so an upstream rename cannot silently
 # desynchronise this plugin's routes from the paths the UI calls.
 _REST_SEGMENT = _get_rest_path("/probe").split("/")[1]
 _AJAX_SEGMENT = _get_ajax_path("/probe").split("/")[1]
+
+# Leading path segments of the two prefixes, e.g. "/api" and "/ajax-api".
+REST_PATH_PREFIX = f"/{_REST_SEGMENT}"
+AJAX_PATH_PREFIX = f"/{_AJAX_SEGMENT}"
+
+# Both prefixes carry programmatic (XHR / API-client) traffic, so a failed
+# request under either must surface as an HTTP error rather than a redirect.
+API_PATH_PREFIXES = (REST_PATH_PREFIX, AJAX_PATH_PREFIX)
 
 
 def to_ajax_path(path: str) -> Optional[str]:
@@ -28,10 +36,10 @@ def to_ajax_path(path: str) -> Optional[str]:
         REST prefix at all (health checks and the "/oidc/*" routes), since those
         have no UI-facing twin.
     """
-    rest_prefix = f"/{_REST_SEGMENT}/"
+    rest_prefix = f"{REST_PATH_PREFIX}/"
     if not path.startswith(rest_prefix):
         return None
-    return f"/{_AJAX_SEGMENT}/{path[len(rest_prefix):]}"
+    return f"{AJAX_PATH_PREFIX}/{path[len(rest_prefix):]}"
 
 
 EXPERIMENT_PERMISSIONS_ROUTER_PREFIX = _get_rest_path("/mlflow/permissions/experiments")

--- a/mlflow_oidc_auth/tests/conftest.py
+++ b/mlflow_oidc_auth/tests/conftest.py
@@ -2,6 +2,22 @@
 
 import os
 
+import dotenv
+
+# ``mlflow_oidc_auth.config`` calls ``load_dotenv()`` at import time, which walks up
+# from the package directory and picks up whatever ".env" a developer keeps at the
+# repository root - including inside a git worktree, where the search reaches the
+# parent checkout. Those values then leak into the suite: a local
+# ``MLFLOW_ENABLE_WORKSPACES=True``, for instance, makes MLflow's workspace-aware
+# store reject every query that has no workspace context, failing a dozen router
+# tests that pass in CI (where no ".env" exists). Neutralise the load so the suite
+# always sees the CI environment.
+#
+# This runs at conftest import time, before any test module imports the config, so
+# the ``from dotenv import load_dotenv`` there binds to the no-op. Tests that need
+# specific configuration set it explicitly (``patch.dict(os.environ, ...)``).
+dotenv.load_dotenv = lambda *args, **kwargs: False
+
 # MLflow 3.14 put the filesystem tracking/registry backends into maintenance mode and
 # raises unless callers opt in explicitly. Several router tests exercise real endpoints
 # that fall back to the default './mlruns' store; they are testing our authorization

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -636,6 +636,29 @@ class TestAuthMiddleware:
             assert b"Authentication required" in response.body
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("prefix", ["/api", "/ajax-api"])
+    async def test_dispatch_unauthenticated_rest_path_returns_401(self, prefix, auth_middleware, create_mock_request, mock_config):
+        """Both REST prefixes are API surfaces and must 401 rather than redirect.
+
+        The plugin serves its endpoints under "/ajax-api" too (that's the prefix
+        MLflow's UI calls), so an unauthenticated call there must not be handed
+        a 302 to the login page.
+        """
+        mock_config.AUTOMATIC_LOGIN_REDIRECT = True
+
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.config", mock_config):
+            request = create_mock_request(
+                path=f"{prefix}/2.0/mlflow/users/current",
+                session={},
+                headers={"sec-fetch-dest": "document"},
+            )
+
+            response = await auth_middleware.dispatch(request, lambda r: pytest.fail("should not be called"))
+
+            assert response.status_code == 401
+            assert b"Authentication required" in response.body
+
+    @pytest.mark.asyncio
     async def test_dispatch_unauthenticated_xhr_returns_401_via_accept_fallback(self, auth_middleware, create_mock_request, mock_config):
         """Older clients without Sec-Fetch-Dest fall back to the Accept header."""
         mock_config.AUTOMATIC_LOGIN_REDIRECT = True

--- a/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
+++ b/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
@@ -1,0 +1,97 @@
+"""Tests for the "/ajax-api" aliasing of this plugin's own routers.
+
+MLflow's web UI calls "/ajax-api/..." while API clients call "/api/...".
+Registering only the latter left UI endpoints such as
+``GET /ajax-api/2.0/mlflow/users/current`` returning 404.
+"""
+
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from mlflow_oidc_auth.routers import ajax_alias_router
+from mlflow_oidc_auth.routers._prefix import USERS_ROUTER_PREFIX, to_ajax_path
+
+
+class TestToAjaxPath:
+    """Test the "/api" -> "/ajax-api" path mapping."""
+
+    def test_maps_v2_path(self):
+        assert to_ajax_path("/api/2.0/mlflow/users/current") == "/ajax-api/2.0/mlflow/users/current"
+
+    def test_maps_v3_path(self):
+        assert to_ajax_path("/api/3.0/mlflow/permissions/workspaces") == "/ajax-api/3.0/mlflow/permissions/workspaces"
+
+    def test_returns_none_for_non_api_paths(self):
+        # Health checks and the "/oidc/*" routes have no UI-facing twin.
+        assert to_ajax_path("/health") is None
+        assert to_ajax_path("/oidc/ui/index.html") is None
+
+    def test_does_not_double_prefix_an_ajax_path(self):
+        assert to_ajax_path("/ajax-api/2.0/mlflow/users/current") is None
+
+    def test_matches_the_real_users_prefix(self):
+        # Guards against MLflow changing its prefixes underneath us.
+        assert to_ajax_path(f"{USERS_ROUTER_PREFIX}/current") == "/ajax-api/2.0/mlflow/users/current"
+
+
+class TestAjaxAliasRouter:
+    """Test mirroring of router routes onto the "/ajax-api" prefix."""
+
+    def test_mirrors_api_routes(self):
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.get("/current")
+        async def current():  # pragma: no cover - never invoked, only routed
+            return {}
+
+        paths = {route.path for route in ajax_alias_router(router).routes}
+        assert paths == {"/ajax-api/2.0/mlflow/users/current"}
+
+    def test_preserves_methods(self):
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.patch("/access-token")
+        async def token():  # pragma: no cover
+            return {}
+
+        (route,) = ajax_alias_router(router).routes
+        assert route.methods == {"PATCH"}
+
+    def test_skips_non_api_routes(self):
+        router = APIRouter(prefix="/oidc/ui")
+
+        @router.get("/index.html")
+        async def index():  # pragma: no cover
+            return {}
+
+        assert ajax_alias_router(router).routes == []
+
+    def test_aliases_are_hidden_from_the_openapi_schema(self):
+        # The "/api" paths stay the documented ones so the schema is not doubled.
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.get("/current")
+        async def current():  # pragma: no cover
+            return {}
+
+        (route,) = ajax_alias_router(router).routes
+        assert route.include_in_schema is False
+
+    def test_both_prefixes_are_served_by_the_same_handler(self):
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.get("/current")
+        async def current():
+            return {"username": "alice", "is_admin": True}
+
+        app = FastAPI()
+        app.include_router(router)
+        app.include_router(ajax_alias_router(router))
+        client = TestClient(app)
+
+        expected = {"username": "alice", "is_admin": True}
+        assert client.get("/api/2.0/mlflow/users/current").json() == expected
+        # This is the request MLflow's UI actually makes; before the alias it 404'd.
+        ajax = client.get("/ajax-api/2.0/mlflow/users/current")
+        assert ajax.status_code == 200
+        assert ajax.json() == expected

--- a/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
+++ b/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
@@ -5,10 +5,15 @@ Registering only the latter left UI endpoints such as
 ``GET /ajax-api/2.0/mlflow/users/current`` returning 404.
 """
 
-from fastapi import APIRouter, FastAPI
-from fastapi.testclient import TestClient
+import inspect
+from typing import Optional
 
-from mlflow_oidc_auth.routers import ajax_alias_router
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from mlflow_oidc_auth.routers import _COPIED_ROUTE_FIELDS, ajax_alias_router
 from mlflow_oidc_auth.routers._prefix import USERS_ROUTER_PREFIX, to_ajax_path
 
 
@@ -95,3 +100,118 @@ class TestAjaxAliasRouter:
         ajax = client.get("/ajax-api/2.0/mlflow/users/current")
         assert ajax.status_code == 200
         assert ajax.json() == expected
+
+
+class _Status(BaseModel):
+    status: str
+    detail: Optional[str] = None
+
+
+class TestAliasFidelity:
+    """A twin must behave exactly like the "/api" route it mirrors."""
+
+    def test_preserves_response_model_serialization_options(self):
+        # Several handlers set response_model_exclude_none=True; dropping it on
+        # the twin would hand the UI a different payload than API clients get.
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.delete("/{username}", response_model=_Status, response_model_exclude_none=True)
+        async def delete_user(username: str):
+            return _Status(status="ok")
+
+        app = FastAPI()
+        app.include_router(router)
+        app.include_router(ajax_alias_router(router))
+        client = TestClient(app)
+
+        assert client.delete("/api/2.0/mlflow/users/alice").json() == {"status": "ok"}
+        assert client.delete("/ajax-api/2.0/mlflow/users/alice").json() == {"status": "ok"}
+
+    def test_preserves_router_level_dependencies(self):
+        # Router-level dependencies are where the admin checks live; a twin
+        # without them would be an unauthenticated copy of a guarded endpoint.
+        calls = []
+
+        async def guard():
+            calls.append(True)
+
+        router = APIRouter(prefix="/api/2.0/mlflow/users", dependencies=[Depends(guard)])
+
+        @router.get("/current")
+        async def current():
+            return {}
+
+        app = FastAPI()
+        app.include_router(ajax_alias_router(router))
+        TestClient(app).get("/ajax-api/2.0/mlflow/users/current")
+
+        assert calls == [True]
+
+    def test_preserves_status_code(self):
+        router = APIRouter(prefix="/api/2.0/mlflow/users")
+
+        @router.post("/", status_code=201)
+        async def create():
+            return {}
+
+        (route,) = ajax_alias_router(router).routes
+        assert route.status_code == 201
+
+    def test_preserves_a_custom_route_class(self):
+        class CustomRoute(APIRoute):
+            pass
+
+        router = APIRouter(prefix="/api/2.0/mlflow/users", route_class=CustomRoute)
+
+        @router.get("/current")
+        async def current():  # pragma: no cover
+            return {}
+
+        (route,) = ajax_alias_router(router).routes
+        assert isinstance(route, CustomRoute)
+
+    def test_copied_fields_cover_every_route_option(self):
+        """Guard against a FastAPI upgrade adding a route option we silently drop.
+
+        Every ``add_api_route`` keyword is either copied from the original route
+        or set deliberately by ``ajax_alias_router``. If this fails, decide which
+        bucket the new keyword belongs in rather than just widening the list.
+        """
+        # Keywords that describe where/how the twin is mounted, not the route.
+        mount_fields = {
+            "self",
+            "path",
+            "endpoint",
+            "methods",
+            "name",
+            "include_in_schema",
+            "route_class_override",
+        }
+        signature_fields = set(inspect.signature(APIRouter.add_api_route).parameters)
+
+        assert signature_fields - mount_fields == set(_COPIED_ROUTE_FIELDS)
+
+
+class TestAppRegistration:
+    """The app-level helper must register both prefixes for real routers."""
+
+    def test_include_router_registers_both_prefixes(self):
+        from mlflow_oidc_auth.app import _include_router
+        from mlflow_oidc_auth.routers.users import users_router
+
+        app = FastAPI()
+        _include_router(app, users_router)
+
+        paths = {route.path for route in app.routes if isinstance(route, APIRoute)}
+        assert f"{USERS_ROUTER_PREFIX}/current" in paths
+        assert "/ajax-api/2.0/mlflow/users/current" in paths
+
+    def test_include_router_skips_an_empty_alias(self):
+        from mlflow_oidc_auth.app import _include_router
+        from mlflow_oidc_auth.routers.health import health_check_router
+
+        app = FastAPI()
+        _include_router(app, health_check_router)
+
+        paths = {route.path for route in app.routes if isinstance(route, APIRoute)}
+        assert not any(path.startswith("/ajax-api") for path in paths)

--- a/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
+++ b/mlflow_oidc_auth/tests/routers/test_ajax_alias.py
@@ -14,7 +14,11 @@ from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
 from mlflow_oidc_auth.routers import _COPIED_ROUTE_FIELDS, ajax_alias_router
-from mlflow_oidc_auth.routers._prefix import USERS_ROUTER_PREFIX, to_ajax_path
+from mlflow_oidc_auth.routers._prefix import (
+    HEALTH_CHECK_ROUTER_PREFIX,
+    USERS_ROUTER_PREFIX,
+    to_ajax_path,
+)
 
 
 class TestToAjaxPath:
@@ -193,7 +197,20 @@ class TestAliasFidelity:
 
 
 class TestAppRegistration:
-    """The app-level helper must register both prefixes for real routers."""
+    """The app-level helper must register both prefixes for real routers.
+
+    These assert through the app's routing rather than by walking ``app.routes``:
+    FastAPI 0.141 wraps each ``include_router()`` call in an internal router
+    object, so the leaf routes are no longer reachable by inspection. What
+    matters is where a request actually lands, and that holds either way.
+    """
+
+    @staticmethod
+    def _status_for(app: FastAPI, path: str) -> int:
+        # Server exceptions become 500s instead of propagating: these handlers
+        # need an auth context that a bare TestClient request does not set up,
+        # and the question here is only which of them the request reaches.
+        return TestClient(app, raise_server_exceptions=False).get(path).status_code
 
     def test_include_router_registers_both_prefixes(self):
         from mlflow_oidc_auth.app import _include_router
@@ -202,9 +219,12 @@ class TestAppRegistration:
         app = FastAPI()
         _include_router(app, users_router)
 
-        paths = {route.path for route in app.routes if isinstance(route, APIRoute)}
-        assert f"{USERS_ROUTER_PREFIX}/current" in paths
-        assert "/ajax-api/2.0/mlflow/users/current" in paths
+        api_status = self._status_for(app, f"{USERS_ROUTER_PREFIX}/current")
+        ajax_status = self._status_for(app, "/ajax-api/2.0/mlflow/users/current")
+
+        assert api_status != 404, "the canonical /api route should be registered"
+        # Same handler, same outcome - the twin must not 404 or diverge.
+        assert ajax_status == api_status
 
     def test_include_router_skips_an_empty_alias(self):
         from mlflow_oidc_auth.app import _include_router
@@ -213,5 +233,6 @@ class TestAppRegistration:
         app = FastAPI()
         _include_router(app, health_check_router)
 
-        paths = {route.path for route in app.routes if isinstance(route, APIRoute)}
-        assert not any(path.startswith("/ajax-api") for path in paths)
+        assert self._status_for(app, HEALTH_CHECK_ROUTER_PREFIX) != 404
+        # Health checks are not part of the REST surface, so there is no twin.
+        assert self._status_for(app, f"/ajax-api{HEALTH_CHECK_ROUTER_PREFIX}") == 404


### PR DESCRIPTION
## Problem

MLflow registers each of its REST handlers under **both** `/api/...` and `/ajax-api/...`, and its web UI calls the `/ajax-api` variants. This plugin registers its own routers under `/api` only (`_prefix.py` uses `_get_rest_path` exclusively), so UI requests fall through FastAPI to the mounted Flask app, which has no such rule, and return **404**.

Observed on MLflow 3.15.1 + mlflow-oidc-auth 7.6.0, authenticated:

```
GET /ajax-api/2.0/mlflow/users/current  ->  404
```

The UI's account layer calls exactly that path:

```js
getCurrentUser:    () => "ajax-api/2.0/mlflow/users/current"
listMyPermissions: () => "ajax-api/3.0/mlflow/users/current/permissions"

const d = () => useQuery({ queryKey: ["account_current_user"], queryFn: getCurrentUser, retry: false })
const isAdmin  = () => Boolean(d().data?.user?.is_admin)   // -> false
const username = () => d().data?.user?.username ?? ""      // -> ""
```

Because the query is `retry: false`, the 404 leaves `is_admin` false and `username` empty. The UI concludes the session is unauthenticated and **hides edit affordances**. Symptoms we hit in production:

- model version aliases cannot be edited from the UI — **even for a user who is `is_admin = True` in the auth DB**
- the header shows no signed-in user
- users report "it's as if it doesn't see that I'm logged in", while `/permissions` (a plugin-served page) greets them by name and the CLI works normally

The same denial is easy to misread: the plugin's `make_forbidden_response()` returns `{"message": "..."}` with no `error_code`, and MLflow's UI maps errors by `error_code` only (`getErrorCode()` falls back to `INTERNAL_ERROR`), so users see `INTERNAL_ERROR` for what is really a routing/permission outcome. That part is left alone here to keep this PR focused.

## Fix

Mirror every router's `/api` routes onto the `/ajax-api` prefix.

- Both leading segments are derived from MLflow's own `_get_rest_path` / `_get_ajax_path` rather than hardcoded, so an upstream rename can't silently desynchronise them.
- Routes outside the REST prefix (`/health`, `/oidc/*`) have no UI-facing twin and are skipped.
- Twins are excluded from the OpenAPI schema, so the documented surface still lists each endpoint once; the alias route name gets an `_ajax` suffix so `url_path_for()` stays unambiguous.

This mirrors the approach already taken for authorization coverage in #283 / #284, which fixed the same `/api` vs `/ajax-api` split on the artifact-proxy side.

## Tests

Added `mlflow_oidc_auth/tests/routers/test_ajax_alias.py` (10 cases): the path mapping for v2/v3, non-API paths returning `None`, no double-prefixing, method and schema preservation, and a `TestClient` check that one handler answers on both prefixes.

Verified against `main` (`a952c87`) on Python 3.12 / MLflow 3.15.1:

- new tests: **10 passed**
- full suite: **3122 passed, 18 failed** — the identical 18 failures occur on unmodified `main` in this environment (Windows-specific, in `test_artifact_proxy_coverage.py`, `test_db_utils.py`, `test_hack.py`). **No regressions introduced.**
- `black --line-length 160` applied

One gap worth stating: I could not enumerate the assembled app's route table to assert both paths end-to-end, because this FastAPI version wraps includes in `_IncludedRouter` and the leaf paths aren't reachable that way — that's equally true on unmodified `main`. The behaviour is covered by the `TestClient` test and by checking the real `users_router` produces `/ajax-api/2.0/mlflow/users/current`.
