### PR TITLE
fix(auth): make omitted arguments mean "unchanged" in UserRepository.update (#338)

### DIFF
--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -180,9 +180,43 @@ class UserRepository:
         username: str,
         password: Optional[str] = None,
         password_expiration: Optional[datetime] = None,
-        is_admin: Optional[bool] = False,
-        is_service_account: Optional[bool] = False,
+        is_admin: Optional[bool] = None,
+        is_service_account: Optional[bool] = None,
     ) -> User:
+        """Update the supplied fields of a user, leaving omitted ones untouched.
+
+        ``None`` means "not supplied" for every parameter but one: the corresponding column is
+        left as it is. The defaults for the two flags previously read ``False`` while the guards
+        below tested for ``None``, so a caller that omitted them silently cleared ``is_admin``
+        and ``is_service_account`` instead of preserving them (issue #338).
+
+        The exception is ``password_expiration``, because expiry is a property of the *secret*
+        rather than of the user:
+
+        * When ``password`` is supplied, the secret is being replaced, so it gets a fresh
+          lifetime — exactly the one passed in, with ``None`` meaning "does not expire". The
+          previous value is never inherited. Inheriting it meant that rotating an already-expired
+          token produced a new token that was rejected on its first use, because ``authenticate``
+          checks expiry before comparing the hash.
+        * When ``password`` is not supplied, the expiry is only changed if one was passed.
+
+        A consequence worth stating: an expiry cannot be cleared without also rotating the
+        secret. That is deliberate — extending the life of a credential that has already been
+        issued should require issuing a new one.
+
+        Parameters:
+            username: Identity key of the user to update.
+            password: New secret. Hashed with :data:`TOKEN_HASH_METHOD`.
+            password_expiration: Expiry for the stored secret. See the semantics above.
+            is_admin: New administrator flag.
+            is_service_account: New service-account flag.
+
+        Returns:
+            User: The updated user entity.
+
+        Raises:
+            MlflowException: If the user does not exist.
+        """
         from werkzeug.security import generate_password_hash
 
         username = normalize_username(username)
@@ -190,7 +224,9 @@ class UserRepository:
             user = get_user(session, username)
             if password is not None:
                 user.password_hash = generate_password_hash(password, method=TOKEN_HASH_METHOD)
-            if password_expiration is not None:
+                # A new secret gets the lifetime it was issued with, never the old one's.
+                user.password_expiration = password_expiration
+            elif password_expiration is not None:
                 user.password_expiration = password_expiration
             if is_admin is not None:
                 user.is_admin = is_admin

--- a/mlflow_oidc_auth/routers/users.py
+++ b/mlflow_oidc_auth/routers/users.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.responses import JSONResponse
+from mlflow.exceptions import MlflowException
 
 from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.dependencies import check_admin_permission
@@ -97,6 +98,13 @@ async def create_access_token(
 
             try:
                 expiration = datetime.fromisoformat(expiration_str)
+                # An ISO 8601 timestamp carries no offset unless one is written, and both
+                # "2027-01-01" and "2027-01-01T00:00:00" are valid. Comparing a naive datetime
+                # to an aware one raises TypeError, which is not a ValueError and so used to
+                # escape as a 500. This layer deals in UTC — the 'Z' handling above says so —
+                # so read a missing offset as UTC rather than rejecting the request (issue #338).
+                if expiration.tzinfo is None:
+                    expiration = expiration.replace(tzinfo=timezone.utc)
                 now = datetime.now(timezone.utc)
 
                 if expiration < now:
@@ -107,11 +115,17 @@ async def create_access_token(
                         status_code=400,
                         detail="Expiration date must be less than 1 year in the future",
                     )
-            except ValueError:
+            except (ValueError, TypeError):
+                # TypeError is belt-and-braces: the normalization above should make it
+                # unreachable, but a bad expiration must never become a 500.
                 raise HTTPException(status_code=400, detail=f"Invalid expiration date format")
 
-        # Check if the target user exists
-        user = store.get_user_profile(target_username)
+        # Check if the target user exists. get_user_profile raises rather than returning None,
+        # so without this the outer handler turns a mistyped username into a 500 (issue #338).
+        try:
+            user = store.get_user_profile(target_username)
+        except MlflowException:
+            raise HTTPException(status_code=404, detail=f"User {target_username} not found")
         if user is None:
             raise HTTPException(status_code=404, detail=f"User {target_username} not found")
 

--- a/mlflow_oidc_auth/routers/users.py
+++ b/mlflow_oidc_auth/routers/users.py
@@ -115,7 +115,9 @@ async def create_access_token(
         if user is None:
             raise HTTPException(status_code=404, detail=f"User {target_username} not found")
 
-        # Generate new token and update user
+        # Generate new token and update user. The new token carries exactly the expiration
+        # requested here; it never inherits the previous token's (issue #338).
+        previous_expiration = user.password_expiration
         new_token = generate_token()
         store.update_user(username=target_username, password=new_token, password_expiration=expiration)
         emit_audit_event(
@@ -123,6 +125,13 @@ async def create_access_token(
             actor=current_username,
             resource_type="user",
             resource_id=target_username,
+            detail={
+                "expiration": expiration.isoformat() if expiration else None,
+                # Rotating without an expiration replaces an expiring token with one that does
+                # not expire. That is a deliberate widening of the credential's lifetime, so it
+                # is recorded rather than left silent.
+                "expiration_cleared": previous_expiration is not None and expiration is None,
+            },
         )
 
         return JSONResponse(

--- a/mlflow_oidc_auth/tests/repository/test_user_update_semantics.py
+++ b/mlflow_oidc_auth/tests/repository/test_user_update_semantics.py
@@ -1,0 +1,173 @@
+"""Argument semantics of ``UserRepository.update`` (issue #338).
+
+Two defects shared one root cause: what "argument not supplied" meant was inconsistent with the
+method's own parameter defaults.
+
+* ``is_admin`` / ``is_service_account`` defaulted to ``False`` while the guards tested for
+  ``None``, so omitting them cleared the flags instead of preserving them.
+* ``password_expiration`` was only ever assigned when supplied, so a rotated token inherited the
+  previous token's expiry — and since ``authenticate`` checks expiry before comparing the hash, a
+  token rotated after the old one expired was rejected on its first use.
+
+The rule these tests pin: omitted means untouched, except that replacing the secret also replaces
+its lifetime with exactly the one supplied.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+TOKEN = "aB3dE6gH9jK2mN5pQ8sT1vW4"  # shaped like generate_token() output; only ever in a tmp db
+ROTATED = "zY9xW8vU7tS6rQ5pO4nM3lK2"
+
+
+@pytest.fixture
+def store(tmp_path):
+    """A real store on a temporary SQLite database."""
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    return s
+
+
+def _past() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=1)
+
+
+def _future() -> datetime:
+    return datetime.now(timezone.utc) + timedelta(days=30)
+
+
+class TestRotationDoesNotInheritExpiry:
+    """A newly issued secret must never arrive already dead."""
+
+    def test_rotating_an_expired_token_yields_a_usable_one(self, store):
+        """The headline bug: the new token was rejected on its first use.
+
+        Reachable through the access-token endpoint whenever the request body omits
+        ``expiration``, which is the default path for direct API and SDK callers.
+        """
+        store.create_user("exp@example.com", TOKEN, "Exp User")
+        store.update_user(username="exp@example.com", password=TOKEN, password_expiration=_past())
+        assert store.authenticate_user("exp@example.com", TOKEN) is False, "precondition: the old token is expired"
+
+        store.update_user(username="exp@example.com", password=ROTATED)
+
+        assert store.authenticate_user("exp@example.com", ROTATED) is True
+
+    def test_rotating_clears_a_past_expiry(self, store):
+        store.create_user("clr@example.com", TOKEN, "Clr User")
+        store.update_user(username="clr@example.com", password=TOKEN, password_expiration=_past())
+
+        store.update_user(username="clr@example.com", password=ROTATED)
+
+        assert store.get_user_profile("clr@example.com").password_expiration is None
+
+    def test_rotating_clears_a_future_expiry_too(self, store):
+        """Omitting the expiration means "no expiry", not "keep whatever was there".
+
+        The widening is deliberate and is recorded in the audit event emitted by the router; see
+        ``TestTokenRotateAudit`` in tests/routers.
+        """
+        store.create_user("fut@example.com", TOKEN, "Fut User")
+        store.update_user(username="fut@example.com", password=TOKEN, password_expiration=_future())
+
+        store.update_user(username="fut@example.com", password=ROTATED)
+
+        assert store.get_user_profile("fut@example.com").password_expiration is None
+
+    def test_rotating_with_an_expiration_applies_exactly_that_one(self, store):
+        store.create_user("set@example.com", TOKEN, "Set User")
+        store.update_user(username="set@example.com", password=TOKEN, password_expiration=_past())
+        wanted = _future().replace(microsecond=0)
+
+        store.update_user(username="set@example.com", password=ROTATED, password_expiration=wanted)
+
+        stored = store.get_user_profile("set@example.com").password_expiration
+        assert stored is not None
+        assert stored.replace(tzinfo=timezone.utc) == wanted
+
+    def test_an_explicit_past_expiration_is_still_honoured(self, store):
+        """The negative case: the fix must not turn into "ignore expiry".
+
+        A caller that deliberately supplies a past expiration is revoking the credential, and
+        that must still take effect.
+        """
+        store.create_user("rev@example.com", TOKEN, "Rev User")
+
+        store.update_user(username="rev@example.com", password=ROTATED, password_expiration=_past())
+
+        assert store.authenticate_user("rev@example.com", ROTATED) is False
+
+
+class TestNonRotatingUpdatesLeaveExpiryAlone:
+    """Group sync and flag changes must not disturb a credential's lifetime."""
+
+    def test_updating_only_flags_preserves_a_future_expiry(self, store):
+        store.create_user("keep@example.com", TOKEN, "Keep User")
+        wanted = _future().replace(microsecond=0)
+        store.update_user(username="keep@example.com", password=TOKEN, password_expiration=wanted)
+
+        store.update_user(username="keep@example.com", is_admin=True)
+
+        stored = store.get_user_profile("keep@example.com").password_expiration
+        assert stored is not None
+        assert stored.replace(tzinfo=timezone.utc) == wanted
+
+    def test_setting_only_an_expiration_still_works(self, store):
+        store.create_user("only@example.com", TOKEN, "Only User")
+
+        store.update_user(username="only@example.com", password_expiration=_past())
+
+        assert store.authenticate_user("only@example.com", TOKEN) is False
+
+
+class TestOmittedFlagsArePreserved:
+    """Omitting a flag must leave it as it was, not clear it."""
+
+    def test_repo_update_with_only_a_password_preserves_admin(self, store):
+        """The direct-repository call that silently demoted an admin."""
+        store.create_user("adm@example.com", TOKEN, "Adm User", is_admin=True, is_service_account=True)
+
+        store.user_repo.update(username="adm@example.com", password=ROTATED)
+
+        profile = store.get_user_profile("adm@example.com")
+        assert profile.is_admin is True
+        assert profile.is_service_account is True
+
+    def test_repo_update_with_only_an_expiration_preserves_admin(self, store):
+        store.create_user("adm2@example.com", TOKEN, "Adm2 User", is_admin=True, is_service_account=True)
+
+        store.user_repo.update(username="adm2@example.com", password_expiration=_future())
+
+        profile = store.get_user_profile("adm2@example.com")
+        assert profile.is_admin is True
+        assert profile.is_service_account is True
+
+    def test_store_update_with_only_a_password_preserves_admin(self, store):
+        """The path that was already safe, pinned so it stays that way."""
+        store.create_user("adm3@example.com", TOKEN, "Adm3 User", is_admin=True, is_service_account=True)
+
+        store.update_user(username="adm3@example.com", password=ROTATED)
+
+        profile = store.get_user_profile("adm3@example.com")
+        assert profile.is_admin is True
+        assert profile.is_service_account is True
+
+    @pytest.mark.parametrize("flag", ["is_admin", "is_service_account"])
+    def test_flags_can_still_be_set_false_explicitly(self, flag):
+        """Preserving on omission must not make demotion impossible."""
+        # Built per-parametrisation rather than via the fixture so each case gets its own db.
+        import tempfile
+        from pathlib import Path
+
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{Path(tempfile.mkdtemp()) / 'auth.db'}")
+        s.create_user("dem@example.com", TOKEN, "Dem User", is_admin=True, is_service_account=True)
+
+        s.update_user(username="dem@example.com", **{flag: False})
+
+        assert getattr(s.get_user_profile("dem@example.com"), flag) is False

--- a/mlflow_oidc_auth/tests/routers/test_users_token_rotate_audit.py
+++ b/mlflow_oidc_auth/tests/routers/test_users_token_rotate_audit.py
@@ -1,0 +1,79 @@
+"""Audit detail emitted when an access token is rotated (issue #338).
+
+Rotating without an ``expiration`` replaces an expiring token with one that does not expire.
+That widens the credential's lifetime, so it is recorded rather than left silent — these tests
+pin that the signal is actually emitted and is not a constant.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow_oidc_auth.models import CreateAccessTokenRequest
+from mlflow_oidc_auth.routers.users import create_access_token
+
+
+def _store_with_expiration(expiration):
+    """A mock store whose current user carries ``expiration``."""
+    store = MagicMock()
+    user = MagicMock()
+    user.password_expiration = expiration
+    store.get_user_profile.return_value = user
+    return store
+
+
+async def _rotate(store, token_request=None):
+    """Drive the endpoint and return the audit call's kwargs."""
+    with patch("mlflow_oidc_auth.routers.users.store", store):
+        with patch("mlflow_oidc_auth.routers.users.emit_audit_event") as audit:
+            result = await create_access_token(
+                token_request=token_request,
+                current_username="user@example.com",
+                is_admin=False,
+            )
+    assert result.status_code == 200
+    audit.assert_called_once()
+    return audit.call_args
+
+
+class TestTokenRotateAudit:
+    @pytest.mark.asyncio
+    async def test_dropping_an_expiry_is_recorded(self):
+        """Expiring token, rotated with no expiration: the widening must be visible."""
+        store = _store_with_expiration(datetime.now(timezone.utc) + timedelta(days=30))
+
+        call = await _rotate(store)
+
+        assert call[0][0] == "user.token_rotate"
+        assert call[1]["detail"]["expiration_cleared"] is True
+        assert call[1]["detail"]["expiration"] is None
+
+    @pytest.mark.asyncio
+    async def test_rotating_a_non_expiring_token_is_not_recorded_as_a_widening(self):
+        """Nothing was dropped, so the flag must be False — otherwise it is noise, not a signal."""
+        store = _store_with_expiration(None)
+
+        call = await _rotate(store)
+
+        assert call[1]["detail"]["expiration_cleared"] is False
+
+    @pytest.mark.asyncio
+    async def test_rotating_with_an_expiration_is_not_a_widening(self):
+        """A replacement expiry is not a drop, and the new value is recorded."""
+        store = _store_with_expiration(datetime.now(timezone.utc) + timedelta(days=1))
+        wanted = datetime.now(timezone.utc) + timedelta(days=30)
+
+        call = await _rotate(store, CreateAccessTokenRequest(expiration=wanted.isoformat()))
+
+        assert call[1]["detail"]["expiration_cleared"] is False
+        assert call[1]["detail"]["expiration"] is not None
+
+    @pytest.mark.asyncio
+    async def test_the_new_expiration_is_passed_to_the_store(self):
+        """Guards the router half of the fix: what is audited is what is stored."""
+        store = _store_with_expiration(datetime.now(timezone.utc) - timedelta(days=1))
+
+        await _rotate(store)
+
+        assert store.update_user.call_args[1]["password_expiration"] is None

--- a/mlflow_oidc_auth/tests/routers/test_users_token_rotate_errors.py
+++ b/mlflow_oidc_auth/tests/routers/test_users_token_rotate_errors.py
@@ -1,0 +1,151 @@
+"""Error handling in the access-token endpoint (issue #338, raised in review of #339).
+
+Two paths returned an opaque 500 for conditions that have a correct status code:
+
+* an ISO 8601 expiration written without a UTC offset, because comparing a naive datetime to an
+  aware one raises ``TypeError`` and the handler only caught ``ValueError``;
+* a target username that does not exist, because ``get_user_profile`` raises rather than
+  returning ``None``, so the 404 branch was unreachable.
+
+The first mattered beyond tidiness: an operator who hits an unexplained 500 naturally retries
+with the ``expiration`` field dropped, and since #338 that issues a token which never expires.
+A wrong status code turned into an accidental permanent credential.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from mlflow.exceptions import MlflowException
+
+from mlflow_oidc_auth.models import CreateAccessTokenRequest
+from mlflow_oidc_auth.routers.users import create_access_token
+
+
+def _store(expiration=None):
+    store = MagicMock()
+    user = MagicMock()
+    user.password_expiration = expiration
+    store.get_user_profile.return_value = user
+    return store
+
+
+async def _rotate(store, expiration_str=None, username=None, is_admin=True):
+    request = None
+    if expiration_str is not None or username is not None:
+        request = CreateAccessTokenRequest(expiration=expiration_str, username=username)
+    with patch("mlflow_oidc_auth.routers.users.store", store):
+        return await create_access_token(
+            token_request=request,
+            current_username="admin@example.com",
+            is_admin=is_admin,
+        )
+
+
+class TestNaiveExpirationIsAccepted:
+    """A missing UTC offset is read as UTC, not turned into a 500."""
+
+    @staticmethod
+    def _soon(**kwargs) -> datetime:
+        """A UTC instant inside the endpoint's 1-year cap."""
+        return datetime.now(timezone.utc) + timedelta(days=30, **kwargs)
+
+    @pytest.mark.parametrize("date_only", [False, True])
+    @pytest.mark.asyncio
+    async def test_offsetless_expiration_is_accepted(self, date_only):
+        """Previously TypeError -> outer handler -> 500 Failed to create access token.
+
+        Covers both ISO 8601 forms that carry no offset: a full timestamp and a bare date.
+        """
+        store = _store()
+        naive = self._soon().replace(tzinfo=None)
+        expiration_str = naive.date().isoformat() if date_only else naive.isoformat()
+
+        result = await _rotate(store, expiration_str=expiration_str)
+
+        assert result.status_code == 200
+        stored = store.update_user.call_args[1]["password_expiration"]
+        assert stored is not None
+        assert stored.tzinfo is not None, "expiration must be normalized to an aware datetime"
+
+    @pytest.mark.asyncio
+    async def test_offsetless_expiration_is_interpreted_as_utc(self):
+        store = _store()
+        naive = self._soon().replace(microsecond=0, tzinfo=None)
+
+        await _rotate(store, expiration_str=naive.isoformat())
+
+        stored = store.update_user.call_args[1]["password_expiration"]
+        assert stored == naive.replace(tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_an_offset_is_still_respected(self):
+        """Normalizing the naive case must not trample an explicit offset."""
+        store = _store()
+        aware = self._soon().astimezone(timezone(timedelta(hours=5))).replace(microsecond=0)
+
+        await _rotate(store, expiration_str=aware.isoformat())
+
+        stored = store.update_user.call_args[1]["password_expiration"]
+        assert stored.utcoffset() == timedelta(hours=5)
+        assert stored == aware
+
+    @pytest.mark.asyncio
+    async def test_a_past_offsetless_expiration_is_still_rejected(self):
+        """The negative case: accepting the format must not stop validating the value."""
+        store = _store()
+        past = (datetime.now(timezone.utc) - timedelta(days=2)).replace(tzinfo=None).isoformat()
+
+        with pytest.raises(HTTPException) as exc:
+            await _rotate(store, expiration_str=past)
+
+        assert exc.value.status_code == 400
+        assert "must be in the future" in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_a_far_future_offsetless_expiration_is_still_rejected(self):
+        store = _store()
+        far = (datetime.now(timezone.utc) + timedelta(days=800)).replace(tzinfo=None).isoformat()
+
+        with pytest.raises(HTTPException) as exc:
+            await _rotate(store, expiration_str=far)
+
+        assert exc.value.status_code == 400
+        assert "less than 1 year" in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_genuinely_malformed_input_is_still_a_400(self):
+        store = _store()
+
+        with pytest.raises(HTTPException) as exc:
+            await _rotate(store, expiration_str="not-a-date")
+
+        assert exc.value.status_code == 400
+        assert "Invalid expiration date format" in str(exc.value.detail)
+
+
+class TestUnknownUserIsNotFound:
+    """A missing target user is a 404, not a 500."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_target_username_returns_404(self):
+        store = MagicMock()
+        store.get_user_profile.side_effect = MlflowException("User 'ghost@example.com' not found")
+
+        with pytest.raises(HTTPException) as exc:
+            await _rotate(store, username="ghost@example.com")
+
+        assert exc.value.status_code == 404
+        assert "ghost@example.com" in str(exc.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_no_token_is_issued_for_an_unknown_user(self):
+        """The 404 must short-circuit before anything is written."""
+        store = MagicMock()
+        store.get_user_profile.side_effect = MlflowException("not found")
+
+        with pytest.raises(HTTPException):
+            await _rotate(store, username="ghost@example.com")
+
+        store.update_user.assert_not_called()


### PR DESCRIPTION
Closes #338.

Two defects in `UserRepository.update`, both found while reviewing #337 and both sharing one root
cause: what "argument not supplied" meant was inconsistent with the method's own parameter
defaults. Both were reproduced against a real store before being fixed, and the tests were
verified to fail against the unfixed code.

## Bug 1 — a rotated token could be born already expired

`update` only assigned `password_expiration` when one was passed, so the previous token's expiry
survived onto the newly issued one. `authenticate` checks expiry *before* comparing the hash, so
rotating after the old token expired produced a token rejected on its first use.

Reachable through the access-token endpoint whenever the request body omits `expiration` — the
default path for direct API and SDK callers. The React UI always sends one (the submit button is
disabled without it), which is why this never showed up in the browser.

**Fix:** expiry is a property of the *secret*, not of the user. Replacing the secret now replaces
its lifetime with exactly the one supplied, and never inherits:

```python
if password is not None:
    user.password_hash = generate_password_hash(password, method=TOKEN_HASH_METHOD)
    user.password_expiration = password_expiration   # None means "does not expire"
elif password_expiration is not None:
    user.password_expiration = password_expiration
```

Non-rotating updates — group sync, an admin-flag change — still leave the expiry alone.

### The design question from the issue, and how it was settled

#338 flagged an open question: does omitting `expiration` on rotation mean "keep the existing
policy" or "issue a non-expiring token"? Settled as **the latter** — the new token's lifetime is
exactly what was asked for, with no inherited hidden state. Predictability on an auth surface
beats cleverness, and it matches user-creation semantics, where a user provisioned by OIDC login
already gets a token with no expiration.

That choice does widen a credential's lifetime when a script rotates without an expiration, so it
is recorded rather than left silent — the `user.token_rotate` audit event now carries:

```json
{"expiration": null, "expiration_cleared": true}
```

Worth noting for reviewers: the feature's original commit (baaea07) says *"all tokens now have a
lifetime limit"*, which argues for a default lifetime instead. That was never actually true —
every OIDC-provisioned user's initial token has no expiration — so enforcing it now would be a new
behavior change for existing API callers, and belongs in its own issue if wanted.

**Consequence, deliberate:** an expiry can no longer be cleared without also rotating the secret.
Extending the life of an already-issued credential should require issuing a new one.

## Bug 2 — omitted admin flags silently demoted the user

```python
is_admin: Optional[bool] = False,          # default False...
...
if is_admin is not None:                   # ...but the guard tests for None
    user.is_admin = is_admin
```

`store.user_repo.update(username=..., password=...)` therefore set `is_admin=False` and
`is_service_account=False`. Verified: an admin service account came back with both cleared.

**Latent, not live** — the only current caller is `SqlAlchemyStore.update_user`, which always
forwards explicit `None`s. Fixed anyway: it is a silent privilege drop waiting for the next
caller, and the defaults now match both the guards and the store's own signature.

## Tests

`tests/repository/test_user_update_semantics.py` (12) and
`tests/routers/test_users_token_rotate_audit.py` (4).

**Verified the tests bind:** against the unfixed code, 5 of the 12 fail — the three
rotation/expiry cases and both direct-repository flag cases — and all 12 pass after. A test that
would have passed either way is not a regression test.

Negative and boundary cases, since this is an auth path:

- an **explicitly supplied past** expiration is still honoured, so the fix cannot degrade into
  "ignore expiry" — that is the case that would turn a bug fix into a vulnerability;
- flags can still be set `False` **explicitly**, so preserving-on-omission does not make demotion
  impossible;
- a non-rotating update preserves a future expiry;
- `expiration_cleared` is `False` when nothing was dropped, so it is a signal rather than a
  constant.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 2893 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 query budget intact
```

No schema change: this is assignment logic, not storage. No frontend change — the UI already
always sends an expiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
