### PR TITLE
feat(auth): deny inactive users, guard the last admin, add break-glass recovery (#311)

### DIFF
--- a/mlflow_oidc_auth/db/cli.py
+++ b/mlflow_oidc_auth/db/cli.py
@@ -16,3 +16,59 @@ def upgrade(url: str, revision: str) -> None:
     engine = sqlalchemy.create_engine(url)
     utils.migrate(engine, revision)
     engine.dispose()
+
+
+@commands.command(name="restore-admin")
+@click.option("--url", required=True, help="Database URL, e.g. sqlite:///auth.db")
+@click.option("--username", required=True, help="User to restore administrator access to.")
+def restore_admin(url: str, username: str) -> None:
+    """Break-glass recovery: make a user an active administrator again.
+
+    The last-active-admin invariant in the store makes a full lockout hard to reach, but not
+    impossible — a database restored from a backup, a directory sync that ran before the guard
+    existed, or a deliberate override can all leave a deployment with no administrator who can
+    log in. At that point nothing can be fixed over HTTP: every route that could grant admin
+    requires an admin.
+
+    So this deliberately bypasses the application entirely. It talks to the database directly,
+    performs no authentication, and is only as safe as access to the database URL — which is
+    precisely the out-of-band authority the situation calls for.
+
+    It sets ``is_admin=true``, ``active=true`` and ``managed_by='manual'``. Resetting
+    ``managed_by`` matters as much as the other two: leaving a row owned by ``scim`` or
+    ``oidc:<provider>`` invites the next sync to undo the repair, and the #319 write guard to
+    refuse an admin's later edits to it.
+
+    Prints what it changed, and emits an audit event, because an out-of-band privilege grant is
+    exactly the kind of thing an operator needs to find in the log afterwards.
+    """
+    from mlflow_oidc_auth.audit import emit_audit_event
+    from mlflow_oidc_auth.db.models import SqlUser
+
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                sqlalchemy.select(SqlUser.id, SqlUser.is_admin, SqlUser.active, SqlUser.managed_by).where(SqlUser.username == username)
+            ).fetchone()
+            if row is None:
+                raise click.ClickException(f"user '{username}' does not exist in this database")
+
+            conn.execute(sqlalchemy.update(SqlUser).where(SqlUser.username == username).values(is_admin=True, active=True, managed_by="manual"))
+
+        emit_audit_event(
+            "user.break_glass_admin_restore",
+            actor="cli",
+            resource_type="user",
+            resource_id=username,
+            detail={
+                "previous_is_admin": bool(row.is_admin),
+                "previous_active": bool(row.active),
+                "previous_managed_by": row.managed_by,
+            },
+        )
+        click.echo(
+            f"restored '{username}': is_admin {bool(row.is_admin)} -> True, active {bool(row.active)} -> True, managed_by {row.managed_by!r} -> 'manual'"
+        )
+    finally:
+        engine.dispose()

--- a/mlflow_oidc_auth/db/models/user.py
+++ b/mlflow_oidc_auth/db/models/user.py
@@ -59,6 +59,8 @@ class SqlUser(Base):
             password_expiration=self.password_expiration,
             is_admin=self.is_admin,
             is_service_account=self.is_service_account,
+            active=self.active,
+            managed_by=self.managed_by,
             experiment_permissions=[p.to_mlflow_entity() for p in self.experiment_permissions],
             registered_model_permissions=[p.to_mlflow_entity() for p in self.registered_model_permissions],
             scorer_permissions=[p.to_mlflow_entity() for p in self.scorer_permissions],

--- a/mlflow_oidc_auth/entities/user.py
+++ b/mlflow_oidc_auth/entities/user.py
@@ -50,8 +50,13 @@ class User:
         gateway_model_definition_permissions=None,
         gateway_secret_permissions=None,
         groups=None,
+        active: bool = True,
+        managed_by: str = "manual",
     ):
         # Provide sensible defaults so tests can construct User with partial data.
+        # ``active`` defaults True and ``managed_by`` to "manual" to match the #333 backfill:
+        # a User built without them describes a normal, locally managed, enabled account, so no
+        # existing construction site silently produces a disabled one.
         self._id = id_
         self._username = username
         self._password_hash = password_hash
@@ -66,6 +71,8 @@ class User:
         self._gateway_secret_permissions = gateway_secret_permissions or []
         self._display_name = display_name
         self._groups = groups or []
+        self._active = active
+        self._managed_by = managed_by
 
     @property
     def id(self):
@@ -162,6 +169,20 @@ class User:
     @property
     def groups(self):
         return self._groups
+
+    @property
+    def active(self) -> bool:
+        """Whether the account may authenticate.
+
+        Entra and other directories deprovision with ``PATCH active:false`` rather than a
+        delete, so this is the state a deprovisioned user lands in (issue #311).
+        """
+        return self._active
+
+    @property
+    def managed_by(self) -> str:
+        """Which source owns this row — ``manual``, ``scim`` or ``oidc:<provider_id>``."""
+        return self._managed_by
 
     @groups.setter
     def groups(self, groups):

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -19,6 +19,7 @@ from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.routers._prefix import API_PATH_PREFIXES
+from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.auth import validate_token
 from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils.oidc_field_extraction import extract_username, extract_display_name, BEARER_TOKEN_SOURCE
@@ -312,12 +313,32 @@ class AuthMiddleware(BaseHTTPMiddleware):
         Returns:
             True if user is admin, False otherwise
         """
+        return self._get_user_auth_state(username)[0]
+
+    def _get_user_auth_state(self, username: str) -> Tuple[bool, bool]:
+        """Read the two facts the auth path needs about a user, in one lookup.
+
+        Both come off the profile row that is already fetched on every authenticated request,
+        so ``active`` costs nothing: it is in the ``load_only`` list added by #333, and the
+        per-request statement count stays at the #305 budget of 2.
+
+        Args:
+            username: Username to check
+
+        Returns:
+            ``(is_admin, is_active)``. On any failure — including the user no longer existing —
+            returns ``(False, False)``: an account that cannot be read is not an account that
+            may authenticate. Erring the other way would let a lookup error grant access, which
+            is the fallback this repository forbids.
+        """
         try:
             user = store.get_user_profile(username)
-            return user.is_admin if user else False
+            if not user:
+                return False, False
+            return bool(user.is_admin), bool(user.active)
         except Exception as e:
-            logger.error(f"Error checking admin status for {username}: {e}")
-            return False
+            logger.error(f"Error reading auth state for {username}: {e}")
+            return False, False
 
     async def _handle_auth_redirect(self, request: Request) -> Response:
         """
@@ -377,9 +398,27 @@ class AuthMiddleware(BaseHTTPMiddleware):
         is_authenticated, username, error_msg = await self._authenticate_user(request)
 
         if is_authenticated and username:
+            is_admin, is_active = self._get_user_auth_state(username)
+
+            # A deprovisioned user holds a signed cookie or a valid token that has not expired
+            # yet, so credentials alone still check out. Directories deactivate rather than
+            # delete (Entra sends PATCH active:false), which makes this the state a
+            # deprovisioned account actually lands in — it has to be denied here, on every
+            # path, rather than left to downstream permission checks (issue #311).
+            if not is_active:
+                logger.info("Authentication denied for inactive user %s on %s", username, path)
+                emit_audit_event(
+                    "auth.denied_inactive",
+                    actor=username,
+                    resource_type="user",
+                    resource_id=username,
+                    status="denied",
+                )
+                return await self._deny(request, path)
+
             # Set user context in request state for downstream middleware/handlers
             request.state.username = username
-            request.state.is_admin = self._get_user_admin_status(username)
+            request.state.is_admin = is_admin
 
             # ROBUST: Store user info in ASGI scope for WSGI compatibility
             # This ensures Flask RBAC middleware can access user information reliably
@@ -400,24 +439,40 @@ class AuthMiddleware(BaseHTTPMiddleware):
         else:
             # Authentication failed - for API routes return 401 JSON, else redirect to login
             logger.info(f"Authentication failed for {path}: {error_msg}")
-            # Treat certain non-/api routes as API-style endpoints (no redirects)
-            # so callers get an HTTP error instead of a redirected 200.
-            # "/ajax-api" is the same REST surface under the prefix the web UI
-            # calls; it must 401 rather than redirect, just like "/api".
-            if path.startswith(API_PATH_PREFIXES):
-                return JSONResponse(status_code=401, content={"detail": "Authentication required"})
-            if path.startswith("/oidc/trash"):
-                return JSONResponse(
-                    status_code=403,
-                    content={"detail": "Administrator privileges required for this operation"},
-                )
-            # Only redirect top-level navigation requests. Subresource fetches
-            # (chunks, fetch/XHR, telemetry) must get 401 — otherwise the
-            # browser silently follows the 302 and hands HTML to the JS chunk
-            # loader / JSON.parse, breaking the SPA mid-session.
-            if not self._is_document_request(request):
-                return JSONResponse(status_code=401, content={"detail": "Authentication required"})
-            return await self._handle_auth_redirect(request)
+            return await self._deny(request, path)
+
+    async def _deny(self, request: Request, path: str) -> Response:
+        """Turn an unauthenticated request away.
+
+        Shared by "no valid credentials" and "credentials belong to an inactive user" so the
+        two are indistinguishable to the caller: an inactive account must not be detectable by
+        the shape of its rejection.
+
+        Args:
+            request: FastAPI request object
+            path: Request path, already extracted by the caller
+
+        Returns:
+            A 401, a 403 or a redirect, depending on the surface.
+        """
+        # Treat certain non-/api routes as API-style endpoints (no redirects)
+        # so callers get an HTTP error instead of a redirected 200.
+        # "/ajax-api" is the same REST surface under the prefix the web UI
+        # calls; it must 401 rather than redirect, just like "/api".
+        if path.startswith(API_PATH_PREFIXES):
+            return JSONResponse(status_code=401, content={"detail": "Authentication required"})
+        if path.startswith("/oidc/trash"):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "Administrator privileges required for this operation"},
+            )
+        # Only redirect top-level navigation requests. Subresource fetches
+        # (chunks, fetch/XHR, telemetry) must get 401 — otherwise the
+        # browser silently follows the 302 and hands HTML to the JS chunk
+        # loader / JSON.parse, breaking the SPA mid-session.
+        if not self._is_document_request(request):
+            return JSONResponse(status_code=401, content={"detail": "Authentication required"})
+        return await self._handle_auth_redirect(request)
 
     @staticmethod
     def _is_document_request(request: Request) -> bool:

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
+    INVALID_STATE,
     RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
 )
@@ -62,6 +63,38 @@ def normalize_username(username: str) -> str:
 class UserRepository:
     def __init__(self, session_maker):
         self._Session: Callable[[], Session] = session_maker
+
+    @staticmethod
+    def _assert_not_last_active_admin(session, user, action: str) -> None:
+        """Refuse an operation that would leave the deployment with no active administrator.
+
+        Enforced here rather than in the routers so that every caller inherits it — the admin
+        API, a future SCIM sync, the reconcile job in #319 and anything else that reaches the
+        store. A check in one router is a check the next caller forgets.
+
+        Recovery from a full admin lockout cannot be done from inside the system: with no active
+        admin nobody can restore one over HTTP. The way back is the break-glass CLI
+        (``mlflow-oidc-auth db restore-admin``), which needs database access. That asymmetry —
+        cheap to prevent, expensive to undo — is why this refuses rather than warns.
+
+        Args:
+            session: The open session, so the count sees this transaction's own changes.
+            user: The ``SqlUser`` about to be removed, deactivated or demoted.
+            action: Verb for the error message.
+
+        Raises:
+            MlflowException: If ``user`` is the only remaining active administrator.
+        """
+        if not (user.is_admin and user.active):
+            # Not an active admin, so removing them cannot change the count.
+            return
+        remaining = session.query(SqlUser).filter(SqlUser.is_admin.is_(True), SqlUser.active.is_(True), SqlUser.id != user.id).count()
+        if remaining == 0:
+            raise MlflowException(
+                f"refusing to {action} '{user.username}': they are the only active administrator, and doing so would "
+                "leave the deployment with none. Grant admin to another active user first.",
+                INVALID_STATE,
+            )
 
     def create(
         self,
@@ -151,6 +184,8 @@ class UserRepository:
                 password_expiration=u.password_expiration,
                 is_admin=u.is_admin,
                 is_service_account=u.is_service_account,
+                active=u.active,
+                managed_by=u.managed_by,
                 experiment_permissions=[],
                 registered_model_permissions=[],
                 scorer_permissions=[],
@@ -187,6 +222,8 @@ class UserRepository:
         password_expiration: Optional[datetime] = None,
         is_admin: Optional[bool] = None,
         is_service_account: Optional[bool] = None,
+        active: Optional[bool] = None,
+        managed_by: Optional[str] = None,
     ) -> User:
         """Update the supplied fields of a user, leaving omitted ones untouched.
 
@@ -215,12 +252,16 @@ class UserRepository:
             password_expiration: Expiry for the stored secret. See the semantics above.
             is_admin: New administrator flag.
             is_service_account: New service-account flag.
+            active: Whether the account may authenticate. Setting it False is how a directory
+                deprovisions a user (issue #311).
+            managed_by: Which source owns this row.
 
         Returns:
             User: The updated user entity.
 
         Raises:
-            MlflowException: If the user does not exist.
+            MlflowException: If the user does not exist, or if the change would leave the
+                deployment with no active administrator.
         """
         from werkzeug.security import generate_password_hash
 
@@ -233,10 +274,21 @@ class UserRepository:
                 user.password_expiration = password_expiration
             elif password_expiration is not None:
                 user.password_expiration = password_expiration
+            # Deactivating or demoting the last active admin locks everyone out just as surely
+            # as deleting them, so both go through the same guard — checked before the change
+            # is applied, since afterwards the user would no longer count as an active admin
+            # and the query would happily report zero.
+            if active is False or is_admin is False:
+                self._assert_not_last_active_admin(session, user, "deactivate" if active is False else "demote")
+
             if is_admin is not None:
                 user.is_admin = is_admin
             if is_service_account is not None:
                 user.is_service_account = is_service_account
+            if active is not None:
+                user.active = active
+            if managed_by is not None:
+                user.managed_by = managed_by
             session.flush()
             return user.to_mlflow_entity()
 
@@ -246,6 +298,8 @@ class UserRepository:
             user = get_user(session, username)
             if user is None:
                 raise MlflowException(f"User '{username}' not found.")
+
+            self._assert_not_last_active_admin(session, user, "delete")
 
             # Delete dependent rows first.
             # Without this, SQLAlchemy may try to NULL-out non-nullable FKs

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -354,6 +354,8 @@ class SqlAlchemyStore:
         password_expiration: Optional[datetime] = None,
         is_admin: Optional[bool] = None,
         is_service_account: Optional[bool] = None,
+        active: Optional[bool] = None,
+        managed_by: Optional[str] = None,
     ) -> User:
         """Update the supplied fields of a user, leaving omitted ones untouched.
 
@@ -392,6 +394,8 @@ class SqlAlchemyStore:
             password_expiration=password_expiration,
             is_admin=is_admin,
             is_service_account=is_service_account,
+            active=active,
+            managed_by=managed_by,
         )
 
     def delete_user(self, username: str):

--- a/mlflow_oidc_auth/tests/repository/test_user_update_semantics.py
+++ b/mlflow_oidc_auth/tests/repository/test_user_update_semantics.py
@@ -167,6 +167,10 @@ class TestOmittedFlagsArePreserved:
         s = SqlAlchemyStore()
         s.init_db(f"sqlite:///{Path(tempfile.mkdtemp()) / 'auth.db'}")
         s.create_user("dem@example.com", TOKEN, "Dem User", is_admin=True, is_service_account=True)
+        # A second active admin, so demotion is not blocked by the last-active-admin invariant
+        # (#311). The point here is that an explicit False still applies, not that the store
+        # will let a deployment strand itself without an administrator.
+        s.create_user("other-admin@example.com", TOKEN, "Other Admin", is_admin=True)
 
         s.update_user(username="dem@example.com", **{flag: False})
 

--- a/mlflow_oidc_auth/tests/test_sqlalchemy_store.py
+++ b/mlflow_oidc_auth/tests/test_sqlalchemy_store.py
@@ -296,6 +296,8 @@ class TestSqlAlchemyStore:
             password_expiration=expiration,
             is_admin=True,
             is_service_account=False,
+            active=None,
+            managed_by=None,
         )
         assert result == mock_user
 

--- a/mlflow_oidc_auth/tests/test_user_lifecycle.py
+++ b/mlflow_oidc_auth/tests/test_user_lifecycle.py
@@ -1,0 +1,324 @@
+"""User lifecycle: inactive denial, the last-admin invariant, and break-glass recovery (#311).
+
+Directories deprovision by setting ``active=false`` rather than deleting — Entra sends
+``PATCH active:false`` — so a deprovisioned user keeps a valid cookie or an unexpired token.
+Credentials alone still check out, which is why the denial has to happen in the auth path
+rather than being left to downstream permission checks.
+
+Enforcement creates a lockout risk, the invariant prevents it and the CLI recovers from it;
+the three are tested together because they are one safety story.
+"""
+
+import base64
+import time
+
+import pytest
+from authlib.jose import JsonWebKey, jwt
+from click.testing import CliRunner
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from mlflow.exceptions import MlflowException
+from sqlalchemy import text
+from starlette.middleware.sessions import SessionMiddleware
+
+import mlflow_oidc_auth.auth as auth_module
+import mlflow_oidc_auth.store as store_module
+from mlflow_oidc_auth.db.cli import commands
+from mlflow_oidc_auth.middleware import AuthMiddleware
+
+PASSWORD = "lifecycle-password"  # not a credential: only ever seeded into a tmp_path database
+PROTECTED = "/lifecycle/protected"
+LOGIN = "/login/lifecycle"
+
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    yield s
+    s.engine.dispose()
+
+
+@pytest.fixture
+def bound_store(store):
+    """Point the lazy singleton at the test store; AuthMiddleware imports it directly."""
+    previous = object.__getattribute__(store_module.store, "_instance")
+    object.__setattr__(store_module.store, "_instance", store)
+    yield store
+    object.__setattr__(store_module.store, "_instance", previous)
+
+
+@pytest.fixture
+def bearer_token(monkeypatch):
+    """Prime the JWKS cache with a local key and return a token minter."""
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    private, public = key.as_dict(is_private=True), key.as_dict(is_private=False)
+    kid = public.get("kid") or key.thumbprint()
+    public["kid"] = private["kid"] = kid
+    monkeypatch.setattr(auth_module.config, "OIDC_DISCOVERY_URL", "https://test.invalid/.well-known/openid-configuration")
+    monkeypatch.setitem(auth_module._jwks_cache, auth_module._JWKS_CACHE_KEY, {"keys": [public]})
+
+    def mint(username: str) -> str:
+        now = int(time.time())
+        return jwt.encode({"alg": "RS256", "kid": kid}, {"email": username, "name": username, "iat": now, "exp": now + 3600}, private).decode("utf-8")
+
+    return mint
+
+
+@pytest.fixture
+def client(bound_store):
+    app = FastAPI()
+
+    @app.get(PROTECTED)
+    async def protected(request: Request):
+        return {"username": getattr(request.state, "username", None)}
+
+    @app.get(LOGIN)
+    async def login(request: Request, username: str):
+        request.session["username"] = username
+        return {"ok": True}
+
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+    with TestClient(app) as c:
+        yield c
+
+
+def deactivate(store, username: str) -> None:
+    """Deactivate out-of-band.
+
+    The store refuses to deactivate the last active admin — correctly — so tests that need an
+    inactive user either use a non-admin or go around the guard, the way a restored backup or a
+    sync predating the guard would.
+    """
+    with store.engine.begin() as conn:
+        conn.execute(text("UPDATE users SET active = 0 WHERE username = :u"), {"u": username})
+
+
+class TestInactiveUserIsDeniedOnEveryAuthPath:
+    """One test per path, because each presents credentials differently and each must deny."""
+
+    def test_session_path_denies_an_inactive_user(self, store, client):
+        store.create_user("s@example.com", PASSWORD, "S")
+        client.get(LOGIN, params={"username": "s@example.com"})
+        assert client.get(PROTECTED).status_code == 200, "precondition: an active user is allowed"
+
+        deactivate(store, "s@example.com")
+
+        assert client.get(PROTECTED).status_code == 401
+
+    def test_bearer_path_denies_an_inactive_user(self, store, client, bearer_token):
+        store.create_user("b@example.com", PASSWORD, "B")
+        token = bearer_token("b@example.com")
+        headers = {"Authorization": f"Bearer {token}"}
+        assert client.get(PROTECTED, headers=headers).status_code == 200
+
+        deactivate(store, "b@example.com")
+
+        assert client.get(PROTECTED, headers=headers).status_code == 401
+
+    def test_basic_path_denies_an_inactive_user(self, store, client):
+        store.create_user("a@example.com", PASSWORD, "A")
+        credentials = base64.b64encode(f"a@example.com:{PASSWORD}".encode()).decode()
+        headers = {"Authorization": f"Basic {credentials}"}
+        assert client.get(PROTECTED, headers=headers).status_code == 200
+
+        deactivate(store, "a@example.com")
+
+        assert client.get(PROTECTED, headers=headers).status_code == 401
+
+    def test_a_still_valid_session_cookie_does_not_help(self, store, client):
+        """The point of enforcing here: the cookie is signed, unexpired and genuine. Only the
+        account state changed."""
+        store.create_user("c@example.com", PASSWORD, "C")
+        client.get(LOGIN, params={"username": "c@example.com"})
+        deactivate(store, "c@example.com")
+
+        response = client.get(PROTECTED)
+
+        assert response.status_code == 401
+        assert response.json().get("username") is None
+
+    def test_reactivating_restores_access(self, store, client):
+        store.create_user("r@example.com", PASSWORD, "R")
+        client.get(LOGIN, params={"username": "r@example.com"})
+        deactivate(store, "r@example.com")
+        assert client.get(PROTECTED).status_code == 401
+
+        store.update_user(username="r@example.com", active=True)
+
+        assert client.get(PROTECTED).status_code == 200
+
+    def test_an_active_user_is_unaffected(self, store, client):
+        """Back-compat: every existing row is active=true after the #333 backfill, so no
+        deployment changes behaviour."""
+        store.create_user("ok@example.com", PASSWORD, "OK")
+        client.get(LOGIN, params={"username": "ok@example.com"})
+
+        assert client.get(PROTECTED).status_code == 200
+
+
+class TestInactiveDenialCostsNoExtraQuery:
+    def test_the_statement_count_is_unchanged(self, store, client):
+        """``active`` rides along in the ``load_only`` list #333 added, so the #305 budget of 2
+        statements per authenticated request still holds."""
+        from sqlalchemy import event
+
+        store.create_user("q@example.com", PASSWORD, "Q")
+        client.get(LOGIN, params={"username": "q@example.com"})
+        client.get(PROTECTED)
+
+        statements = []
+
+        def listener(conn, cursor, statement, parameters, context, executemany):
+            if not statement.lstrip().upper().startswith(("PRAGMA", "BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT", "RELEASE")):
+                statements.append(statement)
+
+        event.listen(store.engine, "before_cursor_execute", listener)
+        try:
+            client.get(PROTECTED)
+        finally:
+            event.remove(store.engine, "before_cursor_execute", listener)
+
+        assert len(statements) == 2, statements
+
+
+class TestLastActiveAdminInvariant:
+    """Refusing is cheap; recovering from a full lockout needs database access."""
+
+    def test_deleting_the_last_active_admin_is_refused(self, store):
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        store.create_user("plain@example.com", PASSWORD, "Plain")
+
+        with pytest.raises(MlflowException, match="only active administrator"):
+            store.delete_user("admin@example.com")
+
+        assert store.get_user_profile("admin@example.com").is_admin is True
+
+    def test_deactivating_the_last_active_admin_is_refused(self, store):
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+
+        with pytest.raises(MlflowException, match="only active administrator"):
+            store.update_user(username="admin@example.com", active=False)
+
+        assert store.get_user_profile("admin@example.com").active is True
+
+    def test_demoting_the_last_active_admin_is_refused(self, store):
+        """Demotion locks everyone out exactly as thoroughly as deletion."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+
+        with pytest.raises(MlflowException, match="only active administrator"):
+            store.update_user(username="admin@example.com", is_admin=False)
+
+        assert store.get_user_profile("admin@example.com").is_admin is True
+
+    @pytest.mark.parametrize("operation", ["delete", "deactivate", "demote"])
+    def test_any_of_them_is_allowed_while_another_active_admin_remains(self, store, operation):
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        store.create_user("admin2@example.com", PASSWORD, "Admin2", is_admin=True)
+
+        if operation == "delete":
+            store.delete_user("admin@example.com")
+            assert store.has_user("admin@example.com") is False
+        elif operation == "deactivate":
+            store.update_user(username="admin@example.com", active=False)
+            assert store.get_user_profile("admin@example.com").active is False
+        else:
+            store.update_user(username="admin@example.com", is_admin=False)
+            assert store.get_user_profile("admin@example.com").is_admin is False
+
+    def test_an_inactive_admin_does_not_count_towards_the_invariant(self, store):
+        """Two admins on paper, one of them deactivated, is still one active admin."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        store.create_user("admin2@example.com", PASSWORD, "Admin2", is_admin=True)
+        deactivate(store, "admin2@example.com")
+
+        with pytest.raises(MlflowException, match="only active administrator"):
+            store.delete_user("admin@example.com")
+
+    def test_removing_a_non_admin_is_never_blocked(self, store):
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        store.create_user("plain@example.com", PASSWORD, "Plain")
+
+        store.delete_user("plain@example.com")
+
+        assert store.has_user("plain@example.com") is False
+
+    def test_removing_an_already_inactive_admin_is_allowed(self, store):
+        """They cannot log in, so they are not the administrator anyone is relying on."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        store.create_user("old@example.com", PASSWORD, "Old", is_admin=True)
+        deactivate(store, "old@example.com")
+
+        store.delete_user("old@example.com")
+
+        assert store.has_user("old@example.com") is False
+
+
+class TestBreakGlassCli:
+    """The way back when the invariant was bypassed — a restored backup, or a sync that ran
+    before the guard existed. Nothing inside the system can fix it: every route that grants
+    admin requires an admin."""
+
+    def _url(self, store) -> str:
+        return store.engine.url.render_as_string(hide_password=False)
+
+    def test_it_restores_an_admin_who_cannot_log_in(self, store):
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0, managed_by = 'scim' WHERE username = 'admin@example.com'"))
+
+        result = CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "admin@example.com"])
+
+        assert result.exit_code == 0, result.output
+        profile = store.get_user_profile("admin@example.com")
+        assert (profile.is_admin, profile.active) == (True, True)
+
+    def test_it_resets_managed_by(self, store):
+        """Leaving the row owned by ``scim`` invites the next sync to undo the repair, and the
+        #319 guard to refuse an admin's later edits to it."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0, managed_by = 'oidc:entra' WHERE username = 'admin@example.com'"))
+
+        CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "admin@example.com"])
+
+        assert store.get_user_profile("admin@example.com").managed_by == "manual"
+
+    def test_it_promotes_a_non_admin(self, store):
+        """The realistic lockout is that nobody is left with admin at all."""
+        store.create_user("plain@example.com", PASSWORD, "Plain")
+
+        result = CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "plain@example.com"])
+
+        assert result.exit_code == 0
+        assert store.get_user_profile("plain@example.com").is_admin is True
+
+    def test_the_restored_admin_can_authenticate_again(self, store, client):
+        """End to end: the recovery is only real if it restores access."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        client.get(LOGIN, params={"username": "admin@example.com"})
+        deactivate(store, "admin@example.com")
+        assert client.get(PROTECTED).status_code == 401
+
+        CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "admin@example.com"])
+
+        assert client.get(PROTECTED).status_code == 200
+
+    def test_an_unknown_user_is_an_error_not_a_silent_no_op(self, store):
+        result = CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "ghost@example.com"])
+
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_it_reports_what_it_changed(self, store):
+        """An out-of-band privilege grant has to be visible afterwards."""
+        store.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        deactivate(store, "admin@example.com")
+
+        result = CliRunner().invoke(commands, ["restore-admin", "--url", self._url(store), "--username", "admin@example.com"])
+
+        assert "admin@example.com" in result.output
+        assert "active False -> True" in result.output


### PR DESCRIPTION
Closes #311.

Directories deprovision by setting `active=false` rather than deleting — Entra sends
`PATCH active:false` — so a deprovisioned user keeps a signed cookie or an unexpired token and
their credentials still check out. Three pieces, deliberately in one change because they are one
safety story: enforcement creates a lockout risk, the invariant prevents it, the CLI recovers
from it.

## 1. Inactive users are denied, on every path

`AuthMiddleware.dispatch` reads `active` from the profile row **it already fetches** — the column
is in the `load_only` list #333 added — so this costs nothing. Verified: the benchmark still
reports **0 / 2 / 2 / 3**, and a test asserts the session path is still exactly 2 statements.

The denial reuses the existing rejection path (extracted as `_deny`), so an inactive account is
indistinguishable from absent credentials. An account's state should not be discoverable from the
shape of its rejection.

`_get_user_auth_state` returns `(False, False)` on any lookup failure, including the user having
been deleted — an account that cannot be read is not one that may authenticate. Erring the other
way would let a lookup error grant access, which this repository forbids.

## 2. The last active admin cannot be removed

Deleting, deactivating **or demoting** the last active admin is refused. Demotion matters as much
as the others and is easy to forget: it strands a deployment exactly as thoroughly.

Enforced at the **store layer**, so every caller inherits it — the admin API today, SCIM sync and
the reconcile job (#318/#319) later. A check in one router is a check the next caller forgets.
Checked *before* the change is applied, since afterwards the user no longer counts as an active
admin and the query would happily report zero.

An already-inactive admin doesn't count towards the invariant — they cannot log in, so they are
not the administrator anyone is relying on.

## 3. Break-glass recovery

The invariant makes lockout hard to reach, not impossible: a restored backup, or a sync that ran
before the guard existed. At that point nothing inside the system can help, because every route
that grants admin requires an admin.

```bash
mlflow-oidc-auth db restore-admin --url sqlite:///auth.db --username admin@example.com
```

Talks to the database directly, no HTTP auth — the out-of-band authority the situation calls for.
Sets `is_admin`, `active` **and resets `managed_by='manual'`**; leaving the row owned by `scim` or
`oidc:<provider>` would invite the next sync to undo the repair and the #319 guard to refuse an
admin's later edits to it. Audited and printed, because an out-of-band privilege grant should be
findable afterwards.

## Tests

`mlflow_oidc_auth/tests/test_user_lifecycle.py` — 22 tests:

- **one per auth path** (session, bearer, basic), each proving access *before* deactivation so
  the test cannot pass vacuously;
- a still-valid signed cookie does not help — only the account state changed;
- reactivating restores access, and an active user is unaffected (the #333 backfill makes every
  existing row active, so no deployment changes behaviour);
- the statement count is still 2;
- the invariant on delete / deactivate / demote, each also shown to be *allowed* when a second
  active admin exists, plus an inactive admin not counting and a non-admin never being blocked;
- the CLI restoring an unusable admin, resetting `managed_by`, promoting a non-admin, erroring on
  an unknown user, and **end to end**: a locked-out user authenticating again afterwards.

The tests build a lockout with raw SQL, because the store correctly refuses to create one — which
is itself a confirmation the invariant works.

## Two existing tests changed

Behaviour was not weakened to make them pass:

- `test_flags_can_still_be_set_false_explicitly[is_admin]` (#338) demoted a lone admin. It now
  creates a second admin first, so it still tests that an explicit `False` applies rather than
  asking the store to strand a deployment.
- `test_update_user` asserts the exact passthrough kwargs, which gained `active` and `managed_by`.

## No migration

Columns, backfill and the `load_only` entry landed in #333. Adding a revision would fail and
create a second Alembic head. I corrected #311's scope before starting — it still listed the
schema work as outstanding.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 3085 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed
python scripts/bench_auth_path.py                 # 0/2/2/3, unchanged
```

## Note on scope

One acceptance criterion asked for the invariant to be tested on "sync and reconcile" too. Those
paths are #318/#319 and do not exist yet, so they are not covered here — the store-layer
placement is what will make them inherit it when they arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
