### PR TITLE
feat(db): single Phase 0 migration for identity, sessions and lifecycle (#333)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,23 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    services:
+      # Migrations must be verified on PostgreSQL as well as SQLite (#333). Without a server
+      # here those tests skip, and "tested on both backends" quietly stops being true.
+      # Local to the runner, trust auth, no secrets involved.
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: mlflow_oidc
+          POSTGRES_PASSWORD: mlflow_oidc
+          POSTGRES_DB: mlflow_oidc_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,6 +55,8 @@ jobs:
         with:
           python-version: 3.12
       - name: Run tests
+        env:
+          MLFLOW_OIDC_TEST_POSTGRES_URI: postgresql+psycopg2://mlflow_oidc:mlflow_oidc@localhost:5432/mlflow_oidc_test
         run: |
           python -m pip install --upgrade pip
           pip install tox

--- a/mlflow_oidc_auth/db/migrations/versions/9c0d1e2f3456_phase0_identity_sessions_lifecycle.py
+++ b/mlflow_oidc_auth/db/migrations/versions/9c0d1e2f3456_phase0_identity_sessions_lifecycle.py
@@ -1,0 +1,163 @@
+"""phase0 identity, sessions and lifecycle schema
+
+Revision ID: 9c0d1e2f3456
+Revises: 8a9b0c1de234
+Create Date: 2026-08-09 00:00:00.000000
+
+All Phase 0 schema for the enterprise-identity epic (#304) lands in this single revision
+(issue #333). Splitting it across #309, #310 and #311 would give each its own revision off
+``8a9b0c1de234``, producing three Alembic heads and breaking ``alembic upgrade head`` outright.
+With the schema here, those three can proceed in parallel on behaviour alone.
+
+Schema and backfill only — no behaviour. Identity resolution (#309), session handling (#310),
+``active`` enforcement (#311) and the ``managed_by`` write guard (#319) all come later.
+
+Two backfill choices are load-bearing and are asserted by tests:
+
+* Pre-existing rows are labelled ``managed_by='manual'``, never ``'oidc:default'``. Existing
+  group memberships were not necessarily claim-derived, and mislabelling them would let the
+  #319 guard refuse admin edits to memberships that were in fact manual — up to locking every
+  admin out of their own permission data, which needs out-of-band access to recover from.
+* ``users.active`` is NOT NULL with a true default, so no existing user is denied at their next
+  login once #311 starts enforcing it.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9c0d1e2f3456"
+down_revision = "8a9b0c1de234"
+branch_labels = None
+depends_on = None
+
+# The identity provider that pre-existing users are attributed to. Their subject is their
+# username, which is what every current lookup already keys on.
+LEGACY_PROVIDER_ID = "default"
+
+# Rows that predate provisioning are manual by definition: nothing external created them.
+MANUAL = "manual"
+
+
+def upgrade() -> None:
+    # --- identity (#309) -------------------------------------------------------------------
+    op.create_table(
+        "user_identities",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("provider_id", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("last_login_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_identities_user_id"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider_id", "subject", name="uq_user_identities_provider_subject"),
+    )
+    op.create_index("ix_user_identities_user_id", "user_identities", ["user_id"])
+
+    # --- sessions (#310) -------------------------------------------------------------------
+    op.create_table(
+        "auth_sessions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        # Opaque 256-bit identifier. Sized for either encoding a caller may choose (64 hex
+        # characters, 43 base64url) with room to spare.
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("provider_id", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        # Encrypted at the application layer before it reaches this column; the schema only
+        # promises somewhere to put it. Text rather than String because provider token sets
+        # have no useful length bound.
+        sa.Column("encrypted_tokens", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_auth_sessions_user_id"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_auth_sessions_session_id", "auth_sessions", ["session_id"], unique=True)
+    op.create_index("ix_auth_sessions_user_id", "auth_sessions", ["user_id"])
+    # Revocation sweeps and expiry sweeps both scan by expiry.
+    op.create_index("ix_auth_sessions_expires_at", "auth_sessions", ["expires_at"])
+
+    # --- in-flight authorization state (#310) ----------------------------------------------
+    op.create_table(
+        "auth_state",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("state", sa.String(length=255), nullable=False),
+        sa.Column("nonce", sa.String(length=255), nullable=True),
+        sa.Column("code_verifier", sa.String(length=255), nullable=True),
+        sa.Column("provider_id", sa.String(length=255), nullable=True),
+        sa.Column("relay_state", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_auth_state_state", "auth_state", ["state"], unique=True)
+    # These rows are short-lived and swept in bulk.
+    op.create_index("ix_auth_state_expires_at", "auth_state", ["expires_at"])
+
+    # --- lifecycle columns (#311) ----------------------------------------------------------
+    # server_default populates existing rows in the same statement, so there is no window in
+    # which a row exists with no value. active is NOT NULL/true so nobody is denied later.
+    op.add_column("users", sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()))
+    op.add_column("users", sa.Column("managed_by", sa.String(length=255), nullable=False, server_default=MANUAL))
+    op.add_column("users", sa.Column("external_id", sa.String(length=255), nullable=True))
+    # Timestamps are added nullable and filled by an explicit UPDATE below. SQLite refuses
+    # ADD COLUMN with a non-constant default (CURRENT_TIMESTAMP) — but only once the table has
+    # rows, accepting it on an empty one. Declaring them NOT NULL DEFAULT now() would therefore
+    # pass every fresh-install test and fail on exactly the deployments that have users.
+    op.add_column("users", sa.Column("created_at", sa.DateTime(), nullable=True))
+    op.add_column("users", sa.Column("updated_at", sa.DateTime(), nullable=True))
+    # Unique *index* rather than a constraint: both backends allow repeated NULLs in a unique
+    # index, which is what "unique when present" means here.
+    op.create_index("ix_users_external_id", "users", ["external_id"], unique=True)
+
+    op.add_column("user_groups", sa.Column("managed_by", sa.String(length=255), nullable=False, server_default=MANUAL))
+
+    op.add_column("groups", sa.Column("external_id", sa.String(length=255), nullable=True))
+    op.add_column("groups", sa.Column("created_at", sa.DateTime(), nullable=True))
+    op.add_column("groups", sa.Column("updated_at", sa.DateTime(), nullable=True))
+    op.create_index("ix_groups_external_id", "groups", ["external_id"], unique=True)
+
+    # --- backfill --------------------------------------------------------------------------
+    # Existing rows predate these columns, so their creation time is unknowable; the migration
+    # time is the honest approximation and is recorded rather than left NULL.
+    for table in ("users", "groups"):
+        op.execute(f"UPDATE {table} SET created_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP")  # nosec B608 - fixed literals
+
+    # Every pre-existing user gets an identity so that identity resolution (#309) never finds a
+    # stranded account. Their subject is the username, which is what today's lookups key on.
+    # id is omitted so the backend assigns it, and created_at falls to its server default.
+    op.execute(sa.text("""
+            INSERT INTO user_identities (provider_id, subject, user_id)
+            SELECT :provider_id, users.username, users.id FROM users
+            """).bindparams(provider_id=LEGACY_PROVIDER_ID))
+
+
+def downgrade() -> None:
+    op.drop_index("ix_groups_external_id", table_name="groups")
+    op.drop_column("groups", "updated_at")
+    op.drop_column("groups", "created_at")
+    op.drop_column("groups", "external_id")
+
+    op.drop_column("user_groups", "managed_by")
+
+    op.drop_index("ix_users_external_id", table_name="users")
+    op.drop_column("users", "updated_at")
+    op.drop_column("users", "created_at")
+    op.drop_column("users", "external_id")
+    op.drop_column("users", "managed_by")
+    op.drop_column("users", "active")
+
+    op.drop_index("ix_auth_state_expires_at", table_name="auth_state")
+    op.drop_index("ix_auth_state_state", table_name="auth_state")
+    op.drop_table("auth_state")
+
+    op.drop_index("ix_auth_sessions_expires_at", table_name="auth_sessions")
+    op.drop_index("ix_auth_sessions_user_id", table_name="auth_sessions")
+    op.drop_index("ix_auth_sessions_session_id", table_name="auth_sessions")
+    op.drop_table("auth_sessions")
+
+    op.drop_index("ix_user_identities_user_id", table_name="user_identities")
+    op.drop_table("user_identities")

--- a/mlflow_oidc_auth/db/models/__init__.py
+++ b/mlflow_oidc_auth/db/models/__init__.py
@@ -22,6 +22,7 @@ from mlflow_oidc_auth.db.models.gateway_secret import (
     SqlGatewaySecretPermission,
     SqlGatewaySecretRegexPermission,
 )
+from mlflow_oidc_auth.db.models.identity import SqlAuthSession, SqlAuthState, SqlUserIdentity
 from mlflow_oidc_auth.db.models.user import SqlUser, SqlGroup, SqlUserGroup
 from mlflow_oidc_auth.db.models.registered_model import (
     SqlRegisteredModelGroupPermission,
@@ -46,6 +47,9 @@ __all__ = [
     "SqlUser",
     "SqlGroup",
     "SqlUserGroup",
+    "SqlUserIdentity",
+    "SqlAuthSession",
+    "SqlAuthState",
     "SqlExperimentPermission",
     "SqlExperimentGroupPermission",
     "SqlExperimentRegexPermission",

--- a/mlflow_oidc_auth/db/models/identity.py
+++ b/mlflow_oidc_auth/db/models/identity.py
@@ -1,0 +1,87 @@
+"""Phase 0 identity and session tables (issue #333).
+
+Schema only. Nothing reads or writes these yet: identity resolution is #309 and session
+handling is #310. They land together so the Alembic chain keeps a single head while those two
+proceed in parallel.
+
+Deliberately no ``to_mlflow_entity`` on any of them — an entity is part of a public surface, and
+these have no consumer to shape one for. The issues that give them behaviour will add what they
+need.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from mlflow_oidc_auth.db.models._base import Base
+
+
+class SqlUserIdentity(Base):
+    """One external identity — a ``(provider, subject)`` pair — bound to a local user.
+
+    A user may hold several: the same person arriving through two providers resolves to one
+    ``users`` row. ``(provider_id, subject)`` is unique, so an identity can never be claimed by
+    two accounts.
+    """
+
+    __tablename__ = "user_identities"
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    provider_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, server_default=func.now())
+    last_login_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True)
+    __table_args__ = (
+        UniqueConstraint("provider_id", "subject", name="uq_user_identities_provider_subject"),
+        Index("ix_user_identities_user_id", "user_id"),
+    )
+
+
+class SqlAuthSession(Base):
+    """A server-side session, so that revocation can be real rather than advisory.
+
+    ``session_id`` is an opaque 256-bit value chosen by the application; the column is sized for
+    either common encoding. ``encrypted_tokens`` holds provider token material that the
+    application encrypts before it ever reaches this column.
+    """
+
+    __tablename__ = "auth_sessions"
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    session_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    provider_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, server_default=func.now())
+    last_seen_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True)
+    encrypted_tokens: Mapped[Optional[str]] = mapped_column(Text(), nullable=True)
+    __table_args__ = (
+        Index("ix_auth_sessions_session_id", "session_id", unique=True),
+        Index("ix_auth_sessions_user_id", "user_id"),
+        Index("ix_auth_sessions_expires_at", "expires_at"),
+    )
+
+
+class SqlAuthState(Base):
+    """In-flight authorization state: the CSRF ``state``, its ``nonce`` and the PKCE verifier.
+
+    Rows are short-lived and swept by ``expires_at``, which is indexed for that reason. Holding
+    the verifier server-side is what lets PKCE and the RFC 9207 mix-up defence be enforced
+    rather than trusted (#312, #316).
+    """
+
+    __tablename__ = "auth_state"
+    id: Mapped[int] = mapped_column(Integer(), primary_key=True)
+    state: Mapped[str] = mapped_column(String(255), nullable=False)
+    nonce: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    code_verifier: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    provider_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    relay_state: Mapped[Optional[str]] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, server_default=func.now())
+    expires_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False)
+    __table_args__ = (
+        Index("ix_auth_state_state", "state", unique=True),
+        Index("ix_auth_state_expires_at", "expires_at"),
+    )

--- a/mlflow_oidc_auth/db/models/user.py
+++ b/mlflow_oidc_auth/db/models/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, func, true
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint, func, true
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from mlflow_oidc_auth.db.models._base import Base

--- a/mlflow_oidc_auth/db/models/user.py
+++ b/mlflow_oidc_auth/db/models/user.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from typing import Optional
 
-from sqlalchemy import Boolean, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, func, true
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from mlflow_oidc_auth.db.models._base import Base
@@ -22,6 +23,16 @@ class SqlUser(Base):
     password_expiration: Mapped[datetime] = mapped_column(nullable=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
     is_service_account: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Phase 0 lifecycle columns (issue #333). Schema only — nothing enforces ``active`` or
+    # honours ``managed_by`` yet; that is #311 and #319 respectively.
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=true(), default=True)
+    managed_by: Mapped[str] = mapped_column(String(255), nullable=False, server_default="manual", default="manual")
+    external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Nullable at the DB level: they are added to an existing table, and SQLite refuses
+    # ADD COLUMN with a non-constant default once the table has rows. The migration backfills
+    # existing rows; ``default`` populates new ones.
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True, default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True, default=func.now(), onupdate=func.now())
     experiment_permissions: Mapped[list["SqlExperimentPermission"]] = relationship("SqlExperimentPermission", backref="users")
     registered_model_permissions: Mapped[list["SqlRegisteredModelPermission"]] = relationship("SqlRegisteredModelPermission", backref="users")
     scorer_permissions: Mapped[list["SqlScorerPermission"]] = relationship("SqlScorerPermission", backref="users")
@@ -35,6 +46,9 @@ class SqlUser(Base):
         secondary="user_groups",
         back_populates="users",
     )
+    # Unique index rather than constraint: repeated NULLs are allowed on both backends, which
+    # is what "unique when present" means for an optional external identifier.
+    __table_args__ = (Index("ix_users_external_id", "external_id", unique=True),)
 
     def to_mlflow_entity(self):
         return User(
@@ -59,7 +73,17 @@ class SqlGroup(Base):
     __tablename__ = "groups"
     id: Mapped[int] = mapped_column(Integer(), primary_key=True)
     group_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    __table_args__ = (UniqueConstraint("group_name"),)
+    # Phase 0 lifecycle columns (issue #333); see SqlUser for why they carry no behaviour yet.
+    external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    # Nullable at the DB level: they are added to an existing table, and SQLite refuses
+    # ADD COLUMN with a non-constant default once the table has rows. The migration backfills
+    # existing rows; ``default`` populates new ones.
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True, default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(), nullable=True, default=func.now(), onupdate=func.now())
+    __table_args__ = (
+        UniqueConstraint("group_name"),
+        Index("ix_groups_external_id", "external_id", unique=True),
+    )
     users: Mapped[list["SqlUser"]] = relationship(
         "SqlUser",
         secondary="user_groups",
@@ -78,6 +102,8 @@ class SqlUserGroup(Base):
     id: Mapped[int] = mapped_column(Integer(), primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     group_id: Mapped[int] = mapped_column(ForeignKey("groups.id"), nullable=False)
+    # Whether this membership was set by an admin or derived from a provider claim (issue #333).
+    managed_by: Mapped[str] = mapped_column(String(255), nullable=False, server_default="manual", default="manual")
     __table_args__ = (UniqueConstraint("user_id", "group_id", name="unique_user_group"),)
 
     def to_mlflow_entity(self):

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -123,6 +123,11 @@ class UserRepository:
                         SqlUser.password_expiration,
                         SqlUser.is_admin,
                         SqlUser.is_service_account,
+                        # Widening the existing select rather than adding a query: this row is
+                        # already fetched on every authenticated request, so #311 and #319 get
+                        # these for free and the #305 budget of 2 statements is unchanged.
+                        SqlUser.active,
+                        SqlUser.managed_by,
                     ),
                     selectinload(SqlUser.groups).load_only(SqlGroup.id, SqlGroup.group_name),
                     noload(SqlUser.experiment_permissions),

--- a/mlflow_oidc_auth/tests/db/test_phase0_migration.py
+++ b/mlflow_oidc_auth/tests/db/test_phase0_migration.py
@@ -1,0 +1,325 @@
+"""Phase 0 schema migration: heads, round-trip and backfill (issue #333).
+
+The migration itself is mechanical; what these tests defend are the two backfill choices that
+later issues depend on, and the head invariant that motivated putting all of Phase 0 in one
+revision.
+
+**Postgres.** Every test here runs against SQLite, and against PostgreSQL too when
+``MLFLOW_OIDC_TEST_POSTGRES_URI`` is set (skipped otherwise, so the default suite stays
+dependency-free). CI should set it — a migration verified on one backend is verified on one
+backend. Run locally with, for example::
+
+    MLFLOW_OIDC_TEST_POSTGRES_URI=postgresql+psycopg2://user@127.0.0.1:5432/test \\
+        pytest mlflow_oidc_auth/tests/db/test_phase0_migration.py
+"""
+
+import os
+
+import pytest
+from alembic.command import downgrade, upgrade
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+
+from mlflow_oidc_auth.db.utils import _get_alembic_config
+
+PREVIOUS_REVISION = "8a9b0c1de234"
+PHASE0_REVISION = "9c0d1e2f3456"
+
+POSTGRES_URI = os.environ.get("MLFLOW_OIDC_TEST_POSTGRES_URI")
+
+
+def _sqlite_uri(tmp_path) -> str:
+    return f"sqlite:///{tmp_path / 'auth.db'}"
+
+
+@pytest.fixture(params=["sqlite", "postgres"])
+def db_uri(request, tmp_path):
+    """A database URI per backend. Postgres cases skip unless a server is configured."""
+    if request.param == "sqlite":
+        return _sqlite_uri(tmp_path)
+    if not POSTGRES_URI:
+        pytest.skip("MLFLOW_OIDC_TEST_POSTGRES_URI is not set")
+    return POSTGRES_URI
+
+
+@pytest.fixture
+def engine(db_uri):
+    eng = create_engine(db_uri)
+    if eng.dialect.name == "postgresql":
+        # Start from a clean slate: the migration chain owns the public schema for this run.
+        with eng.begin() as conn:
+            conn.execute(text("DROP SCHEMA public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    yield eng
+    eng.dispose()
+
+
+def _alembic_config(engine):
+    """An Alembic config that does not reconfigure this process's logging.
+
+    ``env.py`` calls ``logging.config.fileConfig()``, which defaults to
+    ``disable_existing_loggers=True`` and therefore silences every logger created before it
+    runs. That is survivable once at application startup, but these tests invoke Alembic dozens
+    of times mid-session, and the collateral damage is unrelated tests losing their ``caplog``
+    records. Clearing the filename makes ``env.py`` skip the call.
+    """
+    cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
+    cfg.config_file_name = None
+    return cfg
+
+
+def _upgrade(engine, revision: str) -> None:
+    cfg = _alembic_config(engine)
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        upgrade(cfg, revision)
+
+
+def _downgrade(engine, revision: str) -> None:
+    cfg = _alembic_config(engine)
+    with engine.begin() as conn:
+        cfg.attributes["connection"] = conn
+        downgrade(cfg, revision)
+
+
+def _seed_legacy_data(engine) -> None:
+    """Insert users, groups and memberships as they exist at the previous revision.
+
+    Raw SQL on purpose: the ORM models already carry the Phase 0 columns, so using them here
+    would not reproduce a pre-migration database.
+    """
+    with engine.begin() as conn:
+        for i, name in enumerate(["alice@example.com", "bob@example.com", "svc@example.com"], start=1):
+            conn.execute(
+                text("INSERT INTO users (username, display_name, password_hash, is_admin, is_service_account) " "VALUES (:u, :d, :h, :a, :s)"),
+                {"u": name, "d": name, "h": "not-a-real-hash", "a": i == 1, "s": i == 3},
+            )
+        conn.execute(text("INSERT INTO groups (group_name) VALUES ('legacy-team')"))
+        conn.execute(
+            text("INSERT INTO user_groups (user_id, group_id) " "SELECT users.id, groups.id FROM users, groups WHERE groups.group_name = 'legacy-team'")
+        )
+
+
+class TestRevisionChain:
+    def test_exactly_one_head(self, tmp_path):
+        """The invariant that put all of Phase 0 in one revision.
+
+        Three parallel revisions off the same parent would give three heads and make
+        ``alembic upgrade head`` fail outright for every deployment.
+        """
+        cfg = _get_alembic_config(_sqlite_uri(tmp_path))
+        heads = ScriptDirectory.from_config(cfg).get_heads()
+
+        assert heads == [PHASE0_REVISION], f"expected a single head, got {heads}"
+
+    def test_phase0_follows_the_previous_head(self, tmp_path):
+        cfg = _get_alembic_config(_sqlite_uri(tmp_path))
+        script = ScriptDirectory.from_config(cfg).get_revision(PHASE0_REVISION)
+
+        assert script.down_revision == PREVIOUS_REVISION
+
+
+class TestUpgradeFromEmpty:
+    def test_upgrade_head_creates_the_phase0_schema(self, engine):
+        _upgrade(engine, "head")
+
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+        assert {"user_identities", "auth_sessions", "auth_state"} <= tables
+        assert {"active", "managed_by", "external_id", "created_at", "updated_at"} <= {c["name"] for c in inspector.get_columns("users")}
+        assert "managed_by" in {c["name"] for c in inspector.get_columns("user_groups")}
+        assert {"external_id", "created_at", "updated_at"} <= {c["name"] for c in inspector.get_columns("groups")}
+
+    def test_active_is_not_nullable(self, engine):
+        """A nullable or false-defaulting ``active`` would deny every user once #311 enforces it."""
+        _upgrade(engine, "head")
+
+        active = next(c for c in inspect(engine).get_columns("users") if c["name"] == "active")
+
+        assert active["nullable"] is False
+
+
+class TestUpgradeFromPreviousRevision:
+    """The path a real deployment takes: an existing database with data in it."""
+
+    def test_upgrade_succeeds_over_existing_data(self, engine):
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM users")).scalar() == 3
+
+    def test_existing_users_are_active(self, engine):
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            inactive = conn.execute(text("SELECT count(*) FROM users WHERE active <> :t"), {"t": True}).scalar()
+        assert inactive == 0, "an existing user would be denied at next login"
+
+    def test_existing_users_are_labelled_manual(self, engine):
+        """Not ``oidc:default``.
+
+        Mislabelling pre-existing rows as provider-managed would let the #319 write guard refuse
+        admin edits to memberships that were in fact manual — up to locking every admin out of
+        their own permission data, which needs out-of-band access to recover from.
+        """
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            labels = {r[0] for r in conn.execute(text("SELECT DISTINCT managed_by FROM users"))}
+        assert labels == {"manual"}
+
+    def test_existing_memberships_are_labelled_manual(self, engine):
+        """Same reasoning as above, for the rows #319 actually guards."""
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            labels = {r[0] for r in conn.execute(text("SELECT DISTINCT managed_by FROM user_groups"))}
+        assert labels == {"manual"}
+
+    def test_every_existing_user_gets_exactly_one_identity(self, engine):
+        """No user may be stranded, and none may be duplicated."""
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            rows = conn.execute(text("SELECT provider_id, subject, user_id FROM user_identities ORDER BY user_id")).fetchall()
+            usernames = [r[0] for r in conn.execute(text("SELECT username FROM users ORDER BY id"))]
+
+        assert len(rows) == 3
+        assert {r[0] for r in rows} == {"default"}
+        assert [r[1] for r in rows] == usernames, "subject must be the username current lookups key on"
+
+    def test_backfill_is_empty_on_a_database_with_no_users(self, engine):
+        """The INSERT ... SELECT must not invent a row when there is nothing to migrate."""
+        _upgrade(engine, PREVIOUS_REVISION)
+
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM user_identities")).scalar() == 0
+
+
+class TestRoundTrip:
+    def test_downgrade_then_upgrade(self, engine):
+        """Migrations must be reversible on both backends."""
+        _upgrade(engine, "head")
+
+        _downgrade(engine, "-1")
+
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+        assert not ({"user_identities", "auth_sessions", "auth_state"} & tables), "downgrade left tables behind"
+        assert "active" not in {c["name"] for c in inspector.get_columns("users")}
+        assert "managed_by" not in {c["name"] for c in inspector.get_columns("user_groups")}
+
+        _upgrade(engine, "head")
+
+        inspector = inspect(engine)
+        assert {"user_identities", "auth_sessions", "auth_state"} <= set(inspector.get_table_names())
+        assert "active" in {c["name"] for c in inspector.get_columns("users")}
+
+    def test_round_trip_preserves_pre_existing_data(self, engine):
+        """Reversibility is worth nothing if it takes the users with it."""
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+        _upgrade(engine, "head")
+
+        _downgrade(engine, "-1")
+        _upgrade(engine, "head")
+
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM users")).scalar() == 3
+            assert conn.execute(text("SELECT count(*) FROM user_groups")).scalar() == 3
+            # The second upgrade re-runs the backfill against the same three users.
+            assert conn.execute(text("SELECT count(*) FROM user_identities")).scalar() == 3
+
+
+class TestExternalIdUniqueness:
+    """``external_id`` is unique when present, which must still allow many absent ones."""
+
+    def test_multiple_null_external_ids_are_allowed(self, engine):
+        _upgrade(engine, "head")
+
+        with engine.begin() as conn:
+            for name in ["u1@example.com", "u2@example.com"]:
+                conn.execute(
+                    text("INSERT INTO users (username, display_name, password_hash, active, managed_by) VALUES (:u, :u, :h, :a, 'manual')"),
+                    {"u": name, "h": "not-a-real-hash", "a": True},
+                )
+
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM users WHERE external_id IS NULL")).scalar() == 2
+
+    def test_duplicate_external_ids_are_rejected(self, engine):
+        """The negative case: uniqueness must actually be enforced, not merely declared."""
+        from sqlalchemy.exc import IntegrityError
+
+        _upgrade(engine, "head")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO users (username, display_name, password_hash, active, managed_by, external_id) "
+                    "VALUES ('e1@example.com', 'e1', :h, :a, 'manual', 'shared-id')"
+                ),
+                {"h": "not-a-real-hash", "a": True},
+            )
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "INSERT INTO users (username, display_name, password_hash, active, managed_by, external_id) "
+                        "VALUES ('e2@example.com', 'e2', :h, :a, 'manual', 'shared-id')"
+                    ),
+                    {"h": "not-a-real-hash", "a": True},
+                )
+
+
+class TestIdentityUniqueness:
+    def test_the_same_subject_cannot_be_claimed_twice_for_one_provider(self, engine):
+        """Two accounts sharing a ``(provider, subject)`` would be an account-takeover primitive."""
+        from sqlalchemy.exc import IntegrityError
+
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+        _upgrade(engine, "head")
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "INSERT INTO user_identities (provider_id, subject, user_id) "
+                        "SELECT 'default', 'alice@example.com', id FROM users WHERE username = 'bob@example.com'"
+                    )
+                )
+
+    def test_the_same_subject_may_exist_under_a_different_provider(self, engine):
+        _upgrade(engine, PREVIOUS_REVISION)
+        _seed_legacy_data(engine)
+        _upgrade(engine, "head")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO user_identities (provider_id, subject, user_id) "
+                    "SELECT 'okta', 'alice@example.com', id FROM users WHERE username = 'alice@example.com'"
+                )
+            )
+
+        with engine.connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM user_identities WHERE subject = 'alice@example.com'")).scalar() == 2

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,11 @@ deps =
     pytest
     coverage<=7.6
     httpx
+    # Only used by the migration tests, and only when MLFLOW_OIDC_TEST_POSTGRES_URI points at a
+    # server; they skip without one. Migrations have to be verified on both backends (#333).
+    psycopg2-binary
+passenv =
+    MLFLOW_OIDC_TEST_POSTGRES_URI
 commands =
     pip install -e '.[full,test]'
     coverage run -m pytest -s -m "not integration" mlflow_oidc_auth/tests


### PR DESCRIPTION
Closes #333.

One Alembic revision (`9c0d1e2f3456`) off `8a9b0c1de234` carrying all Phase 0 schema, so #309,
#310 and #311 can proceed in parallel on behaviour alone. **Schema and backfill only — no
behaviour.**

## What lands

| | |
|---|---|
| `user_identities` (#309) | `(provider_id, subject)` unique, FK to `users`, indexed on `user_id` |
| `auth_sessions` (#310) | opaque `session_id` (unique index), FK to `users`, expiry/revocation columns, `encrypted_tokens` |
| `auth_state` (#310) | `state` (unique), `nonce`, PKCE `code_verifier`, `relay_state`, indexed on `expires_at` for sweeping |
| `users` (#311) | `active`, `managed_by`, `external_id`, `created_at`, `updated_at` |
| `user_groups` (#311) | `managed_by` |
| `groups` (#311) | `external_id`, `created_at`, `updated_at` |

`active` and `managed_by` join the existing `load_only` in `get_profile`, so #311 and #319 get
them for free. **The #305 budget is unchanged at 0/2/2/3** — verified by the perf tests and by
re-running the benchmark.

## The bug this nearly shipped with

The first version declared the timestamps `NOT NULL DEFAULT CURRENT_TIMESTAMP`. That is fine on
SQLite *until the table has rows* — SQLite accepts `ADD COLUMN` with a non-constant default on an
empty table and rejects it on a populated one:

```
sqlite3.OperationalError: Cannot add a column with non-constant default
[SQL: ALTER TABLE users ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL]
```

So it passed every fresh-install test, and would have failed on **exactly the deployments that
have users** — the ones that run migrations. It only surfaced because the tests upgrade a
database seeded at the previous revision rather than an empty one. Timestamps are now added
nullable and filled by an explicit `UPDATE`.

Worth keeping in mind for future migrations: a migration test that starts from an empty database
is not testing a migration.

## Backfill, and why the labels matter

- Every pre-existing user gets a `user_identities` row for provider `default`, subject =
  username. No account is stranded when #309 starts resolving identities.
- Pre-existing rows are `managed_by='manual'`, **never `oidc:default`**. Existing memberships
  were not necessarily claim-derived, and mislabelling them would let the #319 guard refuse admin
  edits to memberships that were in fact manual — up to locking every admin out of their own
  permission data, which needs out-of-band access to recover from.
- `users.active` is NOT NULL defaulting true, so nobody is denied at next login once #311
  enforces it.

Both are asserted, not assumed.

## Tests

`mlflow_oidc_auth/tests/db/test_phase0_migration.py` — 15 cases, each run against **both**
backends:

- exactly one Alembic head (the invariant that motivated the single revision), and it follows
  `8a9b0c1de234`;
- upgrade from empty, and upgrade over a database seeded at the previous revision with users,
  groups and memberships;
- `active` non-nullable, existing users active, users and memberships labelled `manual`;
- one identity per existing user, subject = username, and **no** identity invented when there
  are no users;
- `downgrade -1 && upgrade head` round-trips, and preserves pre-existing data;
- `external_id` allows many NULLs but rejects duplicates — uniqueness enforced, not just
  declared;
- a `(provider, subject)` pair cannot be claimed by two accounts (that would be an
  account-takeover primitive), while the same subject may exist under a different provider.

## CI now actually checks PostgreSQL

The tests skip without `MLFLOW_OIDC_TEST_POSTGRES_URI`, so "verified on both backends" would have
been true once, on my machine, and never again. `unit-tests.yml` gains a `postgres:18-alpine`
service and `tox.ini` passes the variable through plus `psycopg2-binary`. `pyproject.toml` is
deliberately untouched — `tox.ini` was the smaller blast radius.

**Workflow threat model**, per `AGENTS.md`: `unit-tests.yml` triggers on `pull_request`, so a fork
PR runs untrusted code with a read-only token and no secrets. It holds untrusted input and code
execution, not secrets. The added service is a runner-local database with no credentials of
consequence, and the trigger and permissions are unchanged.

## Validation

```
pytest mlflow_oidc_auth/tests/db/test_phase0_migration.py        # 16 passed, 14 skipped (SQLite)
MLFLOW_OIDC_TEST_POSTGRES_URI=... pytest .../test_phase0_migration.py  # 30 passed (both backends)
pre-commit run --all-files                                       # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks                # 2918 passed (x3 runs)
pytest mlflow_oidc_auth/tests/hooks/<each file>                  # 352 passed (per file)
pytest mlflow_oidc_auth/tests/perf/                              # 37 passed — #305 budget intact
python scripts/bench_auth_path.py --users 50 --groups 20         # 0/2/2/3, unchanged
```

Postgres numbers came from a real PostgreSQL 18.3 server, not a mock.

## One thing found along the way, not fixed here

Alembic's `env.py` calls `logging.config.fileConfig()`, which defaults to
`disable_existing_loggers=True` and silences every logger created before it runs. In the test
session this broke an unrelated test's `caplog` assertions once these tests started invoking
Alembic dozens of times; the tests now clear `config_file_name` so `env.py` skips it.

The same call runs at application startup, where it will silence any logger configured before
`init_db()`. That is pre-existing and out of scope here, but it looks like a real wart worth its
own issue — say the word and I will file it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
