### PR TITLE
ci: allow perf in pull request titles

### DIFF
--- a/.github/workflows/pr-validate-title.yml
+++ b/.github/workflows/pr-validate-title.yml
@@ -19,9 +19,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Keep in sync with the pattern in commit-message-check.yml, which already
+          # accepts these. "perf" is a release type: the angular preset that
+          # @semantic-release/commit-analyzer defaults to maps it to a patch release and
+          # gives it its own "Performance Improvements" changelog section.
           types: |
             fix
             feat
+            perf
             docs
             ci
             chore


### PR DESCRIPTION
The PR-title validator's `types` list omits `perf`, so a performance commit fails the
"Conventional commit title validation" check even though `commit-message-check.yml` already
accepts `perf` in its pattern. [#334](https://github.com/mlflow-oidc/mlflow-oidc-auth/pull/334)
hit this: [failing run](https://github.com/mlflow-oidc/mlflow-oidc-auth/actions/runs/31338101245/job/93307157396?pr=334).

One line: add `perf` to the allowed types, plus a comment noting the two workflows have to stay
in sync.

### Why this is a separate PR

`pr-validate-title.yml` triggers on `pull_request_target`, so GitHub runs the copy of the
workflow on the **base** branch. Fixing it inside #334 therefore cannot unblock #334 — this has
to land on `main` first. (#334 also carries the identical commit; once this merges, that becomes
a no-op there.)

### No `.releaserc` change is needed

`@semantic-release/commit-analyzer` is configured with defaults, so it uses the angular preset,
which already maps `perf` to a **patch** release and gives it its own "Performance Improvements"
section in the release notes. Only the title gate was rejecting it.

### Workflow threat model

Per `AGENTS.md`, for changes under `.github/workflows/` — unchanged by this commit, stated for
review: this job runs on `pull_request_target`, so it holds **untrusted input** (the PR title) and
an **elevated token** (`statuses: write`). It holds neither together with code execution — it
never checks out or runs PR code. Two of the three, which is the workable combination. This commit
changes only a list of allowed strings; it touches neither the trigger nor the permissions.

### Still divergent, deliberately left alone

`commit-message-check.yml` also accepts `style` and `refactor`, which the title validator still
rejects. Out of scope here — flagging it so it is a known gap rather than a surprise for the next
person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
