### PR TITLE
feat(config): identity provider registry with a legacy back-compat shim (#308)

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 
 from mlflow_oidc_auth.config_providers import config_manager
 from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.provider_registry import build_provider_registry
 
 load_dotenv()  # take environment variables from .env.
 logger = get_logger()
@@ -210,11 +211,19 @@ class AppConfig:
         # API documentation settings
         self.ENABLE_API_DOCS = config_manager.get_bool("ENABLE_API_DOCS", default=False)
 
+        # Identity provider registry (issue #308). Built from AUTH_PROVIDERS /
+        # AUTH_PROVIDERS_FILE, falling back to a single "default" provider synthesised from the
+        # flat OIDC_* values above — so a deployment that sets neither behaves exactly as it
+        # does today. Nothing consumes this yet; the flat variables remain authoritative.
+        # Must run after the OIDC_* block, which it reads.
+        self.AUTH_PROVIDERS = build_provider_registry(config_manager, self)
+
         # Run last: these read settings loaded above.
         self._warn_if_resource_creation_restriction_is_inert()
         self._warn_if_default_permission_is_permissive()
         self._warn_if_username_field_unusable()
         self._warn_if_group_name_unusable()
+        self._warn_if_provider_registry_invalid()
 
     @staticmethod
     def _has_usable_entry(field_list) -> bool:
@@ -231,6 +240,23 @@ class AppConfig:
             return any(isinstance(field, str) and field.strip() for field in field_list)
         except TypeError:
             return False
+
+    def _warn_if_provider_registry_invalid(self) -> None:
+        """Report registry entries that were rejected at startup (issue #308).
+
+        Warns rather than raises, for the same reason as the checks around it: ``AppConfig`` is
+        a module-level singleton imported by tooling with nothing to do with login, and taking
+        Alembic down over a malformed provider it never reads would be worse than the
+        misconfiguration. Rejected entries are already absent from the registry, so nothing
+        unvalidated is reachable — this only makes the reason visible.
+
+        Logged at WARNING per entry: an operator who wrote a provider and cannot use it needs
+        the specific reason, and each of these is a security-relevant rejection (a missing
+        audience, an admin source that would allow privilege escalation, an email binding with
+        no domain restriction), not a formatting nit.
+        """
+        for message in self.AUTH_PROVIDERS.errors:
+            logger.warning("Identity provider registry: %s", message)
 
     def _warn_if_username_field_unusable(self) -> None:
         """Warn at startup when OIDC_USERNAME_FIELD or OIDC_DISPLAY_NAME_FIELD is unusable.

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -52,6 +52,31 @@ IDENTITY_BINDINGS = ("subject", "email")
 # replayed as an HMAC secret and any caller can mint a valid token.
 HMAC_ALGORITHMS = ("HS256", "HS384", "HS512")
 
+# Asymmetric algorithms this plugin can actually verify: signatures are checked against keys
+# fetched from the provider's JWKS.
+ASYMMETRIC_ALGORITHMS = (
+    "RS256",
+    "RS384",
+    "RS512",
+    "PS256",
+    "PS384",
+    "PS512",
+    "ES256",
+    "ES384",
+    "ES512",
+    "EdDSA",
+)
+
+# Canonical spelling by uppercase name, so "rs256" and "eddsa" resolve to "RS256" and "EdDSA".
+# Storing the canonical form matters: a consumer comparing against "RS256" would otherwise miss
+# a provider configured as "rs256", and silently fall through to whatever its own default is.
+_CANONICAL_ALGORITHMS = {algorithm.upper(): algorithm for algorithm in ASYMMETRIC_ALGORITHMS + HMAC_ALGORITHMS}
+
+# ``alg: none`` means the token carries no signature at all. Rejected by name and with its own
+# message because it is the single most dangerous value this field can take, and because it is
+# easy to arrive at innocently by copying an example.
+NONE_ALGORITHM = "NONE"
+
 DEFAULT_ALGORITHMS = ("RS256",)
 
 
@@ -99,13 +124,16 @@ class ProviderConfig:
     discovery_url: Optional[str] = None
     client_id: Optional[str] = None
 
-    def uses_jwks(self) -> bool:
-        """Whether this provider verifies signatures against a fetched key set.
+    def has_own_key_source(self) -> bool:
+        """Whether this entry names its own JWKS source rather than inheriting the flat one.
 
-        True for anything with a discovery document or an issuer to discover from. That is
-        what makes an HMAC algorithm dangerous here rather than merely unusual.
+        Reports only what the entry says. It is deliberately *not* used to decide whether an
+        algorithm is safe: an entry naming no source still resolves keys somehow — from the
+        deployment-wide ``OIDC_DISCOVERY_URL`` — so gating the algorithm checks on this was
+        evadable by simply omitting two optional fields. Algorithms are validated on their own
+        merits instead (see :func:`_validate_algorithms`).
         """
-        return bool(self.discovery_url or self.issuer) and self.type in ("oidc", "k8s")
+        return bool(self.discovery_url or self.issuer)
 
 
 @dataclass
@@ -197,7 +225,9 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             "the provider will assert can claim a local user"
         )
 
-    allowed_algorithms = _as_tuple(entry.get("allowed_algorithms")) or DEFAULT_ALGORITHMS
+    allowed_algorithms, algorithm_errors = _validate_algorithms(entry.get("allowed_algorithms"), label)
+    errors.extend(algorithm_errors)
+
     audience = entry.get("audience")
     issuer = entry.get("issuer")
     discovery_url = entry.get("discovery_url")
@@ -205,13 +235,6 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
 
     if not isinstance(audience, str) or not audience.strip():
         errors.append(f"{label}: 'audience' is required; a token validated with no audience check is valid for every relying party of that issuer")
-
-    hmac_listed = [algorithm for algorithm in allowed_algorithms if algorithm.upper() in HMAC_ALGORITHMS]
-    if hmac_listed and (discovery_url or issuer):
-        errors.append(
-            f"{label}: symmetric algorithm(s) {', '.join(hmac_listed)} cannot be combined with a JWKS source "
-            "(discovery_url/issuer) — that is the algorithm-confusion setup where a public key is replayed as an HMAC secret"
-        )
 
     if provider_type == "saml" and not _saml_extra_installed():
         errors.append(f"{label}: type 'saml' requires the [saml] extra to be installed")
@@ -238,6 +261,57 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
         ),
         [],
     )
+
+
+def _validate_algorithms(value: Any, label: str) -> Tuple[Tuple[str, ...], List[str]]:
+    """Resolve ``allowed_algorithms`` to canonical names, rejecting anything unverifiable.
+
+    Three rules, in descending order of how badly they end:
+
+    * ``none`` is rejected outright. It means the token carries no signature, so accepting it
+      lets anyone mint a token for that provider. It is worse than the algorithm-confusion case
+      below, which at least requires a key to confuse.
+    * Symmetric (HMAC) algorithms are rejected outright, not merely when a JWKS source appears
+      on the same entry. This plugin has no symmetric-key verification path at all — signatures
+      are checked against keys fetched from the provider's JWKS — so an HMAC entry cannot work,
+      and the only question is whether it fails safely. Gating on whether the *entry* names a
+      key source was evadable by omitting ``issuer``/``discovery_url`` while the deployment's
+      flat ``OIDC_DISCOVERY_URL`` still supplied one, which is the confusion setup restored.
+      This is stricter than issue #308 asked for, deliberately.
+    * Anything not in the supported set is rejected rather than passed through, so a typo
+      becomes a startup message instead of an algorithm a consumer silently does not honour.
+
+    Returns:
+        ``(algorithms, errors)``. Names are canonically spelled, so a consumer comparing against
+        ``"RS256"`` matches an entry written as ``"rs256"``.
+    """
+    raw = _as_tuple(value)
+    if not raw:
+        return DEFAULT_ALGORITHMS, []
+
+    algorithms: List[str] = []
+    errors: List[str] = []
+    for algorithm in raw:
+        upper = algorithm.upper()
+        if upper == NONE_ALGORITHM:
+            errors.append(f"{label}: algorithm 'none' is never allowed; it means the token carries no signature, so anyone could mint one for this provider")
+            continue
+        if upper in HMAC_ALGORITHMS:
+            errors.append(
+                f"{label}: symmetric algorithm {algorithm!r} is not supported; this plugin verifies signatures against the provider's JWKS, "
+                "and accepting an HMAC algorithm alongside a fetched public key is the algorithm-confusion setup where that key is replayed "
+                "as a shared secret"
+            )
+            continue
+        canonical = _CANONICAL_ALGORITHMS.get(upper)
+        if canonical is None:
+            errors.append(f"{label}: unknown algorithm {algorithm!r}; expected one of {', '.join(ASYMMETRIC_ALGORITHMS)}")
+            continue
+        algorithms.append(canonical)
+
+    if errors:
+        return DEFAULT_ALGORITHMS, errors
+    return tuple(algorithms), []
 
 
 def _validate_admin_source(admin_source: Any, label: str) -> List[str]:
@@ -283,12 +357,37 @@ def _saml_extra_installed() -> bool:
     return False
 
 
-def _parse_entries(raw: str, origin: str) -> Tuple[List[Dict[str, Any]], List[str]]:
-    """Parse the JSON payload into a list of entry dicts."""
-    try:
-        parsed = json.loads(raw)
-    except (ValueError, TypeError) as exc:
-        return [], [f"{origin}: could not be parsed as JSON ({exc})"]
+def _is_present(value: Any) -> bool:
+    """Whether a configuration value was actually supplied.
+
+    A blank or whitespace-only string counts as absent, matching how the rest of the config
+    layer treats an unset variable; an empty list or dict does not, because writing one is a
+    deliberate statement that there are no providers.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _parse_entries(raw: Any, origin: str) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Parse the payload into a list of entry dicts.
+
+    ``raw`` may already be a list or dict rather than a JSON string. Providers in the
+    ``config_providers`` chain are typed ``-> Any``, and the AWS Secrets Manager provider in
+    particular ``json.loads`` its whole secret, so a registry stored as nested JSON — the
+    natural way to write one in a secrets manager — arrives already parsed. Treating that as
+    "not a string, therefore not configured" silently ignored the operator's entire
+    configuration.
+    """
+    if isinstance(raw, (list, dict)):
+        parsed: Any = raw
+    else:
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            return [], [f"{origin}: could not be parsed as JSON ({exc})"]
 
     if isinstance(parsed, dict):
         # Tolerate {"providers": [...]}, which is what most people write first.
@@ -349,7 +448,18 @@ def build_provider_registry(config_manager: Any, app_config: Any) -> RegistryLoa
     source = "env"
     origin = "AUTH_PROVIDERS"
 
-    if not (isinstance(raw, str) and raw.strip()):
+    if _is_present(raw) and not isinstance(raw, (str, list, dict)):
+        # Configured, but as something no reading of it can turn into providers. Say so rather
+        # than falling through to legacy as though it had never been set.
+        return RegistryLoadResult(
+            providers=_legacy_providers(app_config),
+            errors=[
+                f"{origin}: expected a JSON array (or an already-parsed list) but got {type(raw).__name__}; " "falling back to the legacy OIDC_* configuration"
+            ],
+            source="legacy",
+        )
+
+    if not _is_present(raw):
         path = config_manager.get("AUTH_PROVIDERS_FILE")
         if isinstance(path, str) and path.strip():
             source = "file"

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -220,6 +220,11 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
         # wrong one.
         return None, [f"{label}: duplicate id"]
 
+    # Before anything else touches these values. See _validate_field_types.
+    type_errors = _validate_field_types(entry, label)
+    if type_errors:
+        return None, type_errors
+
     provider_type = entry.get("type", "oidc")
     if provider_type not in PROVIDER_TYPES:
         errors.append(f"{label}: unknown type {provider_type!r}; expected one of {', '.join(PROVIDER_TYPES)}")
@@ -300,6 +305,49 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
     )
 
 
+# Entry fields that must be strings when present. Checked up front, before any of them is used
+# as a dict key or has a string method called on it: JSON can put a list or object in any of
+# these, and this module must report that rather than raise. ``AppConfig`` is instantiated at
+# import time, so an exception here does not degrade login — it stops the plugin and Alembic
+# from importing at all, which is the opposite of what dropping invalid entries is for.
+_STRING_FIELDS = (
+    "type",
+    "display_name",
+    "provisioning",
+    "group_sync",
+    "group_sync_mode",
+    "admin_source",
+    "identity_binding",
+    "audience",
+    "issuer",
+    "discovery_url",
+    "client_id",
+)
+
+# Fields that may be a single string or a list of them.
+_LIST_FIELDS = ("allowed_email_domains", "allowed_algorithms")
+
+
+def _validate_field_types(entry: Dict[str, Any], label: str) -> List[str]:
+    """Check that every field is the shape the rest of validation assumes.
+
+    Runs before any other check and short-circuits it, so no later line can call ``.strip()`` on
+    a list or use one as a dict key. Reporting the wrong type is also more useful to an operator
+    than the downstream symptom: ``'type' must be a string, got list`` points at the mistake,
+    whereas ``unhashable type: 'list'`` points at our dictionary.
+    """
+    errors = []
+    for key in _STRING_FIELDS:
+        value = entry.get(key)
+        if value is not None and not isinstance(value, str):
+            errors.append(f"{label}: '{key}' must be a string, got {type(value).__name__}")
+    for key in _LIST_FIELDS:
+        value = entry.get(key)
+        if value is not None and not isinstance(value, (str, list, tuple)):
+            errors.append(f"{label}: '{key}' must be a string or a list of strings, got {type(value).__name__}")
+    return errors
+
+
 def _validate_algorithms(value: Any, label: str) -> Tuple[Tuple[str, ...], List[str]]:
     """Resolve ``allowed_algorithms`` to canonical names, rejecting anything unverifiable.
 
@@ -322,9 +370,21 @@ def _validate_algorithms(value: Any, label: str) -> Tuple[Tuple[str, ...], List[
         ``(algorithms, errors)``. Names are canonically spelled, so a consumer comparing against
         ``"RS256"`` matches an entry written as ``"rs256"``.
     """
+    if value is None:
+        return DEFAULT_ALGORITHMS, []
+
+    # Present but unusable is reported rather than quietly defaulted. Falling back to RS256 is
+    # the safe direction, but an operator who believes they narrowed or widened the accepted
+    # set needs to find out that they did not — silently discarding a configured value leaves
+    # nothing to debug from.
+    items = [value] if isinstance(value, str) else list(value)
+    non_strings = [item for item in items if not isinstance(item, str)]
+    if non_strings:
+        return DEFAULT_ALGORITHMS, [f"{label}: 'allowed_algorithms' must contain only strings; got {type(non_strings[0]).__name__}"]
+
     raw = _as_tuple(value)
     if not raw:
-        return DEFAULT_ALGORITHMS, []
+        return DEFAULT_ALGORITHMS, [f"{label}: 'allowed_algorithms' is set but lists no algorithm; omit it to accept the default {DEFAULT_ALGORITHMS[0]}"]
 
     algorithms: List[str] = []
     errors: List[str] = []

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -40,6 +40,14 @@ logger = get_logger()
 DEFAULT_PROVIDER_ID = "default"
 
 PROVIDER_TYPES = ("oidc", "saml", "k8s")
+
+# Provider types that can carry a browser login flow. ``k8s`` cannot: a projected
+# service-account token is presented directly as a bearer credential — there is no
+# authorization endpoint to redirect a human to, no consent, and no callback. This is a
+# different axis from ``type``, which describes how a credential is *verified*: a k8s provider
+# verifies tokens the same way an OIDC one does (JWT against the cluster's JWKS), it just can
+# never appear on a login page.
+INTERACTIVE_BY_DEFAULT = {"oidc": True, "saml": True, "k8s": False}
 PROVISIONING_MODES = ("jit", "scim", "none")
 GROUP_SYNC_MODES = ("none", "first_login", "every_login")
 GROUP_SYNC_STRATEGIES = ("additive", "authoritative")
@@ -98,6 +106,12 @@ class ProviderConfig:
         group_sync_mode: ``authoritative`` replaces local membership with the claim,
             ``additive`` only adds.
         admin_source: Where administrator status may come from. Never ``scim``.
+        interactive: Whether this provider can carry a browser login flow, and so whether it
+            belongs on the login page (#317, #330). Independent of ``type``, which describes how
+            a credential is *verified*: a ``k8s`` provider verifies tokens exactly as an
+            ``oidc`` one does, but a projected service-account token is presented directly as a
+            bearer credential — there is no authorization endpoint to redirect to. Defaults
+            from the type and cannot be set True for a type that has no browser flow.
         identity_binding: Which token field identifies the user.
         allowed_email_domains: Required when binding on ``email``; an email-bound provider
             with no domain restriction lets anyone who can prove any address take an account.
@@ -117,6 +131,7 @@ class ProviderConfig:
     group_sync_mode: str = "authoritative"
     admin_source: str = "claims"
     identity_binding: str = "subject"
+    interactive: bool = True
     allowed_email_domains: Tuple[str, ...] = ()
     allowed_algorithms: Tuple[str, ...] = DEFAULT_ALGORITHMS
     audience: Optional[str] = None
@@ -149,6 +164,15 @@ class RegistryLoadResult:
     providers: List[ProviderConfig] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
     source: str = "legacy"
+
+    def interactive_providers(self) -> List[ProviderConfig]:
+        """Providers that belong on the login page.
+
+        What #317 renders one button per. Excludes machine-only providers such as a Kubernetes
+        service-account issuer, which verifies tokens like any other OIDC provider but has no
+        flow a browser can start.
+        """
+        return [provider for provider in self.providers if provider.interactive]
 
     def by_id(self, provider_id: str) -> Optional[ProviderConfig]:
         """Return the provider with ``provider_id``, or None."""
@@ -218,6 +242,18 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
     if identity_binding not in IDENTITY_BINDINGS:
         errors.append(f"{label}: unknown identity_binding {identity_binding!r}; expected one of {', '.join(IDENTITY_BINDINGS)}")
 
+    interactive_default = INTERACTIVE_BY_DEFAULT.get(provider_type, True)
+    interactive = entry.get("interactive", interactive_default)
+    if not isinstance(interactive, bool):
+        errors.append(f"{label}: 'interactive' must be true or false, got {interactive!r}")
+    elif interactive and not interactive_default:
+        # Rejected rather than silently corrected: an operator who asked for this expects a
+        # login button, and #317 would render one that cannot complete a flow.
+        errors.append(
+            f"{label}: type {provider_type!r} has no browser login flow, so 'interactive' cannot be true; "
+            "its credentials are presented directly as bearer tokens"
+        )
+
     allowed_email_domains = _as_tuple(entry.get("allowed_email_domains"))
     if identity_binding == "email" and not allowed_email_domains:
         errors.append(
@@ -252,6 +288,7 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             group_sync_mode=group_sync_mode,
             admin_source=entry.get("admin_source", "claims"),
             identity_binding=identity_binding,
+            interactive=bool(interactive),
             allowed_email_domains=allowed_email_domains,
             allowed_algorithms=allowed_algorithms,
             audience=audience.strip(),

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -1,0 +1,450 @@
+"""Identity provider registry (issue #308).
+
+Configuration is a flat set of ``OIDC_*`` singletons and cannot express more than one identity
+provider. This module adds a structured registry that can, while leaving the flat variables as
+the sole source of truth for deployments that have not adopted it.
+
+**Nothing consumes this yet.** It is the shape the rest of the enterprise-identity epic (#304)
+is built against; login, callback and token validation are unchanged by this module.
+
+Two ways to configure it, both read through the existing ``config_providers`` chain so secrets
+managers keep working:
+
+``AUTH_PROVIDERS``
+    A JSON array of provider objects.
+``AUTH_PROVIDERS_FILE``
+    A path to a file containing the same JSON.
+
+With neither set, a single provider ``default`` is synthesised from the flat ``OIDC_*``
+variables with ``jit`` / ``every_login`` / ``authoritative`` — which is what the plugin does
+today, so an existing deployment sees no change.
+
+Invalid entries are **dropped, not repaired**, and the reasons are reported so startup can log
+them. Dropping rather than raising follows the ``_warn_if_*`` precedent in ``config.py``:
+``AppConfig`` is a module-level singleton imported by tooling with nothing to do with login —
+Alembic's migration environment, for one — so raising here would take that tooling down over a
+provider it never uses. Dropping is also the deny-by-default answer: an entry that cannot be
+validated does not exist, so nobody can authenticate through it.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+# The provider id synthesised from the flat OIDC_* variables.
+DEFAULT_PROVIDER_ID = "default"
+
+PROVIDER_TYPES = ("oidc", "saml", "k8s")
+PROVISIONING_MODES = ("jit", "scim", "none")
+GROUP_SYNC_MODES = ("none", "first_login", "every_login")
+GROUP_SYNC_STRATEGIES = ("additive", "authoritative")
+# "scim" is deliberately absent — see _validate_admin_source.
+ADMIN_SOURCES = ("claims", "none")
+IDENTITY_BINDINGS = ("subject", "email")
+
+# Symmetric algorithms: the verifier holds the same secret the signer does. Combined with a
+# JWKS source this is the classic algorithm-confusion setup, where a public verification key is
+# replayed as an HMAC secret and any caller can mint a valid token.
+HMAC_ALGORITHMS = ("HS256", "HS384", "HS512")
+
+DEFAULT_ALGORITHMS = ("RS256",)
+
+
+@dataclass(frozen=True)
+class ProviderConfig:
+    """One identity provider and the policy that applies to it.
+
+    Frozen because the registry is read at startup and shared; a consumer mutating a provider
+    in place would change authentication policy for every later request.
+
+    Attributes:
+        id: Stable identifier, unique across the registry. Used as ``provider_id`` on
+            ``user_identities`` rows (#333).
+        type: One of ``oidc``, ``saml``, ``k8s``.
+        display_name: Human-readable label for the login picker.
+        provisioning: ``jit`` creates users on first login, ``scim`` expects an external
+            directory to create them, ``none`` requires them to exist already.
+        group_sync: When group membership is refreshed from provider claims.
+        group_sync_mode: ``authoritative`` replaces local membership with the claim,
+            ``additive`` only adds.
+        admin_source: Where administrator status may come from. Never ``scim``.
+        identity_binding: Which token field identifies the user.
+        allowed_email_domains: Required when binding on ``email``; an email-bound provider
+            with no domain restriction lets anyone who can prove any address take an account.
+        allowed_algorithms: Accepted JWT signing algorithms.
+        audience: Expected ``aud``. Required — a token with no audience check is valid for
+            any relying party the issuer serves.
+        issuer: Expected ``iss``, when known.
+        discovery_url: OIDC discovery document, for ``oidc`` providers.
+        client_id: OAuth client id, for ``oidc`` providers.
+    """
+
+    id: str
+    type: str = "oidc"
+    display_name: str = ""
+    provisioning: str = "jit"
+    group_sync: str = "every_login"
+    group_sync_mode: str = "authoritative"
+    admin_source: str = "claims"
+    identity_binding: str = "subject"
+    allowed_email_domains: Tuple[str, ...] = ()
+    allowed_algorithms: Tuple[str, ...] = DEFAULT_ALGORITHMS
+    audience: Optional[str] = None
+    issuer: Optional[str] = None
+    discovery_url: Optional[str] = None
+    client_id: Optional[str] = None
+
+    def uses_jwks(self) -> bool:
+        """Whether this provider verifies signatures against a fetched key set.
+
+        True for anything with a discovery document or an issuer to discover from. That is
+        what makes an HMAC algorithm dangerous here rather than merely unusual.
+        """
+        return bool(self.discovery_url or self.issuer) and self.type in ("oidc", "k8s")
+
+
+@dataclass
+class RegistryLoadResult:
+    """Providers that validated, plus why anything else did not.
+
+    Attributes:
+        providers: Entries that passed every check, in configuration order.
+        errors: One human-readable line per rejected entry or per structural problem.
+        source: Where the registry came from — ``legacy``, ``env`` or ``file``.
+    """
+
+    providers: List[ProviderConfig] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    source: str = "legacy"
+
+    def by_id(self, provider_id: str) -> Optional[ProviderConfig]:
+        """Return the provider with ``provider_id``, or None."""
+        for provider in self.providers:
+            if provider.id == provider_id:
+                return provider
+        return None
+
+
+def _as_tuple(value: Any) -> Tuple[str, ...]:
+    """Coerce a JSON scalar or list into a tuple of non-blank strings.
+
+    A single string is treated as a one-element list, which is what an operator writing
+    ``"allowed_email_domains": "example.com"`` means.
+    """
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optional[ProviderConfig], List[str]]:
+    """Validate one registry entry.
+
+    Returns:
+        ``(provider, errors)``. ``provider`` is None whenever ``errors`` is non-empty — an
+        entry is never partially accepted, because a provider missing half its policy is more
+        dangerous than one that does not exist.
+    """
+    errors: List[str] = []
+    label = f"provider[{index}]"
+
+    provider_id = entry.get("id")
+    if not isinstance(provider_id, str) or not provider_id.strip():
+        return None, [f"{label}: 'id' is required and must be a non-empty string"]
+    provider_id = provider_id.strip()
+    label = f"provider '{provider_id}'"
+
+    if provider_id in seen_ids:
+        # Both copies are rejected by the caller: with two entries claiming one id there is no
+        # way to tell which policy the operator meant, and guessing would silently apply the
+        # wrong one.
+        return None, [f"{label}: duplicate id"]
+
+    provider_type = entry.get("type", "oidc")
+    if provider_type not in PROVIDER_TYPES:
+        errors.append(f"{label}: unknown type {provider_type!r}; expected one of {', '.join(PROVIDER_TYPES)}")
+
+    provisioning = entry.get("provisioning", "jit")
+    if provisioning not in PROVISIONING_MODES:
+        errors.append(f"{label}: unknown provisioning {provisioning!r}; expected one of {', '.join(PROVISIONING_MODES)}")
+
+    group_sync = entry.get("group_sync", "every_login")
+    if group_sync not in GROUP_SYNC_MODES:
+        errors.append(f"{label}: unknown group_sync {group_sync!r}; expected one of {', '.join(GROUP_SYNC_MODES)}")
+
+    group_sync_mode = entry.get("group_sync_mode", "authoritative")
+    if group_sync_mode not in GROUP_SYNC_STRATEGIES:
+        errors.append(f"{label}: unknown group_sync_mode {group_sync_mode!r}; expected one of {', '.join(GROUP_SYNC_STRATEGIES)}")
+
+    errors.extend(_validate_admin_source(entry.get("admin_source", "claims"), label))
+
+    identity_binding = entry.get("identity_binding", "subject")
+    if identity_binding not in IDENTITY_BINDINGS:
+        errors.append(f"{label}: unknown identity_binding {identity_binding!r}; expected one of {', '.join(IDENTITY_BINDINGS)}")
+
+    allowed_email_domains = _as_tuple(entry.get("allowed_email_domains"))
+    if identity_binding == "email" and not allowed_email_domains:
+        errors.append(
+            f"{label}: identity_binding 'email' requires allowed_email_domains; without it any account at any domain "
+            "the provider will assert can claim a local user"
+        )
+
+    allowed_algorithms = _as_tuple(entry.get("allowed_algorithms")) or DEFAULT_ALGORITHMS
+    audience = entry.get("audience")
+    issuer = entry.get("issuer")
+    discovery_url = entry.get("discovery_url")
+    client_id = entry.get("client_id")
+
+    if not isinstance(audience, str) or not audience.strip():
+        errors.append(f"{label}: 'audience' is required; a token validated with no audience check is valid for every relying party of that issuer")
+
+    hmac_listed = [algorithm for algorithm in allowed_algorithms if algorithm.upper() in HMAC_ALGORITHMS]
+    if hmac_listed and (discovery_url or issuer):
+        errors.append(
+            f"{label}: symmetric algorithm(s) {', '.join(hmac_listed)} cannot be combined with a JWKS source "
+            "(discovery_url/issuer) — that is the algorithm-confusion setup where a public key is replayed as an HMAC secret"
+        )
+
+    if provider_type == "saml" and not _saml_extra_installed():
+        errors.append(f"{label}: type 'saml' requires the [saml] extra to be installed")
+
+    if errors:
+        return None, errors
+
+    return (
+        ProviderConfig(
+            id=provider_id,
+            type=provider_type,
+            display_name=entry.get("display_name") or provider_id,
+            provisioning=provisioning,
+            group_sync=group_sync,
+            group_sync_mode=group_sync_mode,
+            admin_source=entry.get("admin_source", "claims"),
+            identity_binding=identity_binding,
+            allowed_email_domains=allowed_email_domains,
+            allowed_algorithms=allowed_algorithms,
+            audience=audience.strip(),
+            issuer=issuer.strip() if isinstance(issuer, str) else None,
+            discovery_url=discovery_url.strip() if isinstance(discovery_url, str) else None,
+            client_id=client_id.strip() if isinstance(client_id, str) else None,
+        ),
+        [],
+    )
+
+
+def _validate_admin_source(admin_source: Any, label: str) -> List[str]:
+    """Reject ``admin_source: scim``, and anything else outside the allowed set.
+
+    SCIM is rejected on purpose rather than as an oversight. If administrator status can be
+    derived from a SCIM-provisioned group, then whoever can create groups in the external
+    directory — or influence their naming — can grant themselves admin here. Grafana shipped
+    exactly that privilege-escalation flaw. Admin group names stay server-side configuration.
+    """
+    if admin_source == "scim":
+        return [
+            f"{label}: admin_source 'scim' is not allowed; it would let whoever controls group naming in the external "
+            "directory grant themselves administrator. Keep admin group names in server-side configuration."
+        ]
+    if admin_source not in ADMIN_SOURCES:
+        return [f"{label}: unknown admin_source {admin_source!r}; expected one of {', '.join(ADMIN_SOURCES)}"]
+    return []
+
+
+# Candidate imports for the optional SAML dependency. Which library ships as the ``[saml]``
+# extra is decided by the packaging spike (#327) and is not settled here — this lists the
+# realistic candidates so the check works whichever is chosen, and so whoever closes #327 has an
+# obvious place to pin it down.
+#
+# Until that extra exists, no import succeeds and every ``type: saml`` provider is rejected.
+# That is the correct answer rather than a gap: SAML cannot be configured before SAML is
+# implemented, and silently accepting the entry would leave a provider in the registry that
+# nothing can authenticate against.
+_SAML_MODULE_CANDIDATES = ("onelogin.saml2", "saml2")
+
+
+def _saml_extra_installed() -> bool:
+    """Whether a SAML implementation is importable."""
+    import importlib.util
+
+    for module in _SAML_MODULE_CANDIDATES:
+        try:
+            if importlib.util.find_spec(module) is not None:
+                return True
+        except (ImportError, ValueError):
+            continue
+    return False
+
+
+def _parse_entries(raw: str, origin: str) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Parse the JSON payload into a list of entry dicts."""
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        return [], [f"{origin}: could not be parsed as JSON ({exc})"]
+
+    if isinstance(parsed, dict):
+        # Tolerate {"providers": [...]}, which is what most people write first.
+        parsed = parsed.get("providers", parsed)
+    if not isinstance(parsed, list):
+        return [], [f"{origin}: expected a JSON array of provider objects"]
+
+    entries = []
+    errors = []
+    for index, entry in enumerate(parsed):
+        if isinstance(entry, dict):
+            entries.append(entry)
+        else:
+            errors.append(f"{origin}: provider[{index}] is not an object")
+    return entries, errors
+
+
+def _legacy_entry(app_config: Any) -> Dict[str, Any]:
+    """Describe the flat ``OIDC_*`` configuration as a single registry entry.
+
+    The policy values are the behaviour the plugin has today, stated explicitly: users are
+    created on first login, groups are re-read from the claim on every login, and that claim
+    replaces local membership.
+    """
+    return {
+        "id": DEFAULT_PROVIDER_ID,
+        "type": "oidc",
+        "display_name": getattr(app_config, "OIDC_PROVIDER_DISPLAY_NAME", "") or DEFAULT_PROVIDER_ID,
+        "provisioning": "jit",
+        "group_sync": "every_login",
+        "group_sync_mode": "authoritative",
+        "admin_source": "claims",
+        "identity_binding": "subject",
+        "allowed_algorithms": list(DEFAULT_ALGORITHMS),
+        "audience": getattr(app_config, "OIDC_AUDIENCE", None),
+        "issuer": getattr(app_config, "OIDC_ISSUER", None),
+        "discovery_url": getattr(app_config, "OIDC_DISCOVERY_URL", None),
+        "client_id": getattr(app_config, "OIDC_CLIENT_ID", None),
+    }
+
+
+def build_provider_registry(config_manager: Any, app_config: Any) -> RegistryLoadResult:
+    """Build the provider registry from configuration.
+
+    Resolution order: ``AUTH_PROVIDERS`` (inline JSON), then ``AUTH_PROVIDERS_FILE``, then the
+    legacy flat variables. Both registry sources are read through ``config_manager`` so a
+    secrets manager can supply them.
+
+    Parameters:
+        config_manager: The chain used to resolve configuration keys.
+        app_config: The partially built :class:`~mlflow_oidc_auth.config.AppConfig`, read for
+            the flat ``OIDC_*`` values when synthesising the legacy provider.
+
+    Returns:
+        RegistryLoadResult: Valid providers, plus a reason for every rejection.
+    """
+    raw = config_manager.get("AUTH_PROVIDERS")
+    source = "env"
+    origin = "AUTH_PROVIDERS"
+
+    if not (isinstance(raw, str) and raw.strip()):
+        path = config_manager.get("AUTH_PROVIDERS_FILE")
+        if isinstance(path, str) and path.strip():
+            source = "file"
+            origin = f"AUTH_PROVIDERS_FILE ({path})"
+            try:
+                with open(os.path.expanduser(path.strip()), "r", encoding="utf-8") as handle:
+                    raw = handle.read()
+            except OSError as exc:
+                # Fall back to legacy rather than leaving the deployment with no providers at
+                # all: an unreadable file is an operator error, not a reason to lock everyone
+                # out of a working installation.
+                return RegistryLoadResult(
+                    providers=_legacy_providers(app_config),
+                    errors=[f"{origin}: could not be read ({exc}); falling back to the legacy OIDC_* configuration"],
+                    source="legacy",
+                )
+        else:
+            return RegistryLoadResult(providers=_legacy_providers(app_config), errors=[], source="legacy")
+
+    entries, errors = _parse_entries(raw, origin)
+    if not entries and errors:
+        # Malformed payload: keep the legacy provider working rather than silently ending up
+        # with an empty registry, and report why.
+        return RegistryLoadResult(
+            providers=_legacy_providers(app_config),
+            errors=errors + [f"{origin}: falling back to the legacy OIDC_* configuration"],
+            source="legacy",
+        )
+
+    providers: List[ProviderConfig] = []
+    seen_ids: set = set()
+    duplicate_ids: set = set()
+
+    # First pass records ids so a duplicate can reject *both* copies rather than keeping
+    # whichever happened to be written first.
+    id_counts: Dict[str, int] = {}
+    for entry in entries:
+        entry_id = entry.get("id")
+        if isinstance(entry_id, str) and entry_id.strip():
+            id_counts[entry_id.strip()] = id_counts.get(entry_id.strip(), 0) + 1
+    duplicate_ids = {entry_id for entry_id, count in id_counts.items() if count > 1}
+
+    for index, entry in enumerate(entries):
+        entry_id = entry.get("id")
+        if isinstance(entry_id, str) and entry_id.strip() in duplicate_ids:
+            if entry_id.strip() not in seen_ids:
+                errors.append(f"provider '{entry_id.strip()}': duplicate id; every entry using it is ignored")
+                seen_ids.add(entry_id.strip())
+            continue
+        provider, entry_errors = _validate(entry, index, seen_ids)
+        if provider is None:
+            errors.extend(entry_errors)
+            continue
+        seen_ids.add(provider.id)
+        providers.append(provider)
+
+    return RegistryLoadResult(providers=providers, errors=errors, source=source)
+
+
+def _legacy_providers(app_config: Any) -> List[ProviderConfig]:
+    """The single ``default`` provider synthesised from the flat ``OIDC_*`` variables.
+
+    Built directly rather than run through :func:`_validate`, and the difference is deliberate:
+    ``audience`` is **required of an explicitly configured entry but not of this one**.
+
+    ``OIDC_AUDIENCE`` is optional today, and a deployment that leaves it unset performs no
+    audience check — that is the current behaviour, whatever one thinks of it. Holding the
+    synthesised provider to the stricter rule would produce an empty registry for most existing
+    installations, which is precisely the back-compat break this synthesis exists to prevent.
+
+    New configuration is held to the higher standard; existing configuration is described
+    faithfully, including where it is weak. Tightening it is a behaviour change and belongs
+    with whichever task first consumes the registry, not here.
+    """
+    entry = _legacy_entry(app_config)
+    audience = entry.get("audience")
+    if not (isinstance(audience, str) and audience.strip()):
+        logger.debug(
+            "OIDC_AUDIENCE is not set, so the synthesised 'default' provider carries no audience — matching today's behaviour, "
+            "in which no audience check is performed."
+        )
+    return [
+        ProviderConfig(
+            id=DEFAULT_PROVIDER_ID,
+            type="oidc",
+            display_name=entry["display_name"],
+            provisioning="jit",
+            group_sync="every_login",
+            group_sync_mode="authoritative",
+            admin_source="claims",
+            identity_binding="subject",
+            allowed_algorithms=DEFAULT_ALGORITHMS,
+            audience=audience.strip() if isinstance(audience, str) and audience.strip() else None,
+            issuer=entry["issuer"],
+            discovery_url=entry["discovery_url"],
+            client_id=entry["client_id"],
+        )
+    ]

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -1,0 +1,302 @@
+"""Identity provider registry parsing, back-compat and validation (issue #308).
+
+The registry is configuration only — nothing authenticates against it yet — so what these tests
+defend is that it describes today's deployment faithfully, and that a misconfigured entry is
+dropped rather than half-applied.
+
+Every rejection below is security-relevant, and each has its own test: an entry that survives
+one of these checks by accident is a provider someone can authenticate through under a policy
+the operator did not write.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mlflow_oidc_auth.provider_registry import (
+    DEFAULT_ALGORITHMS,
+    DEFAULT_PROVIDER_ID,
+    ProviderConfig,
+    build_provider_registry,
+)
+
+
+class FakeConfigManager:
+    """A stand-in for the ``config_providers`` chain, returning fixed values."""
+
+    def __init__(self, **values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+def legacy_app_config(**overrides) -> SimpleNamespace:
+    """The flat ``OIDC_*`` attributes the synthesiser reads."""
+    values = {
+        "OIDC_PROVIDER_DISPLAY_NAME": "Login with OIDC",
+        "OIDC_AUDIENCE": None,
+        "OIDC_ISSUER": None,
+        "OIDC_DISCOVERY_URL": "https://idp.example.com/.well-known/openid-configuration",
+        "OIDC_CLIENT_ID": "client-123",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def valid_entry(**overrides) -> dict:
+    """A minimal entry that passes every check, for tests that break one thing at a time."""
+    entry = {"id": "okta", "type": "oidc", "audience": "mlflow"}
+    entry.update(overrides)
+    return entry
+
+
+def build(entries=None, app_config=None, **manager_values):
+    """Build a registry from ``entries`` as inline JSON."""
+    if entries is not None:
+        manager_values.setdefault("AUTH_PROVIDERS", json.dumps(entries))
+    return build_provider_registry(FakeConfigManager(**manager_values), app_config or legacy_app_config())
+
+
+class TestLegacyBackCompat:
+    """With no registry configured, behaviour must be exactly what it is today."""
+
+    def test_no_registry_synthesises_a_single_default_provider(self):
+        result = build()
+
+        assert result.source == "legacy"
+        assert [p.id for p in result.providers] == [DEFAULT_PROVIDER_ID]
+        assert result.errors == []
+
+    def test_the_default_provider_carries_todays_policy(self):
+        """jit / every_login / authoritative — the behaviour the plugin already has."""
+        provider = build().providers[0]
+
+        assert provider.provisioning == "jit"
+        assert provider.group_sync == "every_login"
+        assert provider.group_sync_mode == "authoritative"
+        assert provider.admin_source == "claims"
+        assert provider.identity_binding == "subject"
+        assert provider.allowed_algorithms == DEFAULT_ALGORITHMS
+
+    def test_the_default_provider_carries_the_flat_oidc_values(self):
+        provider = build(app_config=legacy_app_config(OIDC_AUDIENCE="aud-1", OIDC_ISSUER="https://idp.example.com")).providers[0]
+
+        assert provider.audience == "aud-1"
+        assert provider.issuer == "https://idp.example.com"
+        assert provider.discovery_url == "https://idp.example.com/.well-known/openid-configuration"
+        assert provider.client_id == "client-123"
+
+    def test_a_deployment_without_an_audience_still_gets_its_provider(self):
+        """The asymmetry that keeps back-compat non-negotiable.
+
+        ``audience`` is required of an explicitly configured entry, but ``OIDC_AUDIENCE`` is
+        optional today and most installations leave it unset. Holding the synthesised provider
+        to the stricter rule would hand those deployments an empty registry — exactly the break
+        this synthesis exists to prevent. New config is held higher; existing config is
+        described faithfully, including where it is weak.
+        """
+        result = build(app_config=legacy_app_config(OIDC_AUDIENCE=None))
+
+        assert [p.id for p in result.providers] == [DEFAULT_PROVIDER_ID]
+        assert result.providers[0].audience is None
+        assert result.errors == []
+
+
+class TestParsingSources:
+    def test_registry_parses_from_the_env_variable(self):
+        result = build([valid_entry()])
+
+        assert result.source == "env"
+        assert [p.id for p in result.providers] == ["okta"]
+
+    def test_registry_parses_from_a_file(self, tmp_path):
+        path = tmp_path / "providers.json"
+        path.write_text(json.dumps([valid_entry(id="from-file")]))
+
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS_FILE=str(path)), legacy_app_config())
+
+        assert result.source == "file"
+        assert [p.id for p in result.providers] == ["from-file"]
+
+    def test_the_env_variable_wins_over_the_file(self, tmp_path):
+        path = tmp_path / "providers.json"
+        path.write_text(json.dumps([valid_entry(id="from-file")]))
+
+        result = build([valid_entry(id="from-env")], AUTH_PROVIDERS_FILE=str(path))
+
+        assert [p.id for p in result.providers] == ["from-env"]
+
+    def test_a_providers_key_wrapper_is_accepted(self):
+        """``{"providers": [...]}`` is what most people write first."""
+        result = build({"providers": [valid_entry()]})
+
+        assert [p.id for p in result.providers] == ["okta"]
+
+    def test_malformed_json_falls_back_to_legacy_rather_than_emptying_the_registry(self):
+        """An operator typo must not lock a working deployment out."""
+        result = build(AUTH_PROVIDERS="{not json")
+
+        assert [p.id for p in result.providers] == [DEFAULT_PROVIDER_ID]
+        assert any("JSON" in e for e in result.errors)
+
+    def test_an_unreadable_file_falls_back_to_legacy(self, tmp_path):
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS_FILE=str(tmp_path / "missing.json")), legacy_app_config())
+
+        assert [p.id for p in result.providers] == [DEFAULT_PROVIDER_ID]
+        assert any("could not be read" in e for e in result.errors)
+
+
+class TestValidationRejections:
+    """One test per rule the issue requires. Each asserts the entry is *gone*, not merely
+    flagged — a rejected provider that stays in the registry is a provider people can use."""
+
+    def _assert_rejected(self, result, fragment: str):
+        assert result.providers == [], "an invalid entry must not survive into the registry"
+        assert any(fragment in e for e in result.errors), f"expected an error mentioning {fragment!r}, got {result.errors}"
+
+    def test_duplicate_ids_reject_every_copy(self):
+        """Not just the second one: with two entries claiming an id there is no way to tell
+        which policy was meant, and guessing would silently apply the wrong one."""
+        result = build([valid_entry(id="dup", audience="a"), valid_entry(id="dup", audience="b")])
+
+        self._assert_rejected(result, "duplicate id")
+
+    def test_admin_source_scim_is_rejected(self):
+        """Whoever controls group naming in the directory would otherwise grant themselves
+        admin — the Grafana privilege-escalation shape."""
+        result = build([valid_entry(admin_source="scim")])
+
+        self._assert_rejected(result, "admin_source 'scim' is not allowed")
+
+    def test_admin_source_claims_and_none_are_allowed(self):
+        for source in ("claims", "none"):
+            result = build([valid_entry(admin_source=source)])
+            assert [p.admin_source for p in result.providers] == [source]
+
+    def test_hmac_algorithm_with_a_jwks_source_is_rejected(self):
+        """Algorithm confusion: a public verification key replayed as an HMAC secret lets any
+        caller mint a token the server accepts."""
+        result = build([valid_entry(allowed_algorithms=["RS256", "HS256"], issuer="https://idp.example.com")])
+
+        self._assert_rejected(result, "algorithm-confusion")
+
+    def test_hmac_algorithm_with_a_discovery_url_is_rejected(self):
+        result = build([valid_entry(allowed_algorithms=["HS512"], discovery_url="https://idp.example.com/.well-known/openid-configuration")])
+
+        self._assert_rejected(result, "algorithm-confusion")
+
+    def test_a_missing_audience_is_rejected(self):
+        """A token validated with no audience check is valid for every relying party of that
+        issuer."""
+        entry = valid_entry()
+        del entry["audience"]
+
+        self._assert_rejected(build([entry]), "'audience' is required")
+
+    def test_a_blank_audience_is_rejected(self):
+        self._assert_rejected(build([valid_entry(audience="   ")]), "'audience' is required")
+
+    def test_email_binding_without_allowed_domains_is_rejected(self):
+        """Otherwise anyone who can prove any address at any domain can claim a local user."""
+        result = build([valid_entry(identity_binding="email")])
+
+        self._assert_rejected(result, "allowed_email_domains")
+
+    def test_email_binding_with_allowed_domains_is_accepted(self):
+        result = build([valid_entry(identity_binding="email", allowed_email_domains=["example.com"])])
+
+        assert [p.allowed_email_domains for p in result.providers] == [("example.com",)]
+
+    def test_a_saml_provider_without_the_extra_is_rejected(self):
+        result = build([valid_entry(type="saml")])
+
+        self._assert_rejected(result, "[saml] extra")
+
+    def test_an_unknown_id_is_rejected(self):
+        entry = valid_entry()
+        del entry["id"]
+
+        self._assert_rejected(build([entry]), "'id' is required")
+
+    @pytest.mark.parametrize(
+        "field,value,fragment",
+        [
+            ("type", "ldap", "unknown type"),
+            ("provisioning", "magic", "unknown provisioning"),
+            ("group_sync", "sometimes", "unknown group_sync"),
+            ("group_sync_mode", "merge", "unknown group_sync_mode"),
+            ("admin_source", "whoever", "unknown admin_source"),
+            ("identity_binding", "phone", "unknown identity_binding"),
+        ],
+    )
+    def test_unknown_enum_values_are_rejected(self, field, value, fragment):
+        self._assert_rejected(build([valid_entry(**{field: value})]), fragment)
+
+
+class TestPartialFailureIsolation:
+    def test_a_valid_provider_survives_alongside_an_invalid_one(self):
+        """One bad entry must not take the whole registry down with it."""
+        result = build([valid_entry(id="good"), valid_entry(id="bad", admin_source="scim")])
+
+        assert [p.id for p in result.providers] == ["good"]
+        assert any("admin_source 'scim'" in e for e in result.errors)
+
+    def test_an_entry_is_never_partially_accepted(self):
+        """Several problems at once still yields no provider, not a half-configured one."""
+        entry = {"id": "broken", "type": "ldap", "provisioning": "magic", "identity_binding": "email"}
+
+        result = build([entry])
+
+        assert result.providers == []
+        assert len(result.errors) >= 3
+
+    def test_a_non_object_entry_is_reported_and_skipped(self):
+        result = build(["not-an-object", valid_entry(id="ok")])
+
+        assert [p.id for p in result.providers] == ["ok"]
+        assert any("is not an object" in e for e in result.errors)
+
+
+class TestProviderConfigShape:
+    def test_providers_are_immutable(self):
+        """The registry is read at startup and shared; a consumer mutating a provider in place
+        would change authentication policy for every later request."""
+        provider = build([valid_entry()]).providers[0]
+
+        with pytest.raises(Exception):
+            provider.admin_source = "none"  # type: ignore[misc]
+
+    def test_lookup_by_id(self):
+        result = build([valid_entry(id="a"), valid_entry(id="b")])
+
+        assert result.by_id("b").id == "b"
+        assert result.by_id("missing") is None
+
+    def test_display_name_defaults_to_the_id(self):
+        assert build([valid_entry(id="okta")]).providers[0].display_name == "okta"
+
+    def test_uses_jwks_is_true_only_with_a_key_source(self):
+        assert ProviderConfig(id="x", audience="a", issuer="https://i").uses_jwks() is True
+        assert ProviderConfig(id="x", audience="a").uses_jwks() is False
+
+
+class TestAppConfigIntegration:
+    def test_app_config_exposes_a_registry(self):
+        """The one consumer that exists today: AppConfig builds it at startup."""
+        from mlflow_oidc_auth.config import config
+
+        assert [p.id for p in config.AUTH_PROVIDERS.providers] == [DEFAULT_PROVIDER_ID]
+
+    def test_invalid_entries_are_logged_not_raised(self, caplog):
+        """Raising would take down tooling that never touches login — Alembic's migration
+        environment imports this same singleton."""
+        from mlflow_oidc_auth.config import AppConfig
+
+        with caplog.at_level("WARNING"):
+            app_config = AppConfig()
+            app_config.AUTH_PROVIDERS.errors = ["provider 'x': something is wrong"]
+            app_config._warn_if_provider_registry_invalid()
+
+        assert any("something is wrong" in r.message for r in caplog.records)

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -177,15 +177,16 @@ class TestValidationRejections:
 
     def test_hmac_algorithm_with_a_jwks_source_is_rejected(self):
         """Algorithm confusion: a public verification key replayed as an HMAC secret lets any
-        caller mint a token the server accepts."""
+        caller mint a token the server accepts. See TestAlgorithmValidation for the stronger
+        rule this became."""
         result = build([valid_entry(allowed_algorithms=["RS256", "HS256"], issuer="https://idp.example.com")])
 
-        self._assert_rejected(result, "algorithm-confusion")
+        self._assert_rejected(result, "symmetric algorithm")
 
     def test_hmac_algorithm_with_a_discovery_url_is_rejected(self):
         result = build([valid_entry(allowed_algorithms=["HS512"], discovery_url="https://idp.example.com/.well-known/openid-configuration")])
 
-        self._assert_rejected(result, "algorithm-confusion")
+        self._assert_rejected(result, "symmetric algorithm")
 
     def test_a_missing_audience_is_rejected(self):
         """A token validated with no audience check is valid for every relying party of that
@@ -235,6 +236,101 @@ class TestValidationRejections:
         self._assert_rejected(build([valid_entry(**{field: value})]), fragment)
 
 
+class TestAlgorithmValidation:
+    """``allowed_algorithms`` decides what a signature check will accept, so an unvalidated
+    value here is the most dangerous field in the entry. Raised in review of #344."""
+
+    def _assert_rejected(self, result, fragment: str):
+        assert result.providers == []
+        assert any(fragment in e for e in result.errors), f"expected an error mentioning {fragment!r}, got {result.errors}"
+
+    @pytest.mark.parametrize("spelling", ["none", "None", "NONE"])
+    def test_alg_none_is_rejected_in_any_spelling(self, spelling):
+        """``alg: none`` means the token carries no signature at all, so anyone can mint one.
+
+        Worse than the algorithm-confusion case the original check covered, and it passed.
+        """
+        result = build([valid_entry(issuer="https://idp.example.com", allowed_algorithms=[spelling])])
+
+        self._assert_rejected(result, "algorithm 'none' is never allowed")
+
+    def test_alg_none_alongside_a_valid_algorithm_is_still_rejected(self):
+        """The whole entry goes, not just the offending value — a provider that accepts RS256
+        *or* nothing accepts nothing."""
+        result = build([valid_entry(allowed_algorithms=["RS256", "none"])])
+
+        self._assert_rejected(result, "algorithm 'none' is never allowed")
+
+    @pytest.mark.parametrize("algorithm", ["HS256", "HS384", "HS512", "hs256"])
+    def test_hmac_algorithms_are_rejected_even_with_no_key_source_on_the_entry(self, algorithm):
+        """Stricter than #308 asked, deliberately.
+
+        Gating on whether the entry named ``issuer``/``discovery_url`` was evadable: omit both
+        and the deployment's flat ``OIDC_DISCOVERY_URL`` still supplies a key set, restoring
+        the confusion setup. This plugin has no symmetric-key verification path, so an HMAC
+        entry cannot work regardless — the only question was whether it failed safely.
+        """
+        entry = valid_entry(allowed_algorithms=[algorithm])
+        entry.pop("issuer", None)
+        entry.pop("discovery_url", None)
+
+        self._assert_rejected(build([entry]), "symmetric algorithm")
+
+    def test_unknown_algorithms_are_rejected(self):
+        """A typo must become a startup message, not an algorithm a consumer quietly ignores."""
+        self._assert_rejected(build([valid_entry(allowed_algorithms=["RS256-ish"])]), "unknown algorithm")
+
+    @pytest.mark.parametrize("written,canonical", [("rs256", "RS256"), ("eddsa", "EdDSA"), ("Es384", "ES384")])
+    def test_algorithms_are_stored_canonically(self, written, canonical):
+        """A consumer comparing against ``"RS256"`` must match an entry written ``"rs256"``,
+        rather than falling through to its own default."""
+        result = build([valid_entry(allowed_algorithms=[written])])
+
+        assert result.providers[0].allowed_algorithms == (canonical,)
+
+    def test_supported_asymmetric_algorithms_are_accepted(self):
+        result = build([valid_entry(allowed_algorithms=["RS256", "PS512", "ES256", "EdDSA"])])
+
+        assert result.providers[0].allowed_algorithms == ("RS256", "PS512", "ES256", "EdDSA")
+
+    def test_an_absent_list_defaults_to_rs256(self):
+        entry = valid_entry()
+        entry.pop("allowed_algorithms", None)
+
+        assert build([entry]).providers[0].allowed_algorithms == DEFAULT_ALGORITHMS
+
+
+class TestAlreadyParsedConfigValues:
+    """``config_providers`` are typed ``-> Any`` and the AWS Secrets Manager provider
+    ``json.loads`` its whole secret, so a registry stored as nested JSON arrives already
+    parsed. Treating that as "not a string, therefore unset" silently discarded it."""
+
+    def test_an_already_parsed_list_is_accepted(self):
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS=[valid_entry(id="from-secret")]), legacy_app_config())
+
+        assert [p.id for p in result.providers] == ["from-secret"]
+        assert result.errors == []
+
+    def test_an_already_parsed_dict_wrapper_is_accepted(self):
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS={"providers": [valid_entry(id="wrapped")]}), legacy_app_config())
+
+        assert [p.id for p in result.providers] == ["wrapped"]
+
+    def test_a_value_of_an_unusable_type_is_reported_rather_than_ignored(self):
+        """The silent-fallback failure this class exists to prevent: configured, ignored, and
+        no diagnostic anywhere."""
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS=42), legacy_app_config())
+
+        assert [p.id for p in result.providers] == [DEFAULT_PROVIDER_ID]
+        assert any("expected a JSON array" in e for e in result.errors)
+
+    def test_an_explicitly_empty_list_is_honoured(self):
+        """Writing ``[]`` says "no providers"; it is not the same as leaving it unset."""
+        result = build_provider_registry(FakeConfigManager(AUTH_PROVIDERS=[]), legacy_app_config())
+
+        assert result.providers == []
+
+
 class TestPartialFailureIsolation:
     def test_a_valid_provider_survives_alongside_an_invalid_one(self):
         """One bad entry must not take the whole registry down with it."""
@@ -277,9 +373,9 @@ class TestProviderConfigShape:
     def test_display_name_defaults_to_the_id(self):
         assert build([valid_entry(id="okta")]).providers[0].display_name == "okta"
 
-    def test_uses_jwks_is_true_only_with_a_key_source(self):
-        assert ProviderConfig(id="x", audience="a", issuer="https://i").uses_jwks() is True
-        assert ProviderConfig(id="x", audience="a").uses_jwks() is False
+    def test_has_own_key_source_reports_only_what_the_entry_says(self):
+        assert ProviderConfig(id="x", audience="a", issuer="https://i").has_own_key_source() is True
+        assert ProviderConfig(id="x", audience="a").has_own_key_source() is False
 
 
 class TestAppConfigIntegration:

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -9,6 +9,7 @@ one of these checks by accident is a provider someone can authenticate through u
 the operator did not write.
 """
 
+import importlib
 import json
 from types import SimpleNamespace
 
@@ -20,6 +21,12 @@ from mlflow_oidc_auth.provider_registry import (
     ProviderConfig,
     build_provider_registry,
 )
+
+# Force the AppConfig singleton into existence now, from the real environment. ``config.py``
+# builds it at module import, so a test that imports it *while* holding a patched
+# AUTH_PROVIDERS would bake that patched value in for every test that runs afterwards — the
+# kind of order-dependent pollution these tests exist to catch elsewhere.
+importlib.import_module("mlflow_oidc_auth.config")
 
 
 class FakeConfigManager:
@@ -380,6 +387,81 @@ class TestInteractiveFlag:
     def test_the_legacy_provider_is_interactive(self):
         """Today's single provider is a browser login provider, and must stay on the page."""
         assert build().providers[0].interactive is True
+
+
+class TestFieldTypesAreValidated:
+    """JSON can put a list or object in any field, and this module must report that rather than
+    raise.
+
+    ``AppConfig`` is instantiated at import time, so an exception here does not degrade login —
+    it stops the plugin and Alembic from importing at all. That is the opposite of what dropping
+    invalid entries is for, and it is what a bare ``dict.get`` on an unvalidated value did.
+    Raised in review of #344.
+    """
+
+    @pytest.mark.parametrize("field", ["type", "display_name", "provisioning", "admin_source", "identity_binding", "audience", "issuer", "client_id"])
+    @pytest.mark.parametrize("bad_value", [["a"], {"a": 1}, 5])
+    def test_a_non_string_scalar_field_is_rejected_without_raising(self, field, bad_value):
+        result = build([valid_entry(**{field: bad_value})])
+
+        assert result.providers == []
+        assert any(f"'{field}' must be a string" in e for e in result.errors), result.errors
+
+    @pytest.mark.parametrize("field", ["allowed_algorithms", "allowed_email_domains"])
+    def test_a_list_field_of_the_wrong_type_is_rejected(self, field):
+        result = build([valid_entry(**{field: 5})])
+
+        assert result.providers == []
+        assert any("must be a string or a list of strings" in e for e in result.errors)
+
+    def test_the_error_names_the_field_not_our_data_structure(self):
+        """``'type' must be a string, got list`` points at the operator's mistake;
+        ``unhashable type: 'list'`` points at our dictionary."""
+        result = build([valid_entry(type=["oidc"])])
+
+        assert any("'type' must be a string, got list" in e for e in result.errors)
+
+    def test_importing_config_survives_a_malformed_entry(self, monkeypatch):
+        """The blast radius that made this more than a validation gap.
+
+        ``config = AppConfig()`` is module-level, so a raise here takes down every importer,
+        including Alembic's migration environment — which never reads a provider.
+        """
+        monkeypatch.setenv("AUTH_PROVIDERS", json.dumps([valid_entry(type=["oidc"])]))
+        from mlflow_oidc_auth.config import AppConfig
+
+        app_config = AppConfig()
+
+        assert app_config.AUTH_PROVIDERS.providers == []
+        assert any("must be a string" in e for e in app_config.AUTH_PROVIDERS.errors)
+
+
+class TestAlgorithmsPresentButUnusable:
+    """Silently discarding a configured value leaves nothing to debug from — the same failure
+    that was fixed one level up for ``AUTH_PROVIDERS`` itself."""
+
+    def test_an_empty_algorithm_list_is_reported(self):
+        result = build([valid_entry(allowed_algorithms=[])])
+
+        assert result.providers == []
+        assert any("lists no algorithm" in e for e in result.errors)
+
+    def test_a_list_with_a_non_string_member_is_reported(self):
+        result = build([valid_entry(allowed_algorithms=["RS256", 5])])
+
+        assert result.providers == []
+        assert any("must contain only strings" in e for e in result.errors)
+
+    def test_an_absent_list_is_still_a_silent_default(self):
+        """Absent is not the same as unusable: omitting the field is the documented way to
+        accept RS256, and must stay quiet."""
+        entry = valid_entry()
+        entry.pop("allowed_algorithms", None)
+
+        result = build([entry])
+
+        assert result.providers[0].allowed_algorithms == DEFAULT_ALGORITHMS
+        assert result.errors == []
 
 
 class TestPartialFailureIsolation:

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -331,6 +331,57 @@ class TestAlreadyParsedConfigValues:
         assert result.providers == []
 
 
+class TestInteractiveFlag:
+    """Whether a provider belongs on the login page is a separate axis from how its credentials
+    are verified.
+
+    A Kubernetes service-account provider verifies tokens exactly as an OIDC one does — JWT
+    against the cluster's JWKS — but a projected token is presented directly as a bearer
+    credential, so there is no flow a browser can start. Without this flag #317 would render a
+    login button for it that cannot complete.
+    """
+
+    def test_oidc_providers_are_interactive_by_default(self):
+        assert build([valid_entry()]).providers[0].interactive is True
+
+    def test_k8s_providers_are_not_interactive_by_default(self):
+        result = build([valid_entry(type="k8s")])
+
+        assert result.providers[0].interactive is False
+        assert result.errors == []
+
+    def test_a_k8s_provider_cannot_be_marked_interactive(self):
+        """Rejected rather than silently corrected: an operator who asked for a login button
+        expects one, and a silently-dropped flag is a worse surprise than a startup message."""
+        result = build([valid_entry(type="k8s", interactive=True)])
+
+        assert result.providers == []
+        assert any("no browser login flow" in e for e in result.errors)
+
+    def test_an_oidc_provider_may_opt_out_of_the_login_page(self):
+        """A machine-to-machine OIDC issuer is a real configuration: tokens are accepted, but
+        nobody should be offered a button for it."""
+        result = build([valid_entry(interactive=False)])
+
+        assert result.providers[0].interactive is False
+
+    def test_a_non_boolean_interactive_is_rejected(self):
+        result = build([valid_entry(interactive="yes")])
+
+        assert result.providers == []
+        assert any("'interactive' must be true or false" in e for e in result.errors)
+
+    def test_the_login_page_sees_only_interactive_providers(self):
+        result = build([valid_entry(id="okta"), valid_entry(id="cluster", type="k8s")])
+
+        assert [p.id for p in result.providers] == ["okta", "cluster"]
+        assert [p.id for p in result.interactive_providers()] == ["okta"]
+
+    def test_the_legacy_provider_is_interactive(self):
+        """Today's single provider is a browser login provider, and must stay on the page."""
+        assert build().providers[0].interactive is True
+
+
 class TestPartialFailureIsolation:
     def test_a_valid_provider_survives_alongside_an_invalid_one(self):
         """One bad entry must not take the whole registry down with it."""


### PR DESCRIPTION
Closes #308.

Flat `OIDC_*` singletons cannot express more than one identity provider, and every later task in
the enterprise-identity epic (#304) needs a registry shape to build against.

**Config layer only — no consumer changes.** Login, callback and token validation are untouched;
the flat variables remain authoritative until something consumes this.

## What it looks like

```json
[
  {
    "id": "okta",
    "type": "oidc",
    "audience": "mlflow",
    "issuer": "https://okta.example.com",
    "provisioning": "jit",
    "group_sync": "every_login",
    "group_sync_mode": "authoritative",
    "admin_source": "claims",
    "identity_binding": "subject",
    "allowed_algorithms": ["RS256"]
  }
]
```

From `AUTH_PROVIDERS` (inline JSON) or `AUTH_PROVIDERS_FILE`, both resolved through the existing
`config_providers` chain so secrets managers keep working. `{"providers": [...]}` is accepted too,
since that is what most people write first.

## Back-compat

With neither set, a single `default` provider is synthesised from the flat variables using
`jit` / `every_login` / `authoritative` — today's behaviour, stated explicitly rather than
implied. **Existing config tests pass unmodified**, as the issue required.

One deliberate asymmetry, and it is the most important decision here: **`audience` is required of
an explicitly configured entry but not of the synthesised one.** `OIDC_AUDIENCE` is optional
today and most installations leave it unset, so holding the shim to the stricter rule would hand
them an empty registry — precisely the break the shim exists to prevent. New configuration is
held to the higher standard; existing configuration is described faithfully, including where it
is weak. Tightening it is a behaviour change and belongs with whatever first consumes the
registry.

I caught this because the first version returned an empty registry on a default install.

## Rejections, and why each one

Invalid entries are **dropped, not repaired** — an entry that survives a check by accident is a
provider someone can authenticate through under a policy nobody wrote.

| Rejected | Why |
|---|---|
| `admin_source: scim` | Whoever controls group naming in the external directory could grant themselves admin. Grafana shipped exactly that. |
| HMAC algorithm + JWKS source | Algorithm confusion: a public verification key replayed as an HMAC secret lets any caller mint an accepted token. |
| Missing `audience` | A token validated with no audience check is valid for every relying party of that issuer. |
| `identity_binding: email` without `allowed_email_domains` | Anyone who can prove any address at any domain could claim a local user. |
| Duplicate `id` | **Every copy**, not just the later one — with two entries claiming an id there is no way to tell which policy was meant, and guessing applies the wrong one. |
| `type: saml` without an implementation | Cannot authenticate against a provider whose protocol is not implemented. |

Dropping rather than raising follows the `_warn_if_*` precedent in `config.py`, for the reason
that file already documents: `AppConfig` is a module-level singleton imported by tooling with
nothing to do with login — Alembic's migration environment, for one — so raising would take that
tooling down over a provider it never reads. It is also the deny-by-default answer: an entry that
cannot be validated does not exist.

A malformed payload or unreadable file falls back to the legacy provider rather than emptying the
registry, so an operator typo cannot lock a working deployment out.

## Tests

`mlflow_oidc_auth/tests/test_provider_registry.py` — 36 tests, one per rule the issue lists, plus
the back-compat and parsing paths. Each rejection test asserts the entry is **gone from the
registry**, not merely flagged.

Also covered: a valid provider survives alongside an invalid one; an entry is never *partially*
accepted (several problems still yield no provider rather than a half-configured one); providers
are immutable, since the registry is shared and a consumer mutating one in place would change
policy for every later request.

## A note on the `[saml]` extra

There is no `[saml]` extra yet — choosing the library is #327's job. Rather than presume that
outcome I check a list of realistic candidate modules, documented so whoever closes #327 has an
obvious place to pin it down. Until then every `type: saml` entry is rejected, which is correct
rather than a gap.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 2962 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/test_config.py test_config_providers.py  # 48 passed, unmodified
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 budget intact
python -m pyflakes <new files>                    # clean
```

## Merge-order note

Three open PRs also touch `config.py` — #300, #301 and #88. My footprint there is deliberately
small (one import, one assignment, one `_warn_if_*` method) with all the logic in a new module,
so conflicts should be textual at worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
