### PR TITLE
fix(db): stop migrations from silencing the process's logging (#342)

### DIFF
--- a/mlflow_oidc_auth/db/migrations/env.py
+++ b/mlflow_oidc_auth/db/migrations/env.py
@@ -11,9 +11,27 @@ from mlflow_oidc_auth.db.models._base import Base
 config = context.config
 
 # Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+#
+# Two guards, both for issue #342. ``fileConfig`` defaults to ``disable_existing_loggers=True``,
+# which sets ``.disabled`` on every logger that already exists:
+#
+# * This plugin applies migrations from inside the running server, on first access to the store
+#   singleton — which is the first authenticated request. By then the application logger, the
+#   audit logger and uvicorn's own loggers all exist, and all of them were being silenced for
+#   the life of the process. The audit trail in particular recorded nothing at all: events were
+#   still constructed, then dropped by a disabled logger, with no error and no visible gap.
+# * A library has no business reconfiguring the logging of the process that embeds it. The
+#   ``.ini``'s logging sections exist for the ``alembic`` CLI, where Alembic owns the process.
+#
+# So: skip it entirely when embedded, and even under the CLI leave existing loggers alone.
+#
+# "Embedded" is signalled explicitly by ``db/utils.py::_get_alembic_config``, which every
+# in-process caller goes through. Inferring it from something incidental — the presence of a
+# ``connection`` attribute, say — is how this was missed the first time: ``migrate_if_needed``,
+# the function that actually runs on startup, never sets one.
+_configure_logging = config.attributes.get("configure_logging", True)
+if config.config_file_name is not None and _configure_logging:
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/mlflow_oidc_auth/db/utils.py
+++ b/mlflow_oidc_auth/db/utils.py
@@ -18,6 +18,12 @@ def _get_alembic_config(url: str) -> Config:
     alembic_cfg.set_main_option("script_location", str(alembic_dir))
     url = url.replace("%", "%%")  # Same as here: https://github.com/mlflow/mlflow/issues/1487
     alembic_cfg.set_main_option("sqlalchemy.url", url)
+    # Every caller of this helper is running Alembic *inside* an already-running process, so
+    # env.py must not apply the .ini's logging sections: fileConfig replaces the root handlers
+    # and, by default, disables every logger that already exists — which silenced the audit
+    # trail for the life of the process (issue #342). The .ini's logging config exists for the
+    # `alembic` CLI, which does not come through here.
+    alembic_cfg.attributes["configure_logging"] = False
     return alembic_cfg
 
 

--- a/mlflow_oidc_auth/tests/db/test_migration_logging.py
+++ b/mlflow_oidc_auth/tests/db/test_migration_logging.py
@@ -1,0 +1,171 @@
+"""Applying migrations must not silence the process's logging (issue #342).
+
+Alembic's ``env.py`` calls ``logging.config.fileConfig()``, whose ``disable_existing_loggers``
+default is True. This plugin runs migrations from inside the server, on first access to the store
+singleton — the first authenticated request — so every logger created at import time was being
+disabled for the remaining life of the process.
+
+The audit logger is the one that mattered: ``emit_audit_event`` kept building records and handing
+them to a disabled logger, so the trail recorded nothing, with no error and no visible gap.
+
+Each test drives a real ``init_db()``, because the defect is in what running migrations does to
+the process, not in any function these tests could call directly.
+"""
+
+import io
+import logging
+
+import pytest
+
+import mlflow_oidc_auth.audit as audit_module
+from mlflow_oidc_auth.audit import emit_audit_event
+from mlflow_oidc_auth.logger import get_logger
+
+
+@pytest.fixture
+def preserve_logging():
+    """Snapshot and restore global logging state around a test.
+
+    For tests that deliberately invoke ``fileConfig``: it swaps out the root logger's handlers,
+    which in a pytest session means discarding the ``caplog`` handler and silently breaking
+    capture for every test that runs afterwards.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    saved_disabled = {name: logger.disabled for name, logger in logging.root.manager.loggerDict.items() if isinstance(logger, logging.Logger)}
+    try:
+        yield
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        for name, disabled in saved_disabled.items():
+            logger = logging.root.manager.loggerDict.get(name)
+            if isinstance(logger, logging.Logger):
+                logger.disabled = disabled
+
+
+@pytest.fixture
+def migrated_store(tmp_path):
+    """A store whose ``init_db`` has actually applied the migration chain."""
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    store = SqlAlchemyStore()
+    store.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    yield store
+    store.engine.dispose()
+
+
+class TestApplicationLoggerSurvives:
+    def test_plugin_logger_is_not_disabled(self, migrated_store):
+        assert get_logger().disabled is False
+
+    def test_plugin_logger_still_emits(self, tmp_path, caplog):
+        """Not merely enabled — still actually producing records."""
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        logger = get_logger()
+        SqlAlchemyStore().init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            logger.warning("emitted after the migration ran")
+
+        assert any("emitted after the migration ran" in r.message for r in caplog.records)
+
+    def test_uvicorn_loggers_are_not_disabled(self, migrated_store):
+        """``alembic.ini`` names only root, sqlalchemy and alembic, so uvicorn's own loggers
+        were collateral damage — the server's access and error logs went with them."""
+        for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+            assert logging.getLogger(name).disabled is False, f"{name} was disabled by the migration"
+
+
+class TestAuditTrailSurvives:
+    """The damage that made #342 more than an observability annoyance."""
+
+    @pytest.fixture
+    def audit_output(self, monkeypatch):
+        """Capture what the audit logger actually writes.
+
+        It sets ``propagate = False`` and owns its handler, so ``caplog`` cannot see it; the
+        handler's stream has to be replaced instead. Reading the real output is the point —
+        asserting on a mock would not have caught this defect, because the call still happened.
+        """
+        monkeypatch.setattr(audit_module, "_audit_logger", None)
+        logger = audit_module._get_audit_logger()
+        stream = io.StringIO()
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        yield stream
+        logger.removeHandler(handler)
+        monkeypatch.setattr(audit_module, "_audit_logger", None)
+
+    def test_audit_events_are_written_after_migrations_run(self, audit_output, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        emit_audit_event("test.before", actor="probe", resource_type="user", resource_id="u1")
+
+        SqlAlchemyStore().init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+
+        emit_audit_event("test.after", actor="probe", resource_type="user", resource_id="u1")
+
+        written = audit_output.getvalue()
+        assert "test.before" in written, "precondition: auditing is on and capturing"
+        assert "test.after" in written, "audit trail stopped recording once migrations ran"
+
+    def test_audit_logger_is_not_disabled(self, audit_output, migrated_store):
+        assert audit_module._get_audit_logger().disabled is False
+
+
+class TestEnvPyGuards:
+    """The two conditions in env.py, checked directly so a later edit cannot quietly drop one."""
+
+    def test_the_embedded_helper_marks_itself_as_not_configuring_logging(self, tmp_path):
+        """The signal is explicit, not inferred.
+
+        The first attempt keyed off ``attributes["connection"]``, which ``migrate_if_needed`` —
+        the function that actually runs at startup — never sets, so the guard missed the real
+        path entirely.
+        """
+        from mlflow_oidc_auth.db.utils import _get_alembic_config
+
+        cfg = _get_alembic_config(f"sqlite:///{tmp_path / 'auth.db'}")
+
+        assert cfg.attributes.get("configure_logging") is False
+        assert cfg.config_file_name is not None, "precondition: the ini path is set, so the flag is what skips it"
+
+    def test_init_db_leaves_the_root_handlers_alone(self, tmp_path):
+        """The property that actually broke: ``fileConfig`` swaps out root's handlers.
+
+        That is what discarded pytest's ``caplog`` handler mid-session, and in a deployment it
+        is what would replace an operator's own root logging configuration.
+        """
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        root = logging.getLogger()
+        before = root.handlers[:]
+
+        SqlAlchemyStore().init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+
+        assert root.handlers == before
+
+    def test_cli_style_config_does_not_disable_existing_loggers(self, tmp_path, preserve_logging):
+        """Even where Alembic owns the process, existing loggers must survive.
+
+        ``preserve_logging`` is not optional here: ``fileConfig`` replaces the *root* handlers,
+        which would take pytest's own ``caplog`` handler with it and break unrelated tests later
+        in the session — the same global-state damage this issue is about.
+        """
+        from logging.config import fileConfig
+
+        from mlflow_oidc_auth.db.utils import _get_alembic_config
+
+        marker = logging.getLogger("test.cli.marker")
+        marker.disabled = False
+        cfg = _get_alembic_config(f"sqlite:///{tmp_path / 'auth.db'}")
+
+        fileConfig(cfg.config_file_name, disable_existing_loggers=False)
+
+        assert marker.disabled is False

--- a/mlflow_oidc_auth/tests/db/test_migration_logging.py
+++ b/mlflow_oidc_auth/tests/db/test_migration_logging.py
@@ -18,7 +18,6 @@ import logging
 import pytest
 
 import mlflow_oidc_auth.audit as audit_module
-from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.logger import get_logger
 
 
@@ -105,11 +104,11 @@ class TestAuditTrailSurvives:
     def test_audit_events_are_written_after_migrations_run(self, audit_output, tmp_path):
         from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
 
-        emit_audit_event("test.before", actor="probe", resource_type="user", resource_id="u1")
+        audit_module.emit_audit_event("test.before", actor="probe", resource_type="user", resource_id="u1")
 
         SqlAlchemyStore().init_db(f"sqlite:///{tmp_path / 'auth.db'}")
 
-        emit_audit_event("test.after", actor="probe", resource_type="user", resource_id="u1")
+        audit_module.emit_audit_event("test.after", actor="probe", resource_type="user", resource_id="u1")
 
         written = audit_output.getvalue()
         assert "test.before" in written, "precondition: auditing is on and capturing"

--- a/mlflow_oidc_auth/tests/db/test_phase0_migration.py
+++ b/mlflow_oidc_auth/tests/db/test_phase0_migration.py
@@ -55,17 +55,15 @@ def engine(db_uri):
 
 
 def _alembic_config(engine):
-    """An Alembic config that does not reconfigure this process's logging.
+    """An Alembic config for the embedded path, the way ``db/utils.py`` builds one.
 
-    ``env.py`` calls ``logging.config.fileConfig()``, which defaults to
-    ``disable_existing_loggers=True`` and therefore silences every logger created before it
-    runs. That is survivable once at application startup, but these tests invoke Alembic dozens
-    of times mid-session, and the collateral damage is unrelated tests losing their ``caplog``
-    records. Clearing the filename makes ``env.py`` skip the call.
+    These tests used to clear ``config_file_name`` here, because ``env.py`` called
+    ``fileConfig()`` with its ``disable_existing_loggers=True`` default and silenced loggers
+    created earlier in the session — unrelated tests lost their ``caplog`` records. ``env.py``
+    now skips that whenever Alembic is embedded (#342), so the workaround is gone and the tests
+    exercise the same configuration the application uses.
     """
-    cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
-    cfg.config_file_name = None
-    return cfg
+    return _get_alembic_config(engine.url.render_as_string(hide_password=False))
 
 
 def _upgrade(engine, revision: str) -> None:


### PR DESCRIPTION
Closes #342.

Alembic's `env.py` called `logging.config.fileConfig()` with its `disable_existing_loggers=True`
default. Migrations run on first access to the store singleton — the first authenticated request
— by which point the application logger, the audit logger and uvicorn's own loggers all exist.
All of them were disabled for the remaining life of the process.

**The audit trail was the real damage.** `emit_audit_event` kept building records and handing them
to a disabled logger, so it recorded nothing — no error, no gap, just an empty file.
`AUDIT_LOG_ENABLED` defaults to true, so this was a default deployment.

Before / after, in a real process:

```
                       before          after
probe.before           written         written
init_db()  ← migrations run here
probe.after            DROPPED         written
app logger warning     DROPPED         emitted
```

## The fix

`_get_alembic_config` marks its config as embedded; `env.py` honours that and skips the `.ini`'s
logging sections entirely. Under the `alembic` CLI — where Alembic legitimately owns the process —
they still apply, but with `disable_existing_loggers=False`.

```python
_configure_logging = config.attributes.get("configure_logging", True)
if config.config_file_name is not None and _configure_logging:
    fileConfig(config.config_file_name, disable_existing_loggers=False)
```

**The flag is explicit rather than inferred, and that matters.** My first attempt keyed off
`attributes["connection"]`, on the assumption that the embedded path passes a live connection.
`migrate()` does — but `migrate_if_needed()`, the function that actually runs at startup, does
not. So the guard missed the real path while passing a test written against `migrate()`. It only
surfaced because a test asserted on captured output rather than on the guard's own logic.

Also removes the workaround in the #333 migration tests, which clearing this makes redundant;
those tests now exercise the same configuration the application uses.

## Tests

`mlflow_oidc_auth/tests/db/test_migration_logging.py` — 8 tests, each driving a real `init_db()`,
because the defect is in what running migrations does to the process:

- the audit trail still records after migrations run — the one that encodes the actual damage,
  asserted against the logger's real output rather than a mock, since the call always happened
  and only the write was lost;
- the application logger is not disabled, and still emits;
- `uvicorn` / `uvicorn.error` / `uvicorn.access` are not disabled — `alembic.ini` names only
  `root`, `sqlalchemy` and `alembic`, so the server's own logs were collateral damage;
- `init_db()` leaves the root logger's **handlers** untouched, which is the property that
  actually broke and what would replace an operator's root logging config;
- the embedded helper sets the flag, and the `.ini` path is still present — so the flag is what
  skips it, not a missing file.

**Verified the tests bind:** 7 of the 8 fail against the unfixed code and all 8 pass after.

One test deliberately calls `fileConfig` to check the CLI path, and uses a `preserve_logging`
fixture to snapshot and restore root's handlers. Without it, that test discards pytest's own
`caplog` handler and breaks unrelated tests later in the session — the same global-state damage
this PR is about, which is worth knowing before anyone copies the pattern.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 2926 passed (x3 runs, order randomised)
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/db/                 # 66 passed (x3 runs)
python -m pyflakes <changed files>                # clean
```

Plus the end-to-end check in the table above, run outside pytest so the result does not depend on
the test harness's own logging setup.

## Note for operators

Any audit log from a deployment running the affected versions is empty for everything after its
first authenticated request. That is worth knowing before relying on one for an incident review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
