### PR TITLE
perf(auth): establish auth-path query budget and baseline (#305)

### DIFF
--- a/.github/workflows/pr-validate-title.yml
+++ b/.github/workflows/pr-validate-title.yml
@@ -19,9 +19,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Keep in sync with the pattern in commit-message-check.yml, which already
+          # accepts these. "perf" is a release type: the angular preset that
+          # @semantic-release/commit-analyzer defaults to maps it to a patch release and
+          # gives it its own "Performance Improvements" changelog section.
           types: |
             fix
             feat
+            perf
             docs
             ci
             chore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,11 @@ permission check.
   it by hand.
 - The permission cache (`PERMISSION_CACHE_TTL_SECONDS`) means permission changes are not
   instantly visible. Invalidate explicitly rather than waiting out the TTL.
-- Every authenticated request already performs a DB round trip in `AuthMiddleware.dispatch`.
-  Adding another one is a real regression — check before you add a query to that path.
+- Every authenticated request already performs a DB round trip in `AuthMiddleware.dispatch` —
+  measured at **2 statements** (3 for basic auth, 0 for unprotected prefixes). That is a budget,
+  not a description: see [`docs/performance-baseline.md`](docs/performance-baseline.md), enforced
+  by `mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py`. Adding a query to that path is a
+  real regression — fit new per-request data into the existing statements, or cache it.
 
 ---
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,4 +9,5 @@
 - [Admin UI](admin-ui)
 - [API Reference](api-reference)
 - [Development and Contribution](development)
+- [Performance Baseline](performance-baseline)
 - [Agentic Development](agentic-development)

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -1,0 +1,160 @@
+# Auth-path performance baseline
+
+Every request that is not on an unprotected prefix passes through `AuthMiddleware.dispatch`.
+Whatever that costs is paid by every API call and every UI navigation, so it is the budget the
+rest of the authentication work is held against.
+
+This page records the measured baseline (issue #305) and states the budget derived from it.
+
+> **The budget: no change may raise the per-request statement counts in the table below.**
+> A change that needs more per-request data must fit it into the existing statements — widen the
+> `load_only` in `UserRepository.get_profile` — or cache it. It may not add a query.
+> The budget is enforced by `mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py`, which
+> asserts the counts exactly: a regression *and* a silent improvement both fail, so the number
+> has to change in a diff, deliberately.
+
+## Running the benchmark
+
+```bash
+# SQLite (default), full matrix
+python scripts/bench_auth_path.py
+
+# PostgreSQL
+python scripts/bench_auth_path.py --db-uri postgresql+psycopg2://user@host:5432/db
+
+# Just the statement counts, as a test
+pytest mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
+```
+
+`--users`, `--groups`, `--scenarios`, `--iterations` and `--json` narrow or redirect a run;
+`--help` lists them. The script exits non-zero if any scenario's statement count varies between
+iterations, since a varying count is not a usable budget.
+
+## What is measured
+
+Four scenarios are driven end to end through a real `AuthMiddleware`, in a minimal ASGI app with
+the same middleware order as `app.py`. MLflow's Flask application is not mounted — this is the
+cost of authentication, not of MLflow.
+
+| Scenario | What it represents |
+|---|---|
+| `unprotected` | A path on an unprotected prefix (`/health`, `/oidc/ui`, `/static-files`, …). The floor. |
+| `session` | The browser path — a signed session cookie, as set by the OIDC callback. |
+| `bearer` | The API path — an RS256 JWT validated against a warm JWKS cache. |
+| `basic` | Username/password, as used by MLflow CLI clients and service accounts. |
+
+Two units are reported:
+
+- **SQL statements per request** — the round-trip count. Against a remote database this dominates,
+  and it is the number the budget is written in. It is dialect-independent: the count comes from
+  the SQLAlchemy loader strategy, not from the driver, which is why SQLite and PostgreSQL agree
+  below.
+- **Wall time** — median and p95 over 200 iterations, measured at the ASGI boundary. This is
+  hardware- and dialect-specific and is recorded for orientation, not as a contract. Both
+  databases here are local, so the numbers understate a production round trip.
+
+Bearer measurements exclude the JWKS network fetch, matching steady state in production where the
+key set is cached for `OIDC_JWKS_CACHE_TTL_SECONDS`. Signature verification is real.
+
+## Baseline
+
+Measured 2026-08-09 on `d1d44ef`, Apple M-series / macOS, Python 3.14, SQLAlchemy 2.0.46,
+MLflow 3.14.0, PostgreSQL 18.3 (local), 200 iterations per scenario.
+
+### Statements per request — the budget
+
+Identical in all 72 cells (2 databases x {1, 50, 500} users x {0, 20, 200} groups per user):
+
+| Scenario | Statements per request | Where they go |
+|---|---:|---|
+| `unprotected` | **0** | `_is_unprotected_route` returns before any store access |
+| `session` | **2** | `_get_user_admin_status` -> `get_profile`: one `load_only` select on `users`, one `selectinload` on `groups` |
+| `bearer` | **2** | same; token validation itself touches no database |
+| `basic` | **3** | one select in `authenticate_user` to load the password hash, then the 2 above |
+
+Denial paths, asserted in `test_auth_path_baseline.py`:
+
+| Denied request | Statements |
+|---|---:|
+| No credentials | **0** |
+| Invalid/forged bearer token | **0** |
+| Basic auth, wrong password | **1** |
+| Basic auth, unknown user | **1** |
+
+### Wall time
+
+Median / p95 milliseconds per request at the ASGI boundary. Both databases are local, so
+these understate a production round trip; they are recorded for orientation, not as a contract.
+
+| db | users | groups/user | unprotected | session | bearer | basic |
+|---|---:|---:|---|---|---|---|
+| sqlite | 1 | 0 | 0.41 / 0.48 | 1.09 / 1.28 | 1.28 / 1.74 | 48.91 / 51.23 |
+| sqlite | 1 | 20 | 0.45 / 0.57 | 1.32 / 1.82 | 1.43 / 1.83 | 51.10 / 53.18 |
+| sqlite | 1 | 200 | 0.49 / 0.59 | 2.41 / 2.85 | 2.63 / 2.95 | 52.59 / 54.52 |
+| sqlite | 50 | 0 | 0.50 / 0.65 | 1.51 / 1.84 | 1.64 / 1.86 | 52.14 / 54.07 |
+| sqlite | 50 | 20 | 0.49 / 0.58 | 1.56 / 1.81 | 1.64 / 1.89 | 51.19 / 54.30 |
+| sqlite | 50 | 200 | 0.43 / 0.58 | 2.03 / 2.42 | 2.15 / 3.07 | 51.65 / 53.76 |
+| sqlite | 500 | 0 | 0.40 / 0.43 | 1.30 / 1.74 | 1.16 / 1.36 | 50.32 / 52.59 |
+| sqlite | 500 | 20 | 0.44 / 0.52 | 1.27 / 1.89 | 1.34 / 1.67 | 50.85 / 55.93 |
+| sqlite | 500 | 200 | 0.48 / 0.65 | 1.95 / 2.61 | 2.08 / 2.78 | 51.75 / 56.25 |
+| postgres | 1 | 0 | 0.43 / 0.47 | 1.48 / 2.05 | 1.57 / 2.22 | 53.44 / 55.41 |
+| postgres | 1 | 20 | 0.52 / 0.64 | 1.90 / 2.46 | 2.36 / 2.88 | 53.99 / 56.69 |
+| postgres | 1 | 200 | 0.57 / 0.71 | 3.14 / 4.21 | 3.43 / 4.57 | 55.15 / 67.37 |
+| postgres | 50 | 0 | 0.51 / 0.62 | 2.23 / 3.63 | 2.44 / 2.89 | 52.37 / 55.48 |
+| postgres | 50 | 20 | 0.42 / 0.50 | 1.57 / 1.87 | 1.74 / 1.95 | 51.88 / 53.74 |
+| postgres | 50 | 200 | 0.43 / 0.54 | 2.38 / 2.98 | 2.58 / 4.03 | 52.34 / 54.31 |
+| postgres | 500 | 0 | 0.42 / 0.50 | 1.39 / 1.55 | 1.47 / 1.67 | 51.10 / 53.13 |
+| postgres | 500 | 20 | 0.42 / 0.49 | 1.51 / 1.88 | 1.73 / 2.98 | 51.49 / 54.13 |
+| postgres | 500 | 200 | 0.44 / 0.54 | 2.75 / 4.28 | 2.93 / 3.89 | 54.89 / 57.68 |
+
+## Findings
+
+**The 2-query claim is confirmed, with one correction to its scope.**
+
+Issue #305 stated that `_get_user_admin_status` "runs on every authenticated request and issues
+2 uncached queries via `get_profile`". Measured:
+
+- **2 queries: confirmed.** `UserRepository.get_profile` emits exactly two statements — a
+  `load_only` select on `users` and a `selectinload` on `groups`. This holds on SQLite and
+  PostgreSQL alike, and at every point in the matrix.
+- **Uncached: confirmed.** Two consecutive `get_user_profile` calls cost four statements. Nothing
+  on this path consults `PERMISSION_CACHE_TTL_SECONDS` or the `mlflow_oidc_auth/cache/` backend,
+  both of which exist and are used elsewhere.
+- **"On every request": too strong.** Requests on an unprotected prefix — `/health`, `/login`,
+  `/callback`, `/oidc/static`, `/oidc/ui`, `/metrics`, `/docs`, `/redoc`, `/openapi.json` and
+  `/static-files` — return from `dispatch` before any store access, at **0 queries**. Since
+  `/static-files` serves MLflow's entire React bundle, a real browser session issues many more
+  0-query requests than 2-query ones. The claim is correct for every *authenticated* request;
+  it is not correct for every request.
+- **Basic auth costs 3, not 2.** `store.authenticate_user` adds a select to load the password
+  hash before the admin check runs. Any downstream work that assumes a flat 2 has to account
+  for this path.
+
+**The count is constant in both dimensions of the matrix.** Statement count does not move with
+the number of users (1 -> 500) or with group membership (0 -> 200 groups per user).
+`selectinload` batches the group load into one statement rather than degrading to one per group,
+so the 2 does not become 2 + G. `test_admin_check_is_constant_in_group_count` guards that.
+
+**Wall time is flat in user count and mildly sensitive to group count.** Going from 0 to 200
+groups per user adds roughly 1 ms to a session request (~1.3 ms -> ~2.4 ms on SQLite,
+~1.5 ms -> ~3.1 ms on PostgreSQL) at an unchanged 2 statements — that is row and entity
+materialization inside the second query, not extra round trips. Growing from 1 to 500 users
+changes nothing measurable, as the unique index on `users.username` predicts.
+
+**Basic auth is ~25x more expensive than session or bearer, and it is not the database.** A
+basic-auth request costs ~50 ms against both databases, of which a directly measured
+**48.2 ms is `check_password_hash`** — Werkzeug's `scrypt:32768:8:1`, deliberately expensive by
+design. The 3 SQL statements are noise beside it. This is out of scope for the baseline and is
+noted here so it is not mistaken for a database problem: any future work on basic-auth latency
+belongs in password-hash policy or a verified-credential cache, not in query reduction.
+
+## Caveats
+
+- Wall times are from one machine with a local database. Treat the *statement counts* as the
+  portable result and the timings as indicative.
+- Statement counts transfer between dialects; query *plans* do not. Nothing here is a claim
+  about the PostgreSQL planner.
+- `OIDC_PROVISION_ON_BEARER_AUTH` is off, as it is by default. With it on, a bearer request adds
+  a `has_user` check — one more statement on every bearer request, not just the first.
+- The benchmark does not mount MLflow's Flask app, so it excludes the Flask `before_request`
+  authorization hooks. Those are a separate budget, measured by `test_query_counts.py` (#253).

--- a/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
+++ b/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
@@ -1,0 +1,296 @@
+"""The per-request auth-path query budget (issue #305).
+
+``AuthMiddleware.dispatch`` runs on every request that is not on an unprotected prefix.
+Whatever it costs is paid by every API call and every UI navigation, so it is the one
+number the enterprise-identity work (epic #304) is budgeted against.
+
+These tests pin that budget. They are exact assertions, so a regression *and* a silent
+improvement both fail and have to be acknowledged in a diff — same discipline as
+``test_query_counts.py`` (issue #253).
+
+The budget, measured by ``scripts/bench_auth_path.py`` and recorded in
+``docs/performance-baseline.md``:
+
+===============  ===================
+scenario         SQL statements
+===============  ===================
+unprotected      0
+session          2
+bearer           2
+basic            3
+===============  ===================
+
+**No task may raise these numbers.** A change that needs more per-request data must fit
+it into the existing statements (widen the ``load_only``) or cache it — not add a query.
+
+See ``conftest.py`` for why round-trips, not query cost, are the metric.
+"""
+
+import base64
+import time
+from typing import List
+
+import pytest
+from authlib.jose import JsonWebKey, jwt
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from starlette.middleware.sessions import SessionMiddleware
+
+import mlflow_oidc_auth.auth as auth_module
+import mlflow_oidc_auth.store as store_module
+from mlflow_oidc_auth.middleware import AuthMiddleware
+
+from .conftest import QueryCounter
+
+BENCH_PASSWORD = "bench-password"  # not a credential: only ever seeded into a tmp_path database
+PROTECTED_PATH = "/bench/protected"
+UNPROTECTED_PATH = "/health/bench"
+LOGIN_PATH = "/login/bench"
+
+
+@pytest.fixture
+def auth_user(store):
+    """A user with a real password hash and a handful of groups."""
+    username = "baseline@example.com"
+    store.create_user(username, BENCH_PASSWORD, "Baseline User")
+    groups = [f"baseline-group-{i}" for i in range(4)]
+    store.populate_groups(groups)
+    store.set_user_groups(username, groups)
+    return username
+
+
+@pytest.fixture
+def bound_store(store, monkeypatch):
+    """Point the lazy ``store`` singleton at the test store for the duration of a test.
+
+    ``AuthMiddleware`` imports the singleton directly, so it cannot be injected. This
+    installs the store the fixture already built rather than constructing a second one,
+    and ``monkeypatch`` restores the previous instance afterwards.
+    """
+    previous = object.__getattribute__(store_module.store, "_instance")
+    object.__setattr__(store_module.store, "_instance", store)
+    yield store
+    object.__setattr__(store_module.store, "_instance", previous)
+
+
+@pytest.fixture
+def bearer_token(monkeypatch):
+    """Prime the JWKS cache with a local key and return a minted RS256 token.
+
+    Signature verification is real; only the JWKS network fetch is bypassed — which is
+    what a warm production process does too, since JWKS is cached for
+    ``OIDC_JWKS_CACHE_TTL_SECONDS``.
+    """
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private = key.as_dict(is_private=True)
+    public = key.as_dict(is_private=False)
+    kid = public.get("kid") or key.thumbprint()
+    public["kid"] = kid
+    private["kid"] = kid
+
+    monkeypatch.setattr(auth_module.config, "OIDC_DISCOVERY_URL", "https://test.invalid/.well-known/openid-configuration")
+    monkeypatch.setitem(auth_module._jwks_cache, auth_module._JWKS_CACHE_KEY, {"keys": [public]})
+
+    def mint(username: str) -> str:
+        now = int(time.time())
+        claims = {"email": username, "name": username, "iat": now, "exp": now + 3600}
+        return jwt.encode({"alg": "RS256", "kid": kid}, claims, private).decode("utf-8")
+
+    return mint
+
+
+@pytest.fixture
+def client(bound_store):
+    """A TestClient over a minimal app wrapping the real ``AuthMiddleware``.
+
+    Middleware is added in the same order as ``app.py`` — Auth, then Session — which in
+    Starlette makes Session the outer one, so ``request.session`` exists by the time
+    ``AuthMiddleware`` looks for it. MLflow's Flask app is not mounted: this measures the
+    auth path, not MLflow.
+    """
+    app = FastAPI()
+
+    @app.get(PROTECTED_PATH)
+    async def protected(request: Request):
+        return {"username": getattr(request.state, "username", None)}
+
+    @app.get(UNPROTECTED_PATH)
+    async def unprotected():
+        return {"ok": True}
+
+    @app.get(LOGIN_PATH)
+    async def login(request: Request, username: str):
+        # "/login" is an unprotected prefix, so this runs without authentication and
+        # mints the same session the OIDC callback would.
+        request.session["username"] = username
+        return {"ok": True}
+
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+
+    with TestClient(app) as c:
+        yield c
+
+
+def _count_requests(counter: QueryCounter, make_request, n: int = 3) -> List[int]:
+    """Issue ``n`` identical requests and return the statement count of each.
+
+    Repeating catches a first-request-only cost (a lazily built cache, a connection
+    warm-up) that a single measurement would bake into the budget.
+    """
+    counts = []
+    for _ in range(n):
+        counter.reset()
+        response = make_request()
+        assert response.status_code == 200, response.text
+        counts.append(counter.count)
+    return counts
+
+
+class TestAuthPathQueryBudget:
+    """The per-request statement budget. These numbers are the contract."""
+
+    def test_unprotected_path_issues_no_queries(self, client, counter, auth_user):
+        """An unprotected prefix must short-circuit before any store access."""
+        counts = _count_requests(counter, lambda: client.get(UNPROTECTED_PATH))
+
+        assert counts == [0, 0, 0], counter.report()
+
+    def test_session_authenticated_request_issues_two_queries(self, client, counter, auth_user):
+        """The browser path: session lookup is free, the admin check costs 2 statements.
+
+        Issue #305 claimed ``_get_user_admin_status`` issues 2 uncached queries on every
+        authenticated request. This is that claim, pinned: ``get_profile`` emits a
+        ``load_only`` select on ``users`` plus a ``selectinload`` for ``groups``.
+        """
+        client.get(LOGIN_PATH, params={"username": auth_user})
+
+        counts = _count_requests(counter, lambda: client.get(PROTECTED_PATH))
+
+        assert counts == [2, 2, 2], counter.report()
+
+    def test_bearer_authenticated_request_issues_two_queries(self, client, counter, auth_user, bearer_token):
+        """The API path: with provisioning off (the default), only the admin check runs."""
+        token = bearer_token(auth_user)
+
+        counts = _count_requests(counter, lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Bearer {token}"}))
+
+        assert counts == [2, 2, 2], counter.report()
+
+    def test_bearer_with_provisioning_enabled_costs_one_extra_query(self, client, counter, auth_user, bearer_token, monkeypatch):
+        """``OIDC_PROVISION_ON_BEARER_AUTH`` adds a ``has_user`` check to *every* bearer
+        request, not only the first — the guard runs before it can decide to do nothing.
+
+        Recorded so the opt-in's cost is a known number rather than a surprise. The flag is
+        off by default, which is why the budget above is 2.
+        """
+        from mlflow_oidc_auth.middleware import auth_middleware as middleware_module
+
+        monkeypatch.setattr(middleware_module.config, "OIDC_PROVISION_ON_BEARER_AUTH", True)
+        token = bearer_token(auth_user)
+
+        counts = _count_requests(counter, lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Bearer {token}"}))
+
+        assert counts == [3, 3, 3], counter.report()
+
+    def test_basic_authenticated_request_issues_three_queries(self, client, counter, auth_user):
+        """Basic auth pays one extra statement to load the password hash before the admin check."""
+        credentials = base64.b64encode(f"{auth_user}:{BENCH_PASSWORD}".encode()).decode()
+
+        counts = _count_requests(counter, lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Basic {credentials}"}))
+
+        assert counts == [3, 3, 3], counter.report()
+
+
+class TestAuthPathDenialCosts:
+    """The denial paths. An unauthenticated caller must not be cheaper to serve than a
+    real one in a way that leaks, nor more expensive in a way that invites a DoS."""
+
+    def test_unauthenticated_request_is_denied_without_touching_the_store(self, client, counter, auth_user):
+        """No credentials means no user to look up: 401 with zero statements.
+
+        This is the negative case for the budget — an anonymous flood must not be able to
+        drive database load through the auth path.
+        """
+        counter.reset()
+
+        response = client.get(PROTECTED_PATH)
+
+        assert response.status_code == 401
+        assert counter.count == 0, counter.report()
+
+    def test_invalid_bearer_token_is_denied_without_touching_the_store(self, client, counter, auth_user):
+        """A forged/garbage token is rejected at signature validation, before any query."""
+        counter.reset()
+
+        response = client.get(PROTECTED_PATH, headers={"Authorization": "Bearer not-a-real-token"})
+
+        assert response.status_code == 401
+        assert counter.count == 0, counter.report()
+
+    def test_wrong_basic_password_is_denied_after_one_query(self, client, counter, auth_user):
+        """Basic auth must load the hash to compare it, but must not go on to the admin check."""
+        credentials = base64.b64encode(f"{auth_user}:wrong-password".encode()).decode()
+        counter.reset()
+
+        response = client.get(PROTECTED_PATH, headers={"Authorization": f"Basic {credentials}"})
+
+        assert response.status_code == 401
+        assert counter.count == 1, counter.report()
+
+    def test_unknown_user_basic_auth_is_denied_after_one_query(self, client, counter, auth_user):
+        """A username that does not exist costs exactly the one lookup that proves it."""
+        credentials = base64.b64encode(b"ghost@example.com:whatever").decode()
+        counter.reset()
+
+        response = client.get(PROTECTED_PATH, headers={"Authorization": f"Basic {credentials}"})
+
+        assert response.status_code == 401
+        assert counter.count == 1, counter.report()
+
+
+class TestAdminStatusLookup:
+    """``_get_user_admin_status`` itself — the specific claim issue #305 asked us to check."""
+
+    def test_admin_check_is_two_statements(self, store, counter, auth_user):
+        """Confirmed: one select on ``users``, one selectinload on ``groups``."""
+        counter.reset()
+
+        store.get_user_profile(auth_user)
+
+        assert counter.count == 2, counter.report()
+        assert counter.for_table("users") >= 1, counter.report()
+        assert counter.for_table("groups") >= 1, counter.report()
+
+    @pytest.mark.parametrize("n_groups", [0, 1, 20])
+    def test_admin_check_is_constant_in_group_count(self, store, counter, n_groups):
+        """The 2 statements must not become 2 + G. ``selectinload`` batches; a lazy load
+        would not, and that is the regression this guards."""
+        username = f"g{n_groups}@example.com"
+        store.create_user(username, BENCH_PASSWORD, username)
+        if n_groups:
+            groups = [f"cg{n_groups}-{i}" for i in range(n_groups)]
+            store.populate_groups(groups)
+            store.set_user_groups(username, groups)
+        counter.reset()
+
+        profile = store.get_user_profile(username)
+
+        assert len(profile.groups) == n_groups
+        assert counter.count == 2, counter.report()
+
+    def test_admin_check_is_uncached(self, store, counter, auth_user):
+        """Two identical calls cost two full lookups.
+
+        This is the *problem statement*, asserted: despite ``PERMISSION_CACHE_TTL_SECONDS``
+        and a pluggable cache backend existing, nothing caches the profile. If a later
+        change adds that cache, this test must fail and be replaced with one asserting
+        the cached count — deliberately, in a diff.
+        """
+        counter.reset()
+
+        store.get_user_profile(auth_user)
+        store.get_user_profile(auth_user)
+
+        assert counter.count == 4, counter.report()

--- a/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
+++ b/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
@@ -34,7 +34,6 @@ import pytest
 from authlib.jose import JsonWebKey, jwt
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from sqlalchemy import event
 from starlette.middleware.sessions import SessionMiddleware
 
 import mlflow_oidc_auth.auth as auth_module

--- a/scripts/bench_auth_path.py
+++ b/scripts/bench_auth_path.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+"""Measure the per-request cost of the authentication path (issue #305).
+
+Every authenticated request passes through ``AuthMiddleware.dispatch``. This script
+measures what that costs, in the two units that matter:
+
+* **SQL statements per request** — the round-trip count. Against a remote database this
+  dominates; it is also the number the downstream enterprise-identity work is budgeted
+  against, so it is reported exactly and must be stable across iterations.
+* **Wall time per request** — median and p95 over N iterations, measured at the ASGI
+  boundary with ``TestClient`` so middleware overhead is included.
+
+Four scenarios are driven end to end through a real ``AuthMiddleware``:
+
+``unprotected``
+    A path matching the middleware's unprotected prefixes. Establishes the floor: the
+    auth path is skipped entirely.
+``session``
+    The browser path — a signed session cookie, as set by the OIDC callback.
+``bearer``
+    The API path — an RS256 JWT validated against a locally primed JWKS cache. The JWKS
+    fetch itself is excluded, matching steady state in production where it is cached for
+    ``OIDC_JWKS_CACHE_TTL_SECONDS``.
+``basic``
+    Username/password, used by MLflow CLI clients and service accounts.
+
+Usage::
+
+    # SQLite (default), full matrix
+    python scripts/bench_auth_path.py
+
+    # PostgreSQL
+    python scripts/bench_auth_path.py --db-uri postgresql+psycopg2://user@host:5432/db
+
+    # Quick pass while iterating
+    python scripts/bench_auth_path.py --users 1 --groups 0 --iterations 50
+
+Output is a Markdown table on stdout; ``--json PATH`` additionally writes the raw
+measurements. The recorded baseline lives in ``docs/performance-baseline.md``.
+"""
+
+import argparse
+import base64
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+# The benchmark configures the plugin through the environment, so every knob has to be
+# set before ``mlflow_oidc_auth.config`` is imported (it reads the environment once, at
+# import time). Imports of plugin modules therefore happen inside main(), after _configure().
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_USER_COUNTS = (1, 50, 500)
+DEFAULT_GROUP_COUNTS = (0, 20, 200)
+SCENARIOS = ("unprotected", "session", "bearer", "basic")
+
+# Statements SQLite and the driver issue that are not application queries.
+_IGNORED_PREFIXES = ("PRAGMA", "BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT", "RELEASE", "SET ", "SHOW ")
+
+BENCH_PASSWORD = "bench-password"  # not a credential: seeded into a throwaway database
+PROTECTED_PATH = "/bench/protected"
+UNPROTECTED_PATH = "/health/bench"
+LOGIN_PATH = "/login/bench"
+
+
+class QueryCounter:
+    """Counts SQL statements issued on an engine while active."""
+
+    def __init__(self) -> None:
+        self.statements: List[str] = []
+
+    @property
+    def count(self) -> int:
+        return len(self.statements)
+
+    def reset(self) -> None:
+        self.statements.clear()
+
+    def report(self) -> str:
+        lines = [f"{len(self.statements)} statement(s):"]
+        for i, stmt in enumerate(self.statements, 1):
+            lines.append(f"  {i:2d}. {' '.join(stmt.split())[:160]}")
+        return "\n".join(lines)
+
+
+def _configure(db_uri: str) -> None:
+    """Set the environment the plugin reads at import time.
+
+    Deliberately leaves ``OIDC_PROVISION_ON_BEARER_AUTH`` at its default (off) so the
+    numbers describe a default deployment. ``OIDC_DISCOVERY_URL`` is set only so
+    ``_get_oidc_jwks`` passes its "is it configured" guard — it is never fetched,
+    because the JWKS cache is primed directly.
+    """
+    os.environ["OIDC_USERS_DB_URI"] = db_uri
+    os.environ["SECRET_KEY"] = "bench-secret-key-not-a-credential"
+    os.environ["OIDC_DISCOVERY_URL"] = "https://bench.invalid/.well-known/openid-configuration"
+    os.environ["MLFLOW_ALLOW_FILE_STORE"] = "true"
+    os.environ.setdefault("LOG_LEVEL", "ERROR")
+
+
+def _build_app(store) -> Any:
+    """A minimal ASGI app wrapping the real ``AuthMiddleware``.
+
+    Middleware is added in the same order as ``app.py`` (Auth, then Session), which in
+    Starlette means Session runs outermost — ``AuthMiddleware`` needs ``request.session``
+    to already exist. MLflow's Flask app is not mounted: this measures the auth path,
+    not MLflow.
+    """
+    from fastapi import FastAPI, Request
+    from starlette.middleware.sessions import SessionMiddleware
+
+    from mlflow_oidc_auth.config import config
+    from mlflow_oidc_auth.middleware import AuthMiddleware
+
+    app = FastAPI()
+
+    @app.get(PROTECTED_PATH)
+    async def protected(request: Request):
+        return {"username": getattr(request.state, "username", None)}
+
+    @app.get(UNPROTECTED_PATH)
+    async def unprotected():
+        return {"ok": True}
+
+    @app.get(LOGIN_PATH)
+    async def login(request: Request, username: str):
+        # Under the "/login" unprotected prefix, so it runs without authentication and
+        # mints the same session the OIDC callback would.
+        request.session["username"] = username
+        return {"ok": True}
+
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(SessionMiddleware, secret_key=config.SECRET_KEY)
+    return app
+
+
+def _seed(store, n_users: int, n_groups: int) -> List[str]:
+    """Bulk-insert ``n_users`` users each belonging to ``n_groups`` groups.
+
+    Uses Core inserts rather than the store API: seeding 500 users x 200 groups through
+    the ORM takes minutes and none of it is what we are measuring. The password hash is
+    computed once and reused, so the basic-auth scenario still verifies a real hash.
+
+    Returns:
+        The seeded usernames.
+    """
+    from sqlalchemy import insert
+    from werkzeug.security import generate_password_hash
+
+    from mlflow_oidc_auth.db.models import SqlGroup, SqlUser, SqlUserGroup
+
+    pwhash = generate_password_hash(BENCH_PASSWORD)
+    usernames = [f"bench{i}@example.com" for i in range(n_users)]
+    group_names = [f"bench-group-{i}" for i in range(n_groups)]
+
+    with store.engine.begin() as conn:
+        conn.execute(
+            insert(SqlUser),
+            [{"username": u, "display_name": u, "password_hash": pwhash, "is_admin": False, "is_service_account": False} for u in usernames],
+        )
+        if group_names:
+            conn.execute(insert(SqlGroup), [{"group_name": g} for g in group_names])
+            user_ids = [r[0] for r in conn.exec_driver_sql("SELECT id FROM users ORDER BY id").fetchall()]
+            group_ids = [r[0] for r in conn.exec_driver_sql("SELECT id FROM groups ORDER BY id").fetchall()]
+            conn.execute(
+                insert(SqlUserGroup),
+                [{"user_id": uid, "group_id": gid} for uid in user_ids for gid in group_ids],
+            )
+    return usernames
+
+
+def _prime_jwks() -> Callable[[str], str]:
+    """Prime the JWKS cache with a locally generated key and return a token minter.
+
+    Signature verification is real; only the network fetch is bypassed, which is what a
+    warm production process does too.
+    """
+    from authlib.jose import JsonWebKey, jwt
+
+    import mlflow_oidc_auth.auth as auth_module
+
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private = key.as_dict(is_private=True)
+    public = key.as_dict(is_private=False)
+    kid = public.get("kid") or key.thumbprint()
+    public["kid"] = kid
+    private["kid"] = kid
+
+    with auth_module._jwks_cache_lock:
+        auth_module._jwks_cache[auth_module._JWKS_CACHE_KEY] = {"keys": [public]}
+
+    def mint(username: str) -> str:
+        now = int(time.time())
+        claims = {"email": username, "name": username, "iat": now, "exp": now + 3600}
+        return jwt.encode({"alg": "RS256", "kid": kid}, claims, private).decode("utf-8")
+
+    return mint
+
+
+def _measure(
+    client,
+    request: Callable[[], Any],
+    counter: QueryCounter,
+    iterations: int,
+    warmup: int,
+) -> Dict[str, Any]:
+    """Drive one scenario and return its query count and timing distribution.
+
+    ``queries_per_request`` is reported as an exact integer when every iteration issued
+    the same number of statements, and as ``None`` (with ``queries_stable`` False) when
+    it varied — a varying count means the scenario is not a usable budget.
+    """
+    for _ in range(warmup):
+        request()
+
+    per_request_queries: List[int] = []
+    timings: List[float] = []
+    for _ in range(iterations):
+        counter.reset()
+        start = time.perf_counter()
+        response = request()
+        elapsed = time.perf_counter() - start
+        if response.status_code != 200:
+            raise RuntimeError(f"scenario request failed: {response.status_code} {response.text[:200]}")
+        per_request_queries.append(counter.count)
+        timings.append(elapsed * 1000.0)
+
+    stable = len(set(per_request_queries)) == 1
+    timings.sort()
+    return {
+        "queries_per_request": per_request_queries[0] if stable else None,
+        "queries_stable": stable,
+        "queries_observed": sorted(set(per_request_queries)),
+        "median_ms": round(statistics.median(timings), 4),
+        "p95_ms": round(timings[min(len(timings) - 1, int(0.95 * len(timings)))], 4),
+        "iterations": iterations,
+    }
+
+
+def _run_matrix(
+    db_uri: str,
+    db_label: str,
+    user_counts: Iterable[int],
+    group_counts: Iterable[int],
+    scenarios: Iterable[str],
+    iterations: int,
+    warmup: int,
+) -> List[Dict[str, Any]]:
+    """Run every (users, groups, scenario) combination against one database."""
+    from fastapi.testclient import TestClient
+    from sqlalchemy import event
+
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    mint_token = _prime_jwks()
+    rows: List[Dict[str, Any]] = []
+
+    for n_users in user_counts:
+        for n_groups in group_counts:
+            store = SqlAlchemyStore()
+            store.init_db(db_uri)
+            _reset_rows(store)
+
+            usernames = _seed(store, n_users, n_groups)
+            # The middleware resolves through the module-level store singleton, so point
+            # it at this freshly seeded store rather than constructing a second one.
+            _bind_singleton(store)
+
+            counter = QueryCounter()
+
+            def _listener(conn, cursor, statement, parameters, context, executemany):
+                if not statement.lstrip().upper().startswith(_IGNORED_PREFIXES):
+                    counter.statements.append(statement)
+
+            event.listen(store.engine, "before_cursor_execute", _listener)
+            try:
+                app = _build_app(store)
+                # Measure the last-seeded user: with an index on users.username the row's
+                # position should not matter, and measuring the tail makes that visible.
+                username = usernames[-1]
+                token = mint_token(username)
+                basic = base64.b64encode(f"{username}:{BENCH_PASSWORD}".encode()).decode()
+
+                with TestClient(app) as client:
+                    client.get(LOGIN_PATH, params={"username": username})
+                    requests = {
+                        "unprotected": lambda: client.get(UNPROTECTED_PATH),
+                        "session": lambda: client.get(PROTECTED_PATH),
+                        "bearer": lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Bearer {token}"}),
+                        "basic": lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Basic {basic}"}),
+                    }
+                    for scenario in scenarios:
+                        result = _measure(client, requests[scenario], counter, iterations, warmup)
+                        result.update(db=db_label, users=n_users, groups_per_user=n_groups, scenario=scenario)
+                        rows.append(result)
+                        print(
+                            f"  {db_label:10s} users={n_users:<4d} groups={n_groups:<4d} {scenario:<12s} "
+                            f"queries={result['queries_per_request']} median={result['median_ms']}ms p95={result['p95_ms']}ms",
+                            file=sys.stderr,
+                        )
+            finally:
+                event.remove(store.engine, "before_cursor_execute", _listener)
+                store.engine.dispose()
+    return rows
+
+
+def _bind_singleton(store) -> None:
+    """Point the lazy ``store`` singleton at an already-initialised store.
+
+    ``AuthMiddleware`` imports the singleton directly, so the benchmark cannot pass one
+    in. This does not construct a second store — it installs the one the benchmark just
+    built, keeping the "one store" rule intact.
+    """
+    import mlflow_oidc_auth.store as store_module
+
+    object.__setattr__(store_module.store, "_instance", store)
+
+
+def _reset_rows(store) -> None:
+    """Empty the user/group tables so each matrix cell starts from a known state.
+
+    Child-before-parent order, so the foreign keys in ``user_groups`` never dangle.
+    """
+    from sqlalchemy import text
+
+    from mlflow_oidc_auth.db.models import SqlGroup, SqlUser, SqlUserGroup
+
+    with store.engine.begin() as conn:
+        for table in (SqlUserGroup.__tablename__, SqlUser.__tablename__, SqlGroup.__tablename__):
+            conn.execute(text(f"DELETE FROM {table}"))
+
+
+def _to_markdown(rows: List[Dict[str, Any]]) -> str:
+    """Render the measurements as a Markdown table, one row per matrix cell."""
+    header = "| db | users | groups/user | scenario | queries/request | median ms | p95 ms |"
+    sep = "|---|---:|---:|---|---:|---:|---:|"
+    lines = [header, sep]
+    for r in rows:
+        queries = r["queries_per_request"] if r["queries_stable"] else f"VARIES {r['queries_observed']}"
+        lines.append(f"| {r['db']} | {r['users']} | {r['groups_per_user']} | {r['scenario']} | {queries} | {r['median_ms']} | {r['p95_ms']} |")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--db-uri", default=None, help="SQLAlchemy URI. Default: a temporary SQLite database.")
+    parser.add_argument("--db-label", default=None, help="Name for this database in the output. Default: the URI's dialect.")
+    parser.add_argument("--users", type=int, nargs="+", default=list(DEFAULT_USER_COUNTS))
+    parser.add_argument("--groups", type=int, nargs="+", default=list(DEFAULT_GROUP_COUNTS))
+    parser.add_argument("--scenarios", nargs="+", default=list(SCENARIOS), choices=list(SCENARIOS))
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--json", dest="json_path", default=None, help="Also write raw measurements here.")
+    args = parser.parse_args(argv)
+
+    tmpdir = None
+    db_uri = args.db_uri
+    if db_uri is None:
+        tmpdir = tempfile.mkdtemp(prefix="bench-auth-")
+        db_uri = f"sqlite:///{Path(tmpdir) / 'auth.db'}"
+    db_label = args.db_label or db_uri.split(":", 1)[0].split("+", 1)[0]
+
+    _configure(db_uri)
+    sys.path.insert(0, str(REPO_ROOT))
+
+    print(f"auth-path benchmark: {db_label} ({args.iterations} iterations/scenario)", file=sys.stderr)
+    rows = _run_matrix(
+        db_uri=db_uri,
+        db_label=db_label,
+        user_counts=args.users,
+        group_counts=args.groups,
+        scenarios=args.scenarios,
+        iterations=args.iterations,
+        warmup=args.warmup,
+    )
+
+    print(_to_markdown(rows))
+    if args.json_path:
+        Path(args.json_path).write_text(json.dumps(rows, indent=2) + "\n")
+        print(f"raw measurements written to {args.json_path}", file=sys.stderr)
+
+    unstable = [r for r in rows if not r["queries_stable"]]
+    if unstable:
+        print(f"\nWARNING: {len(unstable)} scenario(s) had a varying query count; see 'queries_observed'.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_auth_path.py
+++ b/scripts/bench_auth_path.py
@@ -203,7 +203,6 @@ def _prime_jwks() -> Callable[[str], str]:
 
 
 def _measure(
-    client,
     request: Callable[[], Any],
     counter: QueryCounter,
     iterations: int,
@@ -295,7 +294,7 @@ def _run_matrix(
                         "basic": lambda: client.get(PROTECTED_PATH, headers={"Authorization": f"Basic {basic}"}),
                     }
                     for scenario in scenarios:
-                        result = _measure(client, requests[scenario], counter, iterations, warmup)
+                        result = _measure(requests[scenario], counter, iterations, warmup)
                         result.update(db=db_label, users=n_users, groups_per_user=n_groups, scenario=scenario)
                         rows.append(result)
                         print(


### PR DESCRIPTION
Closes #305.

Establishes the per-request authentication budget that the rest of the enterprise identity
epic (#304) is held against. **No production code changes** — this adds a benchmark, a set of
budget tests, and the recorded numbers.

## The claim in #305: confirmed, with one correction to its scope

> `_get_user_admin_status` runs on every authenticated request and issues 2 uncached queries
> via `get_profile`.

- **2 queries — confirmed.** `UserRepository.get_profile` emits exactly two statements: a
  `load_only` select on `users`, and a `selectinload` on `groups`. Identical on SQLite and
  PostgreSQL, at every point in the matrix.
- **Uncached — confirmed.** Two consecutive calls cost four statements. Nothing on this path
  consults `PERMISSION_CACHE_TTL_SECONDS` or the `mlflow_oidc_auth/cache/` backend.
- **"On every request" — too strong.** Unprotected prefixes (`/health`, `/login`, `/callback`,
  `/oidc/ui`, `/oidc/static`, `/metrics`, `/docs`, `/redoc`, `/openapi.json`, `/static-files`)
  return from `dispatch` before any store access, at **0 queries**. Since `/static-files` serves
  MLflow's whole React bundle, a real browser session issues far more 0-query requests than
  2-query ones. The claim holds for every *authenticated* request, not every request.
- **Basic auth costs 3, not 2.** `store.authenticate_user` adds a select for the password hash
  before the admin check. Downstream work assuming a flat 2 needs to account for this path.

Downstream issues citing "2 uncached queries" are safe to keep citing it, as long as they mean
authenticated requests and treat basic auth as 3.

## The budget

Identical in all 72 cells (2 databases x {1, 50, 500} users x {0, 20, 200} groups per user):

| Scenario | Statements/request |
|---|---:|
| unprotected | **0** |
| session | **2** |
| bearer | **2** |
| basic | **3** |

Denial paths: no credentials **0**, invalid bearer token **0**, wrong basic password **1**,
unknown user **1**.

**No subsequent task may raise these numbers.** New per-request data must fit into the existing
statements (widen the `load_only`) or be cached — not add a query. Enforced by
`mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py`, which asserts exactly, so a regression
*and* a silent improvement both fail.

## Wall time

Median/p95 ms per request at the ASGI boundary, 200 iterations, local databases. Selected cells;
the full 18-row table is in `docs/performance-baseline.md`.

| db | users | groups/user | unprotected | session | bearer | basic |
|---|---:|---:|---|---|---|---|
| sqlite | 1 | 0 | 0.41 / 0.48 | 1.09 / 1.28 | 1.28 / 1.74 | 48.91 / 51.23 |
| sqlite | 500 | 200 | 0.48 / 0.65 | 1.95 / 2.61 | 2.08 / 2.78 | 51.75 / 56.25 |
| postgres | 1 | 0 | 0.43 / 0.47 | 1.48 / 2.05 | 1.57 / 2.22 | 53.44 / 55.41 |
| postgres | 500 | 200 | 0.44 / 0.54 | 2.75 / 4.28 | 2.93 / 3.89 | 54.89 / 57.68 |

Three things the timings show:

1. **Constant in user count.** 1 -> 500 users changes nothing measurable, as the unique index on
   `users.username` predicts.
2. **Mildly sensitive to group count.** 0 -> 200 groups/user adds ~1 ms to a session request at an
   unchanged 2 statements — row materialization inside the second query, not extra round trips.
   `selectinload` batches, so 2 never becomes 2 + G; a test guards that.
3. **Basic auth is ~25x session/bearer, and it is not the database.** ~50 ms per request, of which
   a directly measured **48.2 ms is `check_password_hash`** (Werkzeug `scrypt:32768:8:1`,
   deliberately expensive). The 3 statements are noise beside it. Out of scope here, and filed
   separately as #336 so it is not mistaken for a query problem.

Also measured: with `OIDC_PROVISION_ON_BEARER_AUTH` enabled (off by default), bearer costs **3** —
the `has_user` guard runs on *every* bearer request, not just the first. Test added.

## Running it

```bash
python scripts/bench_auth_path.py                                            # SQLite, full matrix
python scripts/bench_auth_path.py --db-uri postgresql+psycopg2://u@h:5432/db # PostgreSQL
pytest mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py                # just the budget
```

The script exits non-zero if a scenario's statement count varies between iterations, since a
varying count is not a usable budget. It did not, in any cell.

## Acceptance criteria

- [x] **Baseline numbers recorded in the repo** — `docs/performance-baseline.md`, query counts and
      timings per scenario, both databases, full matrix.
- [x] **Benchmark runs from one command and is documented** — `python scripts/bench_auth_path.py`,
      documented in that page and in `--help`.
- [x] **The 2-query claim confirmed or corrected in writing** — confirmed, scope corrected; above
      and in the "Findings" section of the page.
- [x] **A stated budget** — stated in `docs/performance-baseline.md`, referenced from `AGENTS.md`,
      and enforced by tests rather than by convention.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 2859 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (run per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed
python -m pyflakes scripts/ tests/perf/           # clean
```

No frontend changes, so `yarn test` / `yarn lint` were not run.

## Commits

- `perf(auth):` the benchmark, the budget tests, and `docs/performance-baseline.md`.
- `ci:` allowed `perf` in PR titles. This is now a **no-op** — the same fix landed on `main` via
  #335, which had to be a separate PR because `pr-validate-title.yml` runs on
  `pull_request_target` and therefore executes the base branch's copy of the workflow. Kept in
  history rather than force-pushed away; the merge of `main` collapsed it, so no workflow change
  remains in this diff.
- `chore:` removed an unused `event` import flagged by github-code-quality, plus a dead `client`
  parameter on the benchmark's `_measure()` that I found while checking it. pyflakes clean; the
  benchmark was re-run end to end afterwards, since a signature change is exactly the kind of
  thing passing tests would not catch.

## Notes for review

- The benchmark installs its own `SqlAlchemyStore` into the lazy `store` singleton, because
  `AuthMiddleware` imports the singleton directly and it cannot be injected. It replaces the
  instance rather than creating a second live one; the pytest fixture restores the previous
  instance afterwards.
- Measurements exclude the JWKS network fetch, matching steady state in production where the key
  set is cached for `OIDC_JWKS_CACHE_TTL_SECONDS`. Signature verification is real.
- The benchmark does not mount MLflow's Flask app, so the Flask `before_request` authorization
  hooks are outside this budget. Those are covered by `test_query_counts.py` (#253).
- Wall times are from one machine with local databases. The statement counts are the portable
  result; the timings are indicative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
