### PR TITLE
perf(auth): hash token secrets with a cost factor suited to their entropy (#336)

### DIFF
--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -86,6 +86,10 @@ Denial paths, asserted in `test_auth_path_baseline.py`:
 Median / p95 milliseconds per request at the ASGI boundary. Both databases are local, so
 these understate a production round trip; they are recorded for orientation, not as a contract.
 
+> The `basic` column is the **T0** measurement, taken before #336 changed how token secrets are
+> hashed. It now costs ~2.8 ms rather than ~50 ms for any secret written after that change; see
+> the findings below. The other three columns are unaffected.
+
 | db | users | groups/user | unprotected | session | bearer | basic |
 |---|---:|---:|---|---|---|---|
 | sqlite | 1 | 0 | 0.41 / 0.48 | 1.09 / 1.28 | 1.28 / 1.74 | 48.91 / 51.23 |
@@ -141,12 +145,23 @@ groups per user adds roughly 1 ms to a session request (~1.3 ms -> ~2.4 ms on SQ
 materialization inside the second query, not extra round trips. Growing from 1 to 500 users
 changes nothing measurable, as the unique index on `users.username` predicts.
 
-**Basic auth is ~25x more expensive than session or bearer, and it is not the database.** A
-basic-auth request costs ~50 ms against both databases, of which a directly measured
-**48.2 ms is `check_password_hash`** — Werkzeug's `scrypt:32768:8:1`, deliberately expensive by
-design. The 3 SQL statements are noise beside it. This is out of scope for the baseline and is
-noted here so it is not mistaken for a database problem: any future work on basic-auth latency
-belongs in password-hash policy or a verified-credential cache, not in query reduction.
+**Basic auth was ~25x more expensive than session or bearer, and it was not the database.** At
+T0 a basic-auth request cost ~50 ms against both databases, of which a directly measured
+**48.2 ms was `check_password_hash`** — Werkzeug's `scrypt:32768:8:1`. The 3 SQL statements were
+noise beside it.
+
+This was fixed in #336, after the baseline was taken. Nothing in this plugin stores a
+human-chosen password: every value in `users.password_hash` comes from `generate_token()`
+(24 characters, 62-character alphabet, ~143 bits of entropy), and no endpoint accepts an
+operator-supplied one. A memory-hard KDF exists to make brute-forcing *low-entropy* passwords
+expensive, so against 143 bits it bought nothing. New hashes use
+`pbkdf2:sha256:1000` (`TOKEN_HASH_METHOD` in `repository/user.py`), taking a basic-auth request
+from **50.98 ms to 2.81 ms median** — into the same range as session and bearer — at an unchanged
+3 statements.
+
+Hashes written before that change keep verifying under their original method and are never
+re-hashed in place, so a deployment that upgrades and rotates nothing still pays the old ~50 ms
+until its tokens are rotated. Measure that path with `--hash-method scrypt:32768:8:1`.
 
 ## Caveats
 

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -16,6 +16,27 @@ from mlflow_oidc_auth.db.models import SqlGroup, SqlUser
 from mlflow_oidc_auth.entities import User
 from mlflow_oidc_auth.repository.utils import get_user
 
+# Hash method for secrets stored in ``users.password_hash`` (issue #336).
+#
+# Nothing in this plugin stores a human-chosen password. Every value written here comes from
+# ``mlflow_oidc_auth.user.generate_token()`` — 24 characters drawn by ``secrets.choice`` from a
+# 62-character alphabet, about 143 bits of entropy — and no endpoint accepts an operator-supplied
+# password. A memory-hard KDF exists to make brute-forcing *low-entropy* human passwords
+# expensive; against 143 bits there is nothing to brute-force, so the ~48 ms that Werkzeug's
+# default scrypt costs bought no security while being paid on every basic-authenticated request.
+# Verification drops from ~47 ms to ~0.08 ms.
+#
+# Migration is handled by Werkzeug itself: the method is encoded in the stored hash and
+# ``check_password_hash`` dispatches on it, so hashes written before this change keep verifying
+# under scrypt, unchanged. Only newly written hashes use this method — a secret moves over when
+# its token is rotated. Existing hashes are deliberately never re-hashed in place: a stored
+# secret cannot be distinguished from a hypothetical operator-set password, and silently
+# re-hashing one at this cost factor would weaken it.
+#
+# This is intentionally a constant, not configuration. It is a property of what we store, not a
+# deployment choice, and the failure mode of setting it wrong is silent.
+TOKEN_HASH_METHOD = "pbkdf2:sha256:1000"
+
 
 def normalize_username(username: str) -> str:
     """Fold a username to its canonical (lowercase) form.
@@ -45,7 +66,7 @@ class UserRepository:
     ) -> User:
         username = normalize_username(username)
         _validate_username(username)
-        pwhash = generate_password_hash(password)
+        pwhash = generate_password_hash(password, method=TOKEN_HASH_METHOD)
         with self._Session(read_only=False) as session:
             try:
                 u = SqlUser(
@@ -161,7 +182,7 @@ class UserRepository:
         with self._Session(read_only=False) as session:
             user = get_user(session, username)
             if password is not None:
-                user.password_hash = generate_password_hash(password)
+                user.password_hash = generate_password_hash(password, method=TOKEN_HASH_METHOD)
             if password_expiration is not None:
                 user.password_expiration = password_expiration
             if is_admin is not None:

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -35,6 +35,13 @@ from mlflow_oidc_auth.repository.utils import get_user
 #
 # This is intentionally a constant, not configuration. It is a property of what we store, not a
 # deployment choice, and the failure mode of setting it wrong is silent.
+#
+# The entropy premise is not self-enforcing: ``generate_token()`` lives in another module, and
+# shortening it or narrowing its alphabet would make this cost factor indefensible without
+# anything here changing. ``TestTokenEntropyPremise`` in
+# ``tests/repository/test_user_token_hashing.py`` pins the token's length, alphabet and resulting
+# entropy, so that change fails a test instead of passing quietly. If one of those tests has to
+# be updated, this constant has to be re-justified in the same diff.
 TOKEN_HASH_METHOD = "pbkdf2:sha256:1000"
 
 

--- a/mlflow_oidc_auth/tests/repository/test_user_token_hashing.py
+++ b/mlflow_oidc_auth/tests/repository/test_user_token_hashing.py
@@ -151,6 +151,58 @@ class TestExpiryStillEnforced:
         assert store.authenticate_user("expold@example.com", TOKEN) is False
 
 
+class TestTokenEntropyPremise:
+    """The premise ``TOKEN_HASH_METHOD`` rests on, pinned so it cannot erode silently.
+
+    A cost factor of 1000 PBKDF2 iterations is only defensible because the secret being
+    hashed is high-entropy. That property lives in ``generate_token()``, in a different
+    module, with nothing previously connecting the two: shortening the token for usability
+    would quietly make every stored hash brute-forceable, and no test would fail.
+
+    These are the tests that fail instead. If one of them breaks, ``TOKEN_HASH_METHOD``
+    has to be re-justified in the same diff, not discovered later.
+    """
+
+    MIN_ENTROPY_BITS = 128
+
+    def test_token_length_is_pinned(self):
+        from mlflow_oidc_auth.user import generate_token
+
+        assert len(generate_token()) == 24
+
+    def test_token_alphabet_is_pinned(self):
+        """Narrowing the alphabet lowers entropy just as shortening the token does."""
+        import string
+
+        from mlflow_oidc_auth.user import generate_token
+
+        expected = set(string.ascii_letters + string.digits)
+        # Enough samples that a dropped character class shows up rather than passing by luck.
+        seen = set("".join(generate_token() for _ in range(200)))
+
+        assert seen <= expected, f"token uses characters outside the expected alphabet: {sorted(seen - expected)}"
+        assert seen == expected, f"token alphabet appears narrowed; never observed: {sorted(expected - seen)}"
+
+    def test_token_entropy_clears_the_bar_the_hash_cost_assumes(self):
+        """The number that justifies TOKEN_HASH_METHOD, asserted rather than asserted-in-prose."""
+        import math
+        import string
+
+        from mlflow_oidc_auth.user import generate_token
+
+        bits = len(generate_token()) * math.log2(len(set(string.ascii_letters + string.digits)))
+
+        assert bits >= self.MIN_ENTROPY_BITS, f"token entropy {bits:.1f} bits is below the {self.MIN_ENTROPY_BITS}-bit floor that {TOKEN_HASH_METHOD} assumes"
+
+    def test_tokens_are_not_repeated(self):
+        """A deterministic or poorly seeded generator would defeat the entropy argument."""
+        from mlflow_oidc_auth.user import generate_token
+
+        tokens = [generate_token() for _ in range(500)]
+
+        assert len(set(tokens)) == len(tokens)
+
+
 class TestHashProperties:
     """Properties the chosen method must keep, independent of its cost factor."""
 

--- a/mlflow_oidc_auth/tests/repository/test_user_token_hashing.py
+++ b/mlflow_oidc_auth/tests/repository/test_user_token_hashing.py
@@ -1,0 +1,175 @@
+"""Hashing of stored token secrets (issue #336).
+
+``users.password_hash`` never holds a human-chosen password — every value comes from
+``generate_token()`` (24 characters, 62-character alphabet, ~143 bits of entropy), and no
+endpoint accepts an operator-supplied one. Werkzeug's default scrypt therefore cost ~48 ms per
+basic-authenticated request to protect something with nothing to brute-force.
+
+These tests pin the two things that make the change safe:
+
+1. new hashes use the cheap method, and
+2. hashes written *before* the change still verify, and are never silently re-hashed down to it.
+
+The second is the one that matters. If it ever fails, an upgrade has either locked existing
+users out or quietly weakened a stored secret.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from mlflow_oidc_auth.repository.user import TOKEN_HASH_METHOD
+
+LEGACY_METHOD = "scrypt:32768:8:1"
+TOKEN = "aB3dE6gH9jK2mN5pQ8sT1vW4"  # shaped like generate_token() output; only ever in a tmp db
+
+
+def _stored_hash(store, username: str) -> str:
+    """Read the raw hash, which ``get_profile`` deliberately redacts."""
+    from mlflow_oidc_auth.db.models import SqlUser
+
+    with store.engine.connect() as conn:
+        row = conn.execute(SqlUser.__table__.select().where(SqlUser.__table__.c.username == username)).fetchone()
+    assert row is not None, f"user {username} not found"
+    return row.password_hash
+
+
+def _method_of(pwhash: str) -> str:
+    """Werkzeug encodes the method as the first ``$``-delimited field."""
+    return pwhash.split("$", 1)[0]
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A real store on a temporary SQLite database."""
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    return s
+
+
+def _write_legacy_hash(store, username: str, secret: str) -> None:
+    """Overwrite a user's hash with a scrypt one, simulating a pre-#336 row."""
+    from mlflow_oidc_auth.db.models import SqlUser
+
+    legacy = generate_password_hash(secret, method=LEGACY_METHOD)
+    with store.engine.begin() as conn:
+        conn.execute(SqlUser.__table__.update().where(SqlUser.__table__.c.username == username).values(password_hash=legacy))
+    assert _method_of(_stored_hash(store, username)) == LEGACY_METHOD
+
+
+class TestNewHashesUseTheCheapMethod:
+    def test_created_user_uses_the_token_hash_method(self, store):
+        store.create_user("new@example.com", TOKEN, "New User")
+
+        assert _method_of(_stored_hash(store, "new@example.com")) == TOKEN_HASH_METHOD
+
+    def test_rotated_token_uses_the_token_hash_method(self, store):
+        store.create_user("rot@example.com", TOKEN, "Rot User")
+        _write_legacy_hash(store, "rot@example.com", TOKEN)
+
+        store.update_user(username="rot@example.com", password="nEwT0ken4567890abcdefghij")
+
+        assert _method_of(_stored_hash(store, "rot@example.com")) == TOKEN_HASH_METHOD
+
+    def test_new_hash_authenticates(self, store):
+        store.create_user("auth@example.com", TOKEN, "Auth User")
+
+        assert store.authenticate_user("auth@example.com", TOKEN) is True
+
+    def test_new_hash_rejects_a_wrong_secret(self, store):
+        """The negative case: a cheaper hash must not become a permissive one."""
+        store.create_user("neg@example.com", TOKEN, "Neg User")
+
+        assert store.authenticate_user("neg@example.com", "wrong-secret") is False
+
+
+class TestLegacyHashesKeepWorking:
+    """Back-compat: a deployment that upgrades and changes nothing must be unaffected."""
+
+    def test_legacy_scrypt_hash_still_authenticates(self, store):
+        store.create_user("old@example.com", TOKEN, "Old User")
+        _write_legacy_hash(store, "old@example.com", TOKEN)
+
+        assert store.authenticate_user("old@example.com", TOKEN) is True
+
+    def test_legacy_scrypt_hash_rejects_a_wrong_secret(self, store):
+        store.create_user("oldneg@example.com", TOKEN, "Old Neg User")
+        _write_legacy_hash(store, "oldneg@example.com", TOKEN)
+
+        assert store.authenticate_user("oldneg@example.com", "wrong-secret") is False
+
+    def test_successful_auth_does_not_rehash_a_legacy_secret(self, store):
+        """No silent downgrade.
+
+        A stored secret cannot be distinguished from a hypothetical operator-set password, so
+        authenticating against a legacy hash must leave it exactly as it was. A secret moves to
+        the cheap method only by being rotated, which replaces it with a generated token.
+        """
+        store.create_user("keep@example.com", TOKEN, "Keep User")
+        _write_legacy_hash(store, "keep@example.com", TOKEN)
+        before = _stored_hash(store, "keep@example.com")
+
+        assert store.authenticate_user("keep@example.com", TOKEN) is True
+
+        after = _stored_hash(store, "keep@example.com")
+        assert after == before, "legacy hash was rewritten on successful authentication"
+        assert _method_of(after) == LEGACY_METHOD
+
+    def test_failed_auth_does_not_rehash_a_legacy_secret(self, store):
+        store.create_user("keepneg@example.com", TOKEN, "Keep Neg User")
+        _write_legacy_hash(store, "keepneg@example.com", TOKEN)
+        before = _stored_hash(store, "keepneg@example.com")
+
+        assert store.authenticate_user("keepneg@example.com", "wrong-secret") is False
+
+        assert _stored_hash(store, "keepneg@example.com") == before
+
+
+class TestExpiryStillEnforced:
+    """The cheaper hash must not disturb the expiration gate that runs alongside it."""
+
+    def test_expired_secret_is_rejected_under_the_new_method(self, store):
+        store.create_user("exp@example.com", TOKEN, "Exp User")
+        store.update_user(username="exp@example.com", password=TOKEN, password_expiration=datetime.now(timezone.utc) - timedelta(days=1))
+
+        assert store.authenticate_user("exp@example.com", TOKEN) is False
+
+    def test_unexpired_secret_is_accepted_under_the_new_method(self, store):
+        store.create_user("live@example.com", TOKEN, "Live User")
+        store.update_user(username="live@example.com", password=TOKEN, password_expiration=datetime.now(timezone.utc) + timedelta(days=1))
+
+        assert store.authenticate_user("live@example.com", TOKEN) is True
+
+    def test_expired_legacy_secret_is_still_rejected(self, store):
+        store.create_user("expold@example.com", TOKEN, "Exp Old User")
+        store.update_user(username="expold@example.com", password=TOKEN, password_expiration=datetime.now(timezone.utc) - timedelta(days=1))
+        _write_legacy_hash(store, "expold@example.com", TOKEN)
+
+        assert store.authenticate_user("expold@example.com", TOKEN) is False
+
+
+class TestHashProperties:
+    """Properties the chosen method must keep, independent of its cost factor."""
+
+    def test_hashes_are_salted(self, store):
+        """Two users with the same secret must not share a hash."""
+        store.create_user("salt1@example.com", TOKEN, "Salt One")
+        store.create_user("salt2@example.com", TOKEN, "Salt Two")
+
+        assert _stored_hash(store, "salt1@example.com") != _stored_hash(store, "salt2@example.com")
+
+    def test_secret_is_not_stored_in_clear(self, store):
+        store.create_user("clear@example.com", TOKEN, "Clear User")
+
+        assert TOKEN not in _stored_hash(store, "clear@example.com")
+
+    def test_profile_never_exposes_the_hash(self, store):
+        """``get_profile`` is what the auth path calls; it must keep redacting."""
+        store.create_user("prof@example.com", TOKEN, "Prof User")
+
+        profile = store.get_user_profile("prof@example.com")
+
+        assert profile.password_hash == "REDACTED"

--- a/scripts/bench_auth_path.py
+++ b/scripts/bench_auth_path.py
@@ -139,12 +139,17 @@ def _build_app(store) -> Any:
     return app
 
 
-def _seed(store, n_users: int, n_groups: int) -> List[str]:
+def _seed(store, n_users: int, n_groups: int, hash_method: Optional[str] = None) -> List[str]:
     """Bulk-insert ``n_users`` users each belonging to ``n_groups`` groups.
 
     Uses Core inserts rather than the store API: seeding 500 users x 200 groups through
     the ORM takes minutes and none of it is what we are measuring. The password hash is
     computed once and reused, so the basic-auth scenario still verifies a real hash.
+
+    ``hash_method`` defaults to the repository's ``TOKEN_HASH_METHOD`` so the seeded rows
+    match what the plugin actually writes. Passing an older method (for example
+    ``scrypt:32768:8:1``) measures the cost a deployment still pays for hashes written
+    before #336 — those keep verifying under their original method until rotated.
 
     Returns:
         The seeded usernames.
@@ -153,8 +158,9 @@ def _seed(store, n_users: int, n_groups: int) -> List[str]:
     from werkzeug.security import generate_password_hash
 
     from mlflow_oidc_auth.db.models import SqlGroup, SqlUser, SqlUserGroup
+    from mlflow_oidc_auth.repository.user import TOKEN_HASH_METHOD
 
-    pwhash = generate_password_hash(BENCH_PASSWORD)
+    pwhash = generate_password_hash(BENCH_PASSWORD, method=hash_method or TOKEN_HASH_METHOD)
     usernames = [f"bench{i}@example.com" for i in range(n_users)]
     group_names = [f"bench-group-{i}" for i in range(n_groups)]
 
@@ -249,6 +255,7 @@ def _run_matrix(
     scenarios: Iterable[str],
     iterations: int,
     warmup: int,
+    hash_method: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Run every (users, groups, scenario) combination against one database."""
     from fastapi.testclient import TestClient
@@ -265,7 +272,7 @@ def _run_matrix(
             store.init_db(db_uri)
             _reset_rows(store)
 
-            usernames = _seed(store, n_users, n_groups)
+            usernames = _seed(store, n_users, n_groups, hash_method)
             # The middleware resolves through the module-level store singleton, so point
             # it at this freshly seeded store rather than constructing a second one.
             _bind_singleton(store)
@@ -354,6 +361,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--scenarios", nargs="+", default=list(SCENARIOS), choices=list(SCENARIOS))
     parser.add_argument("--iterations", type=int, default=200)
     parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument(
+        "--hash-method",
+        default=None,
+        help="Werkzeug hash method for seeded secrets. Default: the repository's TOKEN_HASH_METHOD. "
+        "Pass scrypt:32768:8:1 to measure hashes written before #336.",
+    )
     parser.add_argument("--json", dest="json_path", default=None, help="Also write raw measurements here.")
     args = parser.parse_args(argv)
 
@@ -376,6 +389,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         scenarios=args.scenarios,
         iterations=args.iterations,
         warmup=args.warmup,
+        hash_method=args.hash_method,
     )
 
     print(_to_markdown(rows))


### PR DESCRIPTION
Closes #336.

## The issue was framed wrong, and the investigation says so

#336 assumed basic auth was slow because of a password-hashing *cost* that had to be worked
around — with a verified-credential cache, rate limiting, or tuning. That framing was mine, and
it was wrong.

**Nothing in this plugin stores a human-chosen password.** Every value ever written to
`users.password_hash` comes from `generate_token()` — 24 characters drawn by `secrets.choice`
from a 62-character alphabet, **142.9 bits of entropy**. There are exactly two writers
(`repository/user.py`, on create and on rotate), and `CreateUserRequest` has no password field:
no endpoint accepts an operator-supplied password.

That makes the 48 ms a category error rather than a tuning problem. scrypt is a memory-hard KDF
whose purpose is making brute-force of *low-entropy* human passwords expensive. Against a
143-bit random token there is nothing to brute-force — at 10^12 guesses/sec, exhausting the space
takes ~10^26 years. The cost bought nothing and was paid on every basic-authenticated request.

So this PR does not add a cache. It corrects the hash method.

## The change

One constant and two call sites:

```python
TOKEN_HASH_METHOD = "pbkdf2:sha256:1000"
```

| method | verify | notes |
|---|---:|---|
| `scrypt:32768:8:1` (old default) | 47.0 ms | |
| `pbkdf2:sha256:600000` | 47.3 ms | no better |
| `pbkdf2:sha256:1000` (**new**) | **0.077 ms** | 610x faster |

Deliberately a constant, not configuration: it is a property of what we store, not a deployment
choice, and the failure mode of setting it wrong is silent.

## Results

Measured with `scripts/bench_auth_path.py` (50 users, 20 groups, 200 iterations, SQLite):

| scenario | before | after | statements |
|---|---:|---:|---:|
| basic | 50.98 ms | **2.81 ms** | 3 → 3 |
| session | 1.31 ms | 1.75 ms | 2 → 2 |
| bearer | 1.56 ms | 2.28 ms | 2 → 2 |
| unprotected | 0.44 ms | 0.55 ms | 0 → 0 |

**Basic auth: 18x faster**, now in the same range as session and bearer. Session/bearer deltas are
run-to-run noise — nothing on those paths changed. The statement budget from #305 is unchanged and
`test_auth_path_baseline.py` still passes.

### A security improvement, not just a speedup

The old cost was itself a **username-enumeration oracle**: a wrong password for an existing user
took ~52 ms (full scrypt) while an unknown user returned in ~0.2 ms (no hash to check). That
250x gap is trivially observable over a network. Measured:

| | wrong password, user exists | unknown user | delta |
|---|---:|---:|---:|
| before | 52.661 ms | 0.191 ms | **52.470 ms** |
| after | 0.284 ms | 0.209 ms | **0.075 ms** |

The oracle shrinks 700x, to well below network jitter. Not tested in CI — a timing assertion
would be flaky — so it is recorded here and in `docs/performance-baseline.md`.

## Back-compat: nothing existing is weakened

Werkzeug encodes the method inside the stored hash and `check_password_hash` dispatches on it, so
hashes written before this change keep verifying **under scrypt, untouched**. No dual-read logic,
no migration script, no schema change.

Existing hashes are deliberately **never re-hashed in place**, even on successful authentication.
A stored secret cannot be distinguished from a hypothetical operator-set password, and silently
re-hashing one down to 1000 iterations would be a real weakening. The cost is that an existing
deployment keeps paying ~50 ms until its tokens are rotated — slower to pay off, but it cannot
weaken anything that exists today. Rotation is already a supported UI action.

Measure that path with `--hash-method scrypt:32768:8:1`, added to the benchmark.

## Tests

`mlflow_oidc_auth/tests/repository/test_user_token_hashing.py`, 14 tests. The ones that matter are
the back-compat and negative cases:

- a pre-change scrypt hash still authenticates, and still **rejects** a wrong secret;
- a successful authentication against a legacy hash leaves the stored hash byte-identical — the
  no-silent-downgrade guarantee, asserted rather than assumed;
- a failed authentication likewise leaves it untouched;
- the new method rejects a wrong secret;
- expiry is still enforced, under both the new and the legacy method;
- hashes are salted (two users, same secret, different hashes), the secret never appears in the
  stored hash, and `get_profile` still redacts.

Also fixed a defect in the #305 benchmark: `_seed` hashed with Werkzeug's default rather than the
repository's method, so it would have kept measuring scrypt forever and reported no improvement.
It now uses `TOKEN_HASH_METHOD`, with `--hash-method` to override.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 2873 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 budget intact
```

No frontend changes. No migration: this changes the format of newly written values in an existing
column, not the schema.

## Acceptance criteria from #336

- [x] **Decision recorded with rationale** — above, and in the `TOKEN_HASH_METHOD` comment. The
      recorded decision is that the premise was wrong: no cache is needed.
- [x] **Changed password rejected immediately, not after a TTL** — no cache exists, so this cannot
      regress; rotation takes effect on the next request by construction.
- [x] **Wrong password never populates a cache** — no cache.
- [x] **No plaintext credential stored anywhere** — asserted by `test_secret_is_not_stored_in_clear`.
- [x] **Basic-auth statement count still 3** — `pytest mlflow_oidc_auth/tests/perf/` passes.
- [x] **Before/after numbers in the PR body** — above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
