### PR TITLE
docs(store): document that a password reset also clears the expiration

### DIFF
--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -353,6 +353,37 @@ class SqlAlchemyStore:
         is_admin: Optional[bool] = None,
         is_service_account: Optional[bool] = None,
     ) -> User:
+        """Update the supplied fields of a user, leaving omitted ones untouched.
+
+        ``None`` means "not supplied" for every parameter but one: the corresponding column is
+        left as it is.
+
+        The exception is ``password_expiration``, because expiry is a property of the *secret*
+        rather than of the user. **Supplying a ``password`` also replaces the expiration** with
+        exactly the value passed in, and ``None`` there means "does not expire" rather than
+        "leave it alone" — a rotated secret never inherits the previous one's lifetime. When no
+        ``password`` is supplied, the expiry changes only if one was passed.
+
+        The practical consequence, which the signature alone does not convey: calling
+        ``update_user(username=u, password=new_secret)`` on a user whose token currently expires
+        will leave them with one that never expires. Pass the expiration explicitly to keep one.
+
+        See :meth:`mlflow_oidc_auth.repository.user.UserRepository.update` for the reasoning
+        (issue #338).
+
+        Parameters:
+            username: Identity key of the user to update.
+            password: New secret. Also resets the expiration, per above.
+            password_expiration: Expiry for the stored secret. See the semantics above.
+            is_admin: New administrator flag.
+            is_service_account: New service-account flag.
+
+        Returns:
+            User: The updated user entity.
+
+        Raises:
+            MlflowException: If the user does not exist.
+        """
         return self.user_repo.update(
             username=username,
             password=password,


### PR DESCRIPTION
Raised in review of [#339](https://github.com/mlflow-oidc/mlflow-oidc-auth/pull/339). Docstring
only — no behaviour change.

## Why

#339 makes supplying a `password` also replace `password_expiration`, so a rotated secret never
inherits the previous one's lifetime. That rule is documented on
`UserRepository.update` — but per `AGENTS.md` the store singleton is the supported entry point,
and `SqlAlchemyStore.update_user` had no docstring at all. Its signature reads as though every
field were independent:

```python
password_expiration: Optional[datetime] = None,
```

A future caller writing `store.update_user(username=u, password=new_secret)` after reading that
would silently convert an expiring credential into a permanent one. That is the same class of
defect #339 fixes — a default whose meaning does not match the behaviour — sitting one layer up,
at exactly the layer callers are told to use.

## Note on the base branch

This is **stacked on `fix/user-update-omitted-args` (#339)**, not on `main`, because it documents
behaviour that only exists once #339 lands. Basing it on `main` would describe something untrue
today. Merge #339 first; GitHub will retarget this to `main` automatically, or I can rebase it.

## Validation

```
pre-commit run --all-files                                       # passed
pytest tests/test_sqlalchemy_store.py tests/repository tests/routers  # 1154 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
