### PR TITLE
feat(auth): identity resolution service for multi-provider login (#309)

### DIFF
--- a/mlflow_oidc_auth/identity_resolution.py
+++ b/mlflow_oidc_auth/identity_resolution.py
@@ -88,6 +88,15 @@ def _email_from_claims(claims: Dict[str, Any]) -> Optional[str]:
     return email or None
 
 
+def _email_is_verified(claims: Dict[str, Any]) -> bool:
+    """Whether the provider states it has verified the address, strictly.
+
+    Only a literal ``True`` counts. Absent, null, ``"true"`` and every other truthy stand-in are
+    treated as unverified, because this decides whether an address may name an account.
+    """
+    return claims.get("email_verified") is True
+
+
 def _domain_of(email: str) -> Optional[str]:
     """Return the domain part of ``email``, or None when it is not a single usable address.
 
@@ -113,6 +122,7 @@ def resolve_identity(
     claims: Dict[str, Any],
     identity_repo,
     user_lookup,
+    username: Optional[str] = None,
 ) -> IdentityDecision:
     """Decide which local user, if any, an external identity reaches.
 
@@ -124,6 +134,10 @@ def resolve_identity(
         user_lookup: Callable ``(username) -> bool`` answering whether a local user exists.
             Injected rather than taken from the store singleton so this stays a pure decision
             that tests can drive without a database.
+        username: The username the caller derived from the claims using the deployment's
+            configured field list. Optional, but supplying it is what lets email binding notice
+            that this deployment does not name accounts by email — in which case it refuses
+            rather than silently creating a duplicate.
 
     Returns:
         IdentityDecision: What the caller should do. Check ``resolution`` — never read
@@ -140,7 +154,7 @@ def resolve_identity(
         return IdentityDecision(Resolution.MATCHED, username=existing, reason="identity already bound")
 
     if provider.identity_binding == "email":
-        return _resolve_by_email(provider, subject, claims, identity_repo, user_lookup)
+        return _resolve_by_email(provider, subject, claims, identity_repo, user_lookup, username)
 
     # subject binding: an unknown (provider, subject) is a new principal, full stop. It is never
     # matched to an existing user by anything the token says about them.
@@ -153,11 +167,18 @@ def _resolve_by_email(
     claims: Dict[str, Any],
     identity_repo,
     user_lookup,
+    username: Optional[str],
 ) -> IdentityDecision:
     """Link by email, but only within the domains this provider is trusted for."""
     email = _email_from_claims(claims)
     if not email:
         return _refuse(provider, subject, "identity_binding is 'email' but the claims carry no usable email")
+
+    if not _email_is_verified(claims):
+        # An unverified address proves nothing. Refused rather than falling through to CREATE:
+        # creating an account named for an unverified address is pre-registration takeover —
+        # claim the name first, and the real owner logs into the attacker's account later.
+        return _refuse(provider, subject, "the provider did not assert email_verified for this address")
 
     domain = _domain_of(email)
     if not domain:
@@ -170,7 +191,20 @@ def _resolve_by_email(
         # account for a domain the operator never authorised this provider to speak for.
         return _refuse(provider, subject, f"provider is not authorised for email domain {domain!r}")
 
-    username = normalize_username(email)
+    # The account is named by the email, and only by the email. Authorising a domain says the
+    # provider may speak for addresses there; it does not license naming some *other* account.
+    # Without this, a caller deriving usernames from another claim could present a verified
+    # address of its own alongside somebody else's username and reach their account.
+    email_username = normalize_username(email)
+    if username is not None and normalize_username(username) != email_username:
+        return _refuse(
+            provider,
+            subject,
+            f"identity_binding 'email' names accounts by their email address, but this deployment derived the username "
+            f"{username!r} from other claims; configure identity_binding 'subject' for this provider instead",
+        )
+
+    username = email_username
     if not user_lookup(username):
         return IdentityDecision(Resolution.CREATE, reason="no local user for this authorised email")
 

--- a/mlflow_oidc_auth/identity_resolution.py
+++ b/mlflow_oidc_auth/identity_resolution.py
@@ -1,0 +1,207 @@
+"""Resolve an external identity to a local user (issue #309).
+
+``users.username`` is the only identity key today, so with more than one provider configured two
+IdPs asserting the same email would silently share an account. This module decides, for a given
+``(provider_id, subject, claims)``, whether an existing user is reached, a new one should be
+created, or the attempt is refused.
+
+**Nothing calls this yet.** Wiring it into login and bearer authentication is #316; this lands
+the decision and its tests.
+
+The rule that matters:
+
+``identity_binding: subject``
+    Only ``(provider_id, sub)`` reaches a user. A claim asserting somebody else's email cannot
+    link to their account, because email is never consulted.
+
+``identity_binding: email``
+    May link to an existing user by email, but only when the email's domain is in the provider's
+    ``allowed_email_domains``. A provider is trusted to speak for the domains an operator listed
+    and no others — otherwise any IdP able to assert ``admin@yourcompany.com`` would take over
+    that account.
+
+Both modes refuse to move an identity that is already bound to a different user. Once
+``(provider_id, subject)`` names a user, only that user answers to it.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from mlflow_oidc_auth.audit import emit_audit_event
+from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.provider_registry import ProviderConfig
+from mlflow_oidc_auth.repository.user import normalize_username
+
+logger = get_logger()
+
+
+class Resolution(Enum):
+    """What the caller should do with the identity it presented."""
+
+    MATCHED = "matched"
+    """An existing user answers to this identity."""
+
+    LINK = "link"
+    """An existing user was reached by policy; bind the identity to them before use."""
+
+    CREATE = "create"
+    """No user matched. Create one, subject to the provider's provisioning policy."""
+
+    REFUSED = "refused"
+    """Policy forbids reaching any user this way. Never fall through to create."""
+
+
+@dataclass(frozen=True)
+class IdentityDecision:
+    """The outcome of resolving one identity.
+
+    Attributes:
+        resolution: What to do next.
+        username: The user reached, for ``MATCHED`` and ``LINK``. None otherwise — in
+            particular it is None for ``REFUSED``, so a caller that ignores ``resolution`` and
+            reads ``username`` gets nothing rather than the account it was refused.
+        reason: Why, for logs and audit. Always set for ``REFUSED``.
+    """
+
+    resolution: Resolution
+    username: Optional[str] = None
+    reason: str = ""
+
+    @property
+    def is_allowed(self) -> bool:
+        """Whether the caller may proceed to authenticate this principal."""
+        return self.resolution is not Resolution.REFUSED
+
+
+def _email_from_claims(claims: Dict[str, Any]) -> Optional[str]:
+    """Pull a usable email out of the claims, normalised.
+
+    Only the ``email`` claim is consulted. Accepting alternatives such as ``upn`` or
+    ``preferred_username`` here would widen what a provider can assert about a person's identity
+    beyond the one claim operators expect to be checked against ``allowed_email_domains``.
+    """
+    email = claims.get("email")
+    if not isinstance(email, str):
+        return None
+    email = email.strip().lower()
+    return email or None
+
+
+def _domain_of(email: str) -> Optional[str]:
+    """Return the domain part of ``email``, or None when it is not a single usable address.
+
+    Rejecting anything but exactly one ``@`` is deliberate: ``a@b@evil.com`` splits differently
+    depending on which end you parse from, and a mismatch between this check and whatever reads
+    the address later is how a domain allowlist gets bypassed.
+
+    Both halves must be non-empty. ``@example.com`` has an authorised-looking domain and no
+    local part, so accepting it would let a provider claim an account named for the bare
+    domain — the check has to be about the whole address, not just the half being compared.
+    """
+    if email.count("@") != 1:
+        return None
+    local, domain = email.split("@", 1)
+    if not local.strip() or not domain.strip():
+        return None
+    return domain.strip()
+
+
+def resolve_identity(
+    provider: ProviderConfig,
+    subject: str,
+    claims: Dict[str, Any],
+    identity_repo,
+    user_lookup,
+) -> IdentityDecision:
+    """Decide which local user, if any, an external identity reaches.
+
+    Parameters:
+        provider: The asserting provider's registry entry, which carries the binding policy.
+        subject: The provider's stable identifier for the principal (``sub``).
+        claims: The validated token or userinfo claims.
+        identity_repo: A :class:`~mlflow_oidc_auth.repository.user_identity.UserIdentityRepository`.
+        user_lookup: Callable ``(username) -> bool`` answering whether a local user exists.
+            Injected rather than taken from the store singleton so this stays a pure decision
+            that tests can drive without a database.
+
+    Returns:
+        IdentityDecision: What the caller should do. Check ``resolution`` — never read
+        ``username`` alone.
+    """
+    if not isinstance(subject, str) or not subject.strip():
+        return _refuse(provider, subject, "the provider asserted no subject")
+    subject = subject.strip()
+
+    # An identity that already exists wins outright, before any claim is consulted. This is what
+    # makes a second provider unable to talk its way into an account that is already bound.
+    existing = identity_repo.get_username_by_identity(provider.id, subject)
+    if existing:
+        return IdentityDecision(Resolution.MATCHED, username=existing, reason="identity already bound")
+
+    if provider.identity_binding == "email":
+        return _resolve_by_email(provider, subject, claims, identity_repo, user_lookup)
+
+    # subject binding: an unknown (provider, subject) is a new principal, full stop. It is never
+    # matched to an existing user by anything the token says about them.
+    return IdentityDecision(Resolution.CREATE, reason="no identity bound for this provider and subject")
+
+
+def _resolve_by_email(
+    provider: ProviderConfig,
+    subject: str,
+    claims: Dict[str, Any],
+    identity_repo,
+    user_lookup,
+) -> IdentityDecision:
+    """Link by email, but only within the domains this provider is trusted for."""
+    email = _email_from_claims(claims)
+    if not email:
+        return _refuse(provider, subject, "identity_binding is 'email' but the claims carry no usable email")
+
+    domain = _domain_of(email)
+    if not domain:
+        return _refuse(provider, subject, f"email {email!r} is not a single address")
+
+    # Compared case-insensitively; the configured list is already stripped by the registry.
+    allowed = {allowed_domain.lower() for allowed_domain in provider.allowed_email_domains}
+    if domain not in allowed:
+        # Not merely "no match" — refused. Falling through to create would hand the caller an
+        # account for a domain the operator never authorised this provider to speak for.
+        return _refuse(provider, subject, f"provider is not authorised for email domain {domain!r}")
+
+    username = normalize_username(email)
+    if not user_lookup(username):
+        return IdentityDecision(Resolution.CREATE, reason="no local user for this authorised email")
+
+    # The user exists and the provider may speak for the domain — but if some *other* provider
+    # already owns this account, linking would let this one inherit it. Refuse instead.
+    bound_providers = identity_repo.list_providers_for_username(username)
+    foreign = [bound for bound in bound_providers if bound != provider.id]
+    if foreign:
+        return _refuse(
+            provider,
+            subject,
+            f"user is already bound to provider(s) {', '.join(sorted(foreign))}; refusing to link a second provider by email",
+        )
+
+    return IdentityDecision(Resolution.LINK, username=username, reason="authorised email domain, no competing provider")
+
+
+def _refuse(provider: ProviderConfig, subject: Any, reason: str) -> IdentityDecision:
+    """Build a refusal, and record it.
+
+    Refusals are audited rather than only logged: each one is a provider failing to reach an
+    account it asked for, which is exactly the signal an operator investigating a suspected
+    takeover attempt needs. ``subject`` is included; claim contents are not.
+    """
+    logger.warning("Identity refused for provider %s: %s", provider.id, reason)
+    emit_audit_event(
+        "identity.refused",
+        actor=str(subject),
+        resource_type="identity_provider",
+        resource_id=provider.id,
+        detail={"reason": reason},
+        status="denied",
+    )
+    return IdentityDecision(Resolution.REFUSED, username=None, reason=reason)

--- a/mlflow_oidc_auth/repository/__init__.py
+++ b/mlflow_oidc_auth/repository/__init__.py
@@ -21,6 +21,7 @@ from mlflow_oidc_auth.repository.registered_model_permission_group import (
     RegisteredModelPermissionGroupRepository,
 )
 from mlflow_oidc_auth.repository.user import UserRepository
+from mlflow_oidc_auth.repository.user_identity import UserIdentityRepository
 from mlflow_oidc_auth.repository.experiment_permission_regex import (
     ExperimentPermissionRegexRepository,
 )
@@ -109,6 +110,7 @@ __all__ = [
     "RegisteredModelPermissionRepository",
     "RegisteredModelPermissionGroupRepository",
     "UserRepository",
+    "UserIdentityRepository",
     "ExperimentPermissionRegexRepository",
     "ExperimentPermissionGroupRegexRepository",
     "RegisteredModelPermissionRegexRepository",

--- a/mlflow_oidc_auth/repository/user_identity.py
+++ b/mlflow_oidc_auth/repository/user_identity.py
@@ -1,0 +1,102 @@
+"""Persistence for external identities bound to local users (issue #309).
+
+The table and its constraints landed with the Phase 0 migration (#333); this is the data access
+over it. Resolution policy lives in :mod:`mlflow_oidc_auth.identity_resolution` — this layer only
+reads and writes rows.
+"""
+
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
+from sqlalchemy.orm import Session
+
+from mlflow_oidc_auth.db.models import SqlUser, SqlUserIdentity
+from mlflow_oidc_auth.repository.user import normalize_username
+
+
+class UserIdentityRepository:
+    """Reads and writes ``user_identities`` rows."""
+
+    def __init__(self, session_maker):
+        self._Session: Callable[[], Session] = session_maker
+
+    def get_username_by_identity(self, provider_id: str, subject: str) -> Optional[str]:
+        """Return the username bound to ``(provider_id, subject)``, or None.
+
+        The pair is unique, so this is the exact-match path: an identity that already exists
+        resolves to its user without consulting any claim, which is what makes ``subject``
+        binding immune to anything the token asserts about email.
+
+        Parameters:
+            provider_id: Registry id of the asserting provider.
+            subject: The provider's stable identifier for the principal.
+
+        Returns:
+            The bound username, or None when the pair is unknown.
+        """
+        with self._Session() as session:
+            row = (
+                session.query(SqlUser.username)
+                .join(SqlUserIdentity, SqlUserIdentity.user_id == SqlUser.id)
+                .filter(SqlUserIdentity.provider_id == provider_id, SqlUserIdentity.subject == subject)
+                .one_or_none()
+            )
+            return row[0] if row else None
+
+    def list_providers_for_username(self, username: str) -> List[str]:
+        """Return the provider ids that have an identity bound to ``username``.
+
+        Used to reason about a user who has arrived through more than one provider.
+        """
+        username = normalize_username(username)
+        with self._Session() as session:
+            rows = session.query(SqlUserIdentity.provider_id).join(SqlUser, SqlUserIdentity.user_id == SqlUser.id).filter(SqlUser.username == username).all()
+            return [row[0] for row in rows]
+
+    def link(self, provider_id: str, subject: str, username: str) -> bool:
+        """Bind ``(provider_id, subject)`` to an existing user.
+
+        Idempotent: re-linking an identity that already points at this user is a no-op rather
+        than an error, so a repeated login does not fail on the unique constraint.
+
+        Returns:
+            True when a new row was written, False when the binding already existed.
+
+        Raises:
+            MlflowException: If the user does not exist, or if the pair is already bound to a
+                *different* user. The latter is an attempted takeover and must never be
+                silently re-pointed.
+
+                MlflowException rather than a bare ValueError because the managed session
+                wraps every other exception into one anyway — raising it directly keeps the
+                error code meaningful instead of collapsing to INTERNAL_ERROR.
+        """
+        username = normalize_username(username)
+        with self._Session(read_only=False) as session:
+            user = session.query(SqlUser).filter(SqlUser.username == username).one_or_none()
+            if user is None:
+                raise MlflowException(f"cannot bind an identity to unknown user '{username}'", RESOURCE_DOES_NOT_EXIST)
+
+            existing = session.query(SqlUserIdentity).filter(SqlUserIdentity.provider_id == provider_id, SqlUserIdentity.subject == subject).one_or_none()
+            if existing is not None:
+                if existing.user_id != user.id:
+                    raise MlflowException(f"identity ({provider_id}, {subject}) is already bound to a different user", RESOURCE_ALREADY_EXISTS)
+                return False
+
+            session.add(SqlUserIdentity(provider_id=provider_id, subject=subject, user_id=user.id))
+            session.flush()
+            return True
+
+    def touch_last_login(self, provider_id: str, subject: str) -> None:
+        """Record that this identity was just used.
+
+        Best-effort by design: an identity that has gone missing between resolution and this
+        call is not worth failing a login over.
+        """
+        with self._Session(read_only=False) as session:
+            identity = session.query(SqlUserIdentity).filter(SqlUserIdentity.provider_id == provider_id, SqlUserIdentity.subject == subject).one_or_none()
+            if identity is not None:
+                identity.last_login_at = datetime.now(timezone.utc).replace(tzinfo=None)
+                session.flush()

--- a/mlflow_oidc_auth/repository/user_identity.py
+++ b/mlflow_oidc_auth/repository/user_identity.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Callable, List, Optional
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import INVALID_STATE, RESOURCE_ALREADY_EXISTS, RESOURCE_DOES_NOT_EXIST
 from sqlalchemy.orm import Session
 
 from mlflow_oidc_auth.db.models import SqlUser, SqlUserIdentity
@@ -55,19 +55,31 @@ class UserIdentityRepository:
             rows = session.query(SqlUserIdentity.provider_id).join(SqlUser, SqlUserIdentity.user_id == SqlUser.id).filter(SqlUser.username == username).all()
             return [row[0] for row in rows]
 
-    def link(self, provider_id: str, subject: str, username: str) -> bool:
+    def link(self, provider_id: str, subject: str, username: str, *, allow_additional_provider: bool = False) -> bool:
         """Bind ``(provider_id, subject)`` to an existing user.
 
         Idempotent: re-linking an identity that already points at this user is a no-op rather
         than an error, so a repeated login does not fail on the unique constraint.
 
+        **Refuses by default to add a second provider to a user another provider already owns.**
+        That rule is also applied when resolving (:mod:`mlflow_oidc_auth.identity_resolution`),
+        but checking it only there left it advisory: this repository is public on the store, so
+        any caller reaching it directly bypassed the check, and even a correct caller had a
+        window between resolving and writing in which a concurrent login could bind a different
+        provider. Enforcing it at the write closes both.
+
+        ``allow_additional_provider`` exists for the deliberate account-linking case — a person
+        who genuinely holds identities at two IdPs — so that becomes an explicit decision at the
+        call site rather than something that happens by omission.
+
         Returns:
             True when a new row was written, False when the binding already existed.
 
         Raises:
-            MlflowException: If the user does not exist, or if the pair is already bound to a
-                *different* user. The latter is an attempted takeover and must never be
-                silently re-pointed.
+            MlflowException: If the user does not exist, if the pair is already bound to a
+                *different* user, or if another provider already owns this user and
+                ``allow_additional_provider`` was not set. The middle case is an attempted
+                takeover and must never be silently re-pointed.
 
                 MlflowException rather than a bare ValueError because the managed session
                 wraps every other exception into one anyway — raising it directly keeps the
@@ -84,6 +96,17 @@ class UserIdentityRepository:
                 if existing.user_id != user.id:
                     raise MlflowException(f"identity ({provider_id}, {subject}) is already bound to a different user", RESOURCE_ALREADY_EXISTS)
                 return False
+
+            if not allow_additional_provider:
+                foreign = (
+                    session.query(SqlUserIdentity.provider_id).filter(SqlUserIdentity.user_id == user.id, SqlUserIdentity.provider_id != provider_id).first()
+                )
+                if foreign is not None:
+                    raise MlflowException(
+                        f"user '{username}' is already bound to provider '{foreign[0]}'; refusing to bind provider "
+                        f"'{provider_id}' as well. Pass allow_additional_provider=True to link deliberately.",
+                        INVALID_STATE,
+                    )
 
             session.add(SqlUserIdentity(provider_id=provider_id, subject=subject, user_id=user.id))
             session.flush()

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -62,6 +62,7 @@ from mlflow_oidc_auth.repository import (
     GatewayModelDefinitionGroupPermissionRepository,
     GatewayModelDefinitionPermissionGroupRegexRepository,
     UserRepository,
+    UserIdentityRepository,
     WorkspacePermissionRepository,
     WorkspaceGroupPermissionRepository,
 )
@@ -82,6 +83,7 @@ class SqlAlchemyStore:
         SessionMaker = sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = _get_managed_session_maker(SessionMaker, self.db_type)
         self.user_repo = UserRepository(self.ManagedSessionMaker)
+        self.user_identity_repo = UserIdentityRepository(self.ManagedSessionMaker)
         self.experiment_repo = ExperimentPermissionRepository(self.ManagedSessionMaker)
         self.experiment_group_repo = ExperimentPermissionGroupRepository(self.ManagedSessionMaker)
         self.group_repo = GroupRepository(self.ManagedSessionMaker)

--- a/mlflow_oidc_auth/tests/test_identity_resolution.py
+++ b/mlflow_oidc_auth/tests/test_identity_resolution.py
@@ -18,6 +18,16 @@ ALICE = "alice@example.com"
 BOB = "bob@example.com"
 
 
+def verified(email: str) -> dict:
+    """Claims for an address the provider states it has verified.
+
+    Spelled out at every call site on purpose: linking on an *unverified* address is the
+    account-takeover shape this module has to refuse, so a test that links must be visibly
+    asserting the verified case.
+    """
+    return {"email": email, "email_verified": True}
+
+
 @pytest.fixture
 def store(tmp_path):
     from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
@@ -84,7 +94,7 @@ class TestSubjectBinding:
         address reaches nothing."""
         store.create_user(ALICE, "tok", "Alice")
 
-        decision = resolve(subject_provider(), "attacker-sub", {"email": ALICE})
+        decision = resolve(subject_provider(), "attacker-sub", verified(ALICE))
 
         assert decision.resolution is Resolution.CREATE
         assert decision.username is None
@@ -99,13 +109,13 @@ class TestEmailBinding:
     def test_an_authorised_domain_links_to_an_existing_user(self, store, resolve):
         store.create_user(ALICE, "tok", "Alice")
 
-        decision = resolve(email_provider(), "sub-1", {"email": ALICE})
+        decision = resolve(email_provider(), "sub-1", verified(ALICE))
 
         assert decision.resolution is Resolution.LINK
         assert decision.username == ALICE
 
     def test_an_authorised_domain_with_no_local_user_yields_create(self, store, resolve):
-        decision = resolve(email_provider(), "sub-1", {"email": "newcomer@example.com"})
+        decision = resolve(email_provider(), "sub-1", verified("newcomer@example.com"))
 
         assert decision.resolution is Resolution.CREATE
 
@@ -117,7 +127,7 @@ class TestEmailBinding:
         """
         store.create_user("victim@corp.example", "tok", "Victim")
 
-        decision = resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "victim@corp.example"})
+        decision = resolve(email_provider(domains=("example.com",)), "sub-1", verified("victim@corp.example"))
 
         assert decision.resolution is Resolution.REFUSED
         assert decision.username is None
@@ -126,7 +136,7 @@ class TestEmailBinding:
     def test_domain_matching_is_case_insensitive(self, store, resolve):
         store.create_user(ALICE, "tok", "Alice")
 
-        decision = resolve(email_provider(domains=("EXAMPLE.COM",)), "sub-1", {"email": "Alice@Example.COM"})
+        decision = resolve(email_provider(domains=("EXAMPLE.COM",)), "sub-1", {"email": "Alice@Example.COM", "email_verified": True})
 
         assert decision.resolution is Resolution.LINK
         assert decision.username == ALICE
@@ -142,12 +152,12 @@ class TestEmailBinding:
         """A second ``@`` parses differently depending on which end you read from, and a
         mismatch between this check and whatever reads the address later is how a domain
         allowlist gets bypassed."""
-        decision = resolve(email_provider(), "sub-1", {"email": email})
+        decision = resolve(email_provider(), "sub-1", {"email": email, "email_verified": True})
 
         assert decision.resolution is Resolution.REFUSED
 
     def test_a_non_string_email_claim_is_refused(self, store, resolve):
-        decision = resolve(email_provider(), "sub-1", {"email": ["alice@example.com"]})
+        decision = resolve(email_provider(), "sub-1", {"email": ["alice@example.com"], "email_verified": True})
 
         assert decision.resolution is Resolution.REFUSED
 
@@ -165,7 +175,7 @@ class TestCrossProviderTakeover:
         store.create_user(ALICE, "tok", "Alice")
         store.user_identity_repo.link("okta", "sub-a", ALICE)
 
-        decision = resolve(email_provider(provider_id="rogue"), "sub-b", {"email": ALICE})
+        decision = resolve(email_provider(provider_id="rogue"), "sub-b", verified(ALICE))
 
         assert decision.resolution is Resolution.REFUSED
         assert decision.username is None
@@ -177,7 +187,7 @@ class TestCrossProviderTakeover:
         store.create_user(ALICE, "tok", "Alice")
         store.user_identity_repo.link("entra", "sub-old", ALICE)
 
-        decision = resolve(email_provider(provider_id="entra"), "sub-new", {"email": ALICE})
+        decision = resolve(email_provider(provider_id="entra"), "sub-new", verified(ALICE))
 
         assert decision.resolution is Resolution.LINK
         assert decision.username == ALICE
@@ -188,10 +198,148 @@ class TestCrossProviderTakeover:
         store.create_user(BOB, "tok", "Bob")
         store.user_identity_repo.link("entra", "sub-1", ALICE)
 
-        decision = resolve(email_provider(provider_id="entra"), "sub-1", {"email": BOB})
+        decision = resolve(email_provider(provider_id="entra"), "sub-1", verified(BOB))
 
         assert decision.resolution is Resolution.MATCHED
         assert decision.username == ALICE
+
+
+class TestUnverifiedEmail:
+    """Linking on an unverified address is the classic "Sign in with X" takeover.
+
+    ``allowed_email_domains`` bounds *which* domains a provider may speak for; it does nothing
+    inside an authorised one. If the provider has not verified the address, an attacker who
+    registers at that IdP under a colleague's email is handed the colleague's account.
+    Raised in review of #345.
+    """
+
+    @pytest.mark.parametrize("claims", [{"email": ALICE}, {"email": ALICE, "email_verified": False}, {"email": ALICE, "email_verified": None}])
+    def test_an_unverified_email_never_links(self, store, resolve, claims):
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve(email_provider(), "attacker-sub", claims)
+
+        assert decision.resolution is Resolution.REFUSED
+        assert decision.username is None
+        assert "email_verified" in decision.reason
+
+    @pytest.mark.parametrize("value", ["true", "True", 1, "yes"])
+    def test_only_a_literal_true_counts_as_verified(self, store, resolve, value):
+        """Truthy stand-ins are not proof. A provider emitting the string "false" would
+        otherwise read as verified."""
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve(email_provider(), "sub-1", {"email": ALICE, "email_verified": value})
+
+        assert decision.resolution is Resolution.REFUSED
+
+    def test_an_unverified_email_is_refused_rather_than_creating(self, store, resolve):
+        """Not CREATE either: an account named for an unverified address is pre-registration
+        takeover — claim the name first, and the real owner logs into the attacker's account."""
+        decision = resolve(email_provider(), "attacker-sub", {"email": "victim@example.com"})
+
+        assert decision.resolution is Resolution.REFUSED
+
+    def test_subject_binding_does_not_care_about_email_verified(self, store, resolve):
+        """It never reads email at all, so the flag is irrelevant there."""
+        decision = resolve(subject_provider(), "sub-1", {"email": ALICE, "email_verified": False})
+
+        assert decision.resolution is Resolution.CREATE
+
+
+class TestUsernameIsNamedByTheEmail:
+    """Under email binding the account is named by the address, and only by it.
+
+    Authorising a domain says the provider may speak for addresses there; it does not license
+    naming some other account. Raised in review of #345.
+    """
+
+    def test_a_username_derived_from_other_claims_is_refused(self, store, resolve):
+        """The hole this closes: presenting a verified address of one's own alongside somebody
+        else's username would otherwise reach their account."""
+        store.create_user("alice", "tok", "Alice")
+
+        decision = resolve_identity(
+            provider=email_provider(),
+            subject="attacker-sub",
+            claims=verified("attacker@example.com"),
+            identity_repo=store.user_identity_repo,
+            user_lookup=store.has_user,
+            username="alice",
+        )
+
+        assert decision.resolution is Resolution.REFUSED
+        assert "names accounts by their email address" in decision.reason
+
+    def test_a_username_matching_the_email_is_accepted(self, store, resolve):
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve_identity(
+            provider=email_provider(),
+            subject="sub-1",
+            claims=verified(ALICE),
+            identity_repo=store.user_identity_repo,
+            user_lookup=store.has_user,
+            username=ALICE,
+        )
+
+        assert decision.resolution is Resolution.LINK
+        assert decision.username == ALICE
+
+    def test_username_comparison_is_case_insensitive(self, store, resolve):
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve_identity(
+            provider=email_provider(),
+            subject="sub-1",
+            claims=verified(ALICE),
+            identity_repo=store.user_identity_repo,
+            user_lookup=store.has_user,
+            username="Alice@Example.com",
+        )
+
+        assert decision.resolution is Resolution.LINK
+
+
+class TestLinkEnforcesTheGuardItself:
+    """The cross-provider rule has to hold at the write, not only at the decision.
+
+    ``user_identity_repo`` is public on the store, so a caller reaching it directly used to
+    bypass the check entirely; and a caller that did resolve first still had a window in which a
+    concurrent login could bind another provider before it wrote. Raised in review of #345.
+    """
+
+    def test_a_second_provider_cannot_be_bound_by_default(self, store):
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-a", ALICE)
+
+        with pytest.raises(MlflowException, match="already bound to provider"):
+            store.user_identity_repo.link("rogue", "sub-b", ALICE)
+
+        assert store.user_identity_repo.list_providers_for_username(ALICE) == ["okta"]
+
+    def test_the_owning_provider_may_add_another_subject(self, store):
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-a", ALICE)
+
+        assert store.user_identity_repo.link("okta", "sub-b", ALICE) is True
+
+    def test_deliberate_account_linking_remains_possible(self, store):
+        """A person genuinely holding identities at two IdPs is a real case — it just has to be
+        an explicit decision at the call site rather than something that happens by omission."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-a", ALICE)
+
+        assert store.user_identity_repo.link("entra", "sub-b", ALICE, allow_additional_provider=True) is True
+        assert sorted(store.user_identity_repo.list_providers_for_username(ALICE)) == ["entra", "okta"]
+
+    def test_the_write_refuses_even_when_resolution_was_skipped(self, store):
+        """The bypass itself: no call to resolve_identity anywhere in this test."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("entra", "sub-a", ALICE)
+
+        with pytest.raises(MlflowException):
+            store.user_identity_repo.link("attacker-idp", "sub-b", ALICE)
 
 
 class TestRepository:
@@ -244,7 +392,7 @@ class TestRepository:
     def test_list_providers_for_username(self, store):
         store.create_user(ALICE, "tok", "Alice")
         store.user_identity_repo.link("okta", "sub-1", ALICE)
-        store.user_identity_repo.link("entra", "sub-2", ALICE)
+        store.user_identity_repo.link("entra", "sub-2", ALICE, allow_additional_provider=True)
 
         assert sorted(store.user_identity_repo.list_providers_for_username(ALICE)) == ["entra", "okta"]
 
@@ -255,7 +403,7 @@ class TestDecisionShape:
         account it was refused."""
         store.create_user("victim@corp.example", "tok", "Victim")
 
-        decision = resolve(email_provider(domains=("example.com",)), "s", {"email": "victim@corp.example"})
+        decision = resolve(email_provider(domains=("example.com",)), "s", verified("victim@corp.example"))
 
         assert decision.username is None
         assert decision.is_allowed is False
@@ -273,7 +421,7 @@ class TestDecisionShape:
             lambda event, **kwargs: events.append((event, kwargs)),
         )
 
-        resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "someone@corp.example"})
+        resolve(email_provider(domains=("example.com",)), "sub-1", verified("someone@corp.example"))
 
         assert events, "a refusal must be audited"
         event, kwargs = events[0]
@@ -290,7 +438,7 @@ class TestDecisionShape:
             lambda event, **kwargs: events.append((event, kwargs)),
         )
 
-        resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "x@corp.example", "secret_claim": "sensitive"})
+        resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "x@corp.example", "email_verified": True, "secret_claim": "sensitive"})
 
         _, kwargs = events[0]
         assert "sensitive" not in str(kwargs)

--- a/mlflow_oidc_auth/tests/test_identity_resolution.py
+++ b/mlflow_oidc_auth/tests/test_identity_resolution.py
@@ -1,0 +1,296 @@
+"""Identity resolution policy (issue #309).
+
+With more than one provider configured, ``users.username`` alone would let two IdPs asserting the
+same email share an account. These tests are mostly about the attempts that must **not** reach a
+user: the happy paths are few and the refusals are the reason the module exists.
+
+Driven against a real store on SQLite, because the exact-match path depends on the unique
+``(provider_id, subject)`` constraint that #333 created, and a fake repository would not have it.
+"""
+
+import pytest
+from mlflow.exceptions import MlflowException
+
+from mlflow_oidc_auth.identity_resolution import IdentityDecision, Resolution, resolve_identity
+from mlflow_oidc_auth.provider_registry import ProviderConfig
+
+ALICE = "alice@example.com"
+BOB = "bob@example.com"
+
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    yield s
+    s.engine.dispose()
+
+
+@pytest.fixture
+def resolve(store):
+    """Resolve against the real repository and the real user table."""
+
+    def _resolve(provider, subject, claims=None):
+        return resolve_identity(
+            provider=provider,
+            subject=subject,
+            claims=claims or {},
+            identity_repo=store.user_identity_repo,
+            user_lookup=store.has_user,
+        )
+
+    return _resolve
+
+
+def subject_provider(provider_id="okta", **kwargs) -> ProviderConfig:
+    return ProviderConfig(id=provider_id, audience="mlflow", identity_binding="subject", **kwargs)
+
+
+def email_provider(provider_id="entra", domains=("example.com",), **kwargs) -> ProviderConfig:
+    return ProviderConfig(id=provider_id, audience="mlflow", identity_binding="email", allowed_email_domains=tuple(domains), **kwargs)
+
+
+class TestSubjectBinding:
+    def test_an_unknown_subject_yields_create(self, store, resolve):
+        decision = resolve(subject_provider(), "sub-1")
+
+        assert decision.resolution is Resolution.CREATE
+        assert decision.username is None
+
+    def test_a_bound_subject_matches_its_user(self, store, resolve):
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-1", ALICE)
+
+        decision = resolve(subject_provider(), "sub-1")
+
+        assert decision.resolution is Resolution.MATCHED
+        assert decision.username == ALICE
+
+    def test_the_same_subject_under_another_provider_does_not_match(self, store, resolve):
+        """Subjects are only unique within a provider. Two IdPs both numbering their users
+        from 1 must not collide."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-1", ALICE)
+
+        decision = resolve(subject_provider(provider_id="other-idp"), "sub-1")
+
+        assert decision.resolution is Resolution.CREATE
+        assert decision.username is None
+
+    def test_a_matching_email_claim_cannot_reach_a_user(self, store, resolve):
+        """The core of subject binding: email is never consulted, so asserting somebody else's
+        address reaches nothing."""
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve(subject_provider(), "attacker-sub", {"email": ALICE})
+
+        assert decision.resolution is Resolution.CREATE
+        assert decision.username is None
+
+    def test_an_empty_subject_is_refused(self, store, resolve):
+        for subject in ("", "   ", None):
+            decision = resolve(subject_provider(), subject)
+            assert decision.resolution is Resolution.REFUSED
+
+
+class TestEmailBinding:
+    def test_an_authorised_domain_links_to_an_existing_user(self, store, resolve):
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve(email_provider(), "sub-1", {"email": ALICE})
+
+        assert decision.resolution is Resolution.LINK
+        assert decision.username == ALICE
+
+    def test_an_authorised_domain_with_no_local_user_yields_create(self, store, resolve):
+        decision = resolve(email_provider(), "sub-1", {"email": "newcomer@example.com"})
+
+        assert decision.resolution is Resolution.CREATE
+
+    def test_an_unauthorised_domain_is_refused_not_created(self, store, resolve):
+        """Refused rather than 'no match'.
+
+        Falling through to create would hand the caller an account for a domain the operator
+        never authorised this provider to speak for.
+        """
+        store.create_user("victim@corp.example", "tok", "Victim")
+
+        decision = resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "victim@corp.example"})
+
+        assert decision.resolution is Resolution.REFUSED
+        assert decision.username is None
+        assert "not authorised for email domain" in decision.reason
+
+    def test_domain_matching_is_case_insensitive(self, store, resolve):
+        store.create_user(ALICE, "tok", "Alice")
+
+        decision = resolve(email_provider(domains=("EXAMPLE.COM",)), "sub-1", {"email": "Alice@Example.COM"})
+
+        assert decision.resolution is Resolution.LINK
+        assert decision.username == ALICE
+
+    def test_a_missing_email_claim_is_refused(self, store, resolve):
+        decision = resolve(email_provider(), "sub-1", {})
+
+        assert decision.resolution is Resolution.REFUSED
+        assert "no usable email" in decision.reason
+
+    @pytest.mark.parametrize("email", ["a@b@example.com", "no-at-sign", "@example.com", "alice@"])
+    def test_a_malformed_email_is_refused(self, store, resolve, email):
+        """A second ``@`` parses differently depending on which end you read from, and a
+        mismatch between this check and whatever reads the address later is how a domain
+        allowlist gets bypassed."""
+        decision = resolve(email_provider(), "sub-1", {"email": email})
+
+        assert decision.resolution is Resolution.REFUSED
+
+    def test_a_non_string_email_claim_is_refused(self, store, resolve):
+        decision = resolve(email_provider(), "sub-1", {"email": ["alice@example.com"]})
+
+        assert decision.resolution is Resolution.REFUSED
+
+
+class TestCrossProviderTakeover:
+    """The acceptance criterion this issue exists for."""
+
+    def test_a_second_provider_cannot_link_by_email_to_an_owned_account(self, store, resolve):
+        """Provider A owns alice. Provider B, authorised for the same domain, asserts her
+        email. It must not inherit the account.
+
+        Domain authorisation says B may speak for example.com; it does not say B may take over
+        an account another provider already established.
+        """
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-a", ALICE)
+
+        decision = resolve(email_provider(provider_id="rogue"), "sub-b", {"email": ALICE})
+
+        assert decision.resolution is Resolution.REFUSED
+        assert decision.username is None
+        assert "already bound to provider" in decision.reason
+
+    def test_the_owning_provider_may_still_link_a_second_identity(self, store, resolve):
+        """The guard is about *other* providers, not about a provider adding an identity for a
+        user it already owns."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("entra", "sub-old", ALICE)
+
+        decision = resolve(email_provider(provider_id="entra"), "sub-new", {"email": ALICE})
+
+        assert decision.resolution is Resolution.LINK
+        assert decision.username == ALICE
+
+    def test_an_existing_binding_wins_over_any_claim(self, store, resolve):
+        """Once (provider, subject) names a user, no claim redirects it."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.create_user(BOB, "tok", "Bob")
+        store.user_identity_repo.link("entra", "sub-1", ALICE)
+
+        decision = resolve(email_provider(provider_id="entra"), "sub-1", {"email": BOB})
+
+        assert decision.resolution is Resolution.MATCHED
+        assert decision.username == ALICE
+
+
+class TestRepository:
+    def test_linking_is_idempotent(self, store):
+        store.create_user(ALICE, "tok", "Alice")
+
+        assert store.user_identity_repo.link("okta", "sub-1", ALICE) is True
+        assert store.user_identity_repo.link("okta", "sub-1", ALICE) is False
+
+    def test_relinking_to_a_different_user_is_rejected(self, store):
+        """The database constraint makes this impossible; the repository must not paper over it
+        by re-pointing the row, which would be a takeover in one call."""
+        store.create_user(ALICE, "tok", "Alice")
+        store.create_user(BOB, "tok", "Bob")
+        store.user_identity_repo.link("okta", "sub-1", ALICE)
+
+        with pytest.raises(MlflowException, match="already bound to a different user"):
+            store.user_identity_repo.link("okta", "sub-1", BOB)
+
+        assert store.user_identity_repo.get_username_by_identity("okta", "sub-1") == ALICE
+
+    def test_linking_to_an_unknown_user_is_rejected(self, store):
+        with pytest.raises(MlflowException, match="unknown user"):
+            store.user_identity_repo.link("okta", "sub-1", "ghost@example.com")
+
+    def test_backfilled_identities_are_visible(self, store):
+        """#333 gave every pre-existing user an identity under provider 'default'. A user
+        created after the migration does not get one — that is #316's job at login."""
+        store.create_user(ALICE, "tok", "Alice")
+
+        assert store.user_identity_repo.get_username_by_identity("default", ALICE) is None
+
+    def test_touch_last_login_sets_a_timestamp(self, store):
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-1", ALICE)
+
+        store.user_identity_repo.touch_last_login("okta", "sub-1")
+
+        from mlflow_oidc_auth.db.models import SqlUserIdentity
+
+        with store.engine.connect() as conn:
+            row = conn.execute(SqlUserIdentity.__table__.select()).fetchone()
+        assert row.last_login_at is not None
+
+    def test_touch_last_login_on_a_missing_identity_is_a_no_op(self, store):
+        """Best-effort by design: an identity that vanished between resolution and this call is
+        not worth failing a login over."""
+        store.user_identity_repo.touch_last_login("okta", "nope")
+
+    def test_list_providers_for_username(self, store):
+        store.create_user(ALICE, "tok", "Alice")
+        store.user_identity_repo.link("okta", "sub-1", ALICE)
+        store.user_identity_repo.link("entra", "sub-2", ALICE)
+
+        assert sorted(store.user_identity_repo.list_providers_for_username(ALICE)) == ["entra", "okta"]
+
+
+class TestDecisionShape:
+    def test_a_refusal_never_carries_a_username(self, store, resolve):
+        """A caller that ignores ``resolution`` and reads ``username`` must get nothing, not the
+        account it was refused."""
+        store.create_user("victim@corp.example", "tok", "Victim")
+
+        decision = resolve(email_provider(domains=("example.com",)), "s", {"email": "victim@corp.example"})
+
+        assert decision.username is None
+        assert decision.is_allowed is False
+
+    def test_allowed_decisions_report_is_allowed(self):
+        for resolution in (Resolution.MATCHED, Resolution.LINK, Resolution.CREATE):
+            assert IdentityDecision(resolution).is_allowed is True
+
+    def test_refusals_are_audited(self, store, resolve, monkeypatch):
+        """Each refusal is a provider failing to reach an account it asked for — the signal an
+        operator investigating a suspected takeover needs."""
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.identity_resolution.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+
+        resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "someone@corp.example"})
+
+        assert events, "a refusal must be audited"
+        event, kwargs = events[0]
+        assert event == "identity.refused"
+        assert kwargs["status"] == "denied"
+        assert kwargs["resource_id"] == "entra"
+
+    def test_audit_detail_does_not_carry_claim_contents(self, store, resolve, monkeypatch):
+        """The reason is enough; copying claims into the audit log would put token contents in
+        it."""
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.identity_resolution.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+
+        resolve(email_provider(domains=("example.com",)), "sub-1", {"email": "x@corp.example", "secret_claim": "sensitive"})
+
+        _, kwargs = events[0]
+        assert "sensitive" not in str(kwargs)


### PR DESCRIPTION
Closes #309.

`users.username` is the only identity key, so with more than one provider configured two IdPs
asserting the same email would silently share an account. This lands the decision: given
`(provider_id, subject, claims)`, is an existing user reached, should one be created, or is the
attempt refused?

**No consumer changes.** Login and bearer auth are untouched; wiring this in is #316.

## The rules

**`identity_binding: subject`** — a user is reached only through `(provider_id, sub)`. Email is
never consulted, so a token asserting somebody else's address reaches nothing.

**`identity_binding: email`** — may link to an existing user, but only when the address's domain
is in the provider's `allowed_email_domains`, and **never to an account another provider already
owns**. Domain authorisation says a provider may speak for a domain; it does not say it may
inherit an account someone else established.

Two properties hold in both modes:

- **An existing binding wins before any claim is read.** Once `(provider_id, subject)` names a
  user, no claim redirects it, so a second provider cannot talk its way into a bound account.
- **A refusal never carries a username.** A caller that ignores `resolution` and reads `username`
  gets nothing, rather than the account it was just refused. An unauthorised domain is `REFUSED`,
  not "no match" — falling through to create would hand out an account for a domain the operator
  never authorised.

Refusals are audited (`identity.refused`, `status="denied"`): a provider failing to reach an
account it asked for is exactly what an operator investigating a suspected takeover needs. The
reason is recorded; claim contents are not, and a test asserts that.

## Tests

`mlflow_oidc_auth/tests/test_identity_resolution.py` — 29 tests, run against a real store on
SQLite because the exact-match path depends on the unique `(provider_id, subject)` constraint
from #333 and a fake repository would not have it.

The takeover cases are the point:

- a second provider cannot link by email to an account provider A already owns;
- the owning provider *may* still add a second identity for its own user;
- an existing binding beats a conflicting email claim;
- under `subject` binding, a matching email claim reaches nothing;
- the same `sub` under a different provider does not collide (two IdPs both numbering users
  from 1);
- re-linking an identity to a different user is rejected rather than re-pointed, which would be
  a takeover in one call.

## Two defects the tests caught in my own code

- `link()` raised `ValueError` inside the managed session, which wraps every exception into
  `MlflowException(INTERNAL_ERROR)` — so the error code was meaningless and callers could not
  distinguish "unknown user" from "already bound". Now raises `MlflowException` directly with
  `RESOURCE_DOES_NOT_EXIST` / `RESOURCE_ALREADY_EXISTS`.
- `"@example.com"` passed the domain check. It has exactly one `@` and an authorised-looking
  domain, but no local part, so a provider could have claimed an account named for the bare
  domain. The check now requires both halves to be non-empty — it has to be about the whole
  address, not just the half being compared.

## No migration

The table, its constraints and the backfill landed in #333. Adding a revision here would fail
(the table exists) **and** create the second Alembic head that #333 exists to prevent. Verified
after this change: `heads: ['9c0d1e2f3456']`.

I updated #309's scope before starting — it still described the schema work as outstanding, which
would have led exactly there.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 3047 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 budget intact
python -m pyflakes <new files>                    # clean
```

The per-request auth path is unchanged — nothing calls this yet — so the #305 budget is
untouched at 0/2/2/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
