### PR TITLE
feat(auth): register one OAuth client per provider (#315)

### DIFF
--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -27,7 +27,7 @@ from mlflow_oidc_auth.middleware import (
     WorkspaceContextMiddleware,
     add_fastapi_permission_middleware,
 )
-from mlflow_oidc_auth.oauth import ensure_oidc_client_registered
+from mlflow_oidc_auth.oauth import ensure_all_clients_registered
 from mlflow_oidc_auth.routers import ajax_alias_router, get_all_routers
 
 logger = get_logger()
@@ -57,12 +57,26 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Startup: Register OIDC client
     logger.info("Starting MLflow OIDC Auth Plugin...")
-    if ensure_oidc_client_registered():
+    # Every provider is registered independently, so one that is misconfigured or whose
+    # discovery document is unreachable does not disable login for the others (#315).
+    results = ensure_all_clients_registered()
+    registered = [provider_id for provider_id, ok in results.items() if ok]
+    failed = [provider_id for provider_id, ok in results.items() if not ok]
+
+    if registered:
         _oidc_initialized = True
-        logger.info("OIDC client successfully registered at startup")
-    else:
+        logger.info("OIDC client(s) successfully registered at startup: %s", ", ".join(sorted(registered)))
+    if failed:
         logger.warning(
-            "OIDC client registration failed at startup. "
+            "OIDC client registration failed at startup for: %s. "
+            "This may indicate missing configuration (OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL, "
+            "or OIDC_CLIENT_SECRET_<PROVIDER_ID> for an additional provider). "
+            "Those providers will not be available until configuration is corrected.",
+            ", ".join(sorted(failed)),
+        )
+    if not results:
+        logger.warning(
+            "No OIDC client was registered at startup. "
             "This may indicate missing configuration (OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_DISCOVERY_URL). "
             "OIDC authentication will not be available until configuration is corrected."
         )

--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -34,6 +34,11 @@ logger = get_logger()
 
 # Global flag to track OIDC initialization status for health checks
 _oidc_initialized: bool = False
+# Per-provider registration outcome from startup. ``_oidc_initialized`` answers the readiness
+# question — can this process serve a login at all — which stays True when one of several
+# providers failed, because failing the startup probe would pull the pod from service while it
+# can still authenticate everyone else. This dict is what says *which* ones are broken (#315).
+_oidc_provider_status: dict[str, bool] = {}
 
 
 def is_oidc_ready() -> bool:
@@ -45,6 +50,15 @@ def is_oidc_ready() -> bool:
     return _oidc_initialized
 
 
+def get_oidc_provider_status() -> dict[str, bool]:
+    """Per-provider registration outcome from startup.
+
+    ``is_oidc_ready()`` alone cannot express a partial failure, and with several providers a
+    partial failure is an expected state rather than an exceptional one.
+    """
+    return dict(_oidc_provider_status)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan context manager for startup/shutdown events.
@@ -53,13 +67,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     This is critical for multi-replica deployments where any replica may receive
     /callback or /logout requests that require the OIDC client to be registered.
     """
-    global _oidc_initialized
+    global _oidc_initialized, _oidc_provider_status
 
     # Startup: Register OIDC client
     logger.info("Starting MLflow OIDC Auth Plugin...")
     # Every provider is registered independently, so one that is misconfigured or whose
     # discovery document is unreachable does not disable login for the others (#315).
     results = ensure_all_clients_registered()
+    _oidc_provider_status = results
     registered = [provider_id for provider_id, ok in results.items() if ok]
     failed = [provider_id for provider_id, ok in results.items() if not ok]
 

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -1,23 +1,51 @@
-"""OAuth configuration for the FastAPI application.
+"""OAuth client registry for the FastAPI application.
 
 Unit tests expect the module attribute `oauth` to be an instance of
 `authlib.integrations.starlette_client.OAuth`.
 
-We keep OIDC client registration lazy so importing this module does not require
-OIDC configuration to be present (and does not perform network calls).
+Registration stays lazy so importing this module needs no OIDC configuration and performs no
+network calls.
+
+**One client per provider** (issue #315). Previously there was a single global client hardcoded
+as ``"oidc"`` with a one-shot registration flag, which cannot express more than one identity
+provider. Clients are now registered per provider id from the registry landed in #308.
+
+The legacy name is preserved deliberately: the ``default`` provider registers under the authlib
+name ``"oidc"``, so ``oauth.oidc`` keeps resolving for every existing call site and test. A
+deployment that configures no registry gets a synthesised ``default`` provider from the flat
+``OIDC_*`` variables, so nothing about its behaviour changes.
+
+Client secrets are **not** read from the registry. ``ProviderConfig`` has no secret field, on
+purpose: the registry is declarative configuration that may sit in a JSON file or an env var,
+and secrets belong in the secrets manager. Each additional provider takes its secret from
+``OIDC_CLIENT_SECRET_<PROVIDER_ID>`` resolved through the normal config chain, so the existing
+providers (Vault, AWS, Azure) keep working.
 """
 
 from __future__ import annotations
 
+import re
+from typing import Dict, Optional
+
 from authlib.integrations.starlette_client import OAuth
 
 from mlflow_oidc_auth.config import config
+from mlflow_oidc_auth.config_providers import config_manager
 from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.provider_registry import DEFAULT_PROVIDER_ID
 
 logger = get_logger()
 
+# The authlib client name the single-provider deployment has always used. Every existing call
+# site reaches the client as ``oauth.oidc``, so the default provider keeps this name rather than
+# being renamed to "default" — a rename would be a breaking change for no benefit.
+LEGACY_CLIENT_NAME = "oidc"
+
 oauth: OAuth = OAuth()
-_oidc_client_registered: bool = False
+
+# Registration state per provider id. A one-shot global flag could not express "provider A is
+# registered, provider B failed", which is the state that matters once there is more than one.
+_registered: Dict[str, bool] = {}
 
 
 def get_oauth() -> OAuth:
@@ -26,8 +54,44 @@ def get_oauth() -> OAuth:
     return oauth
 
 
+def client_name(provider_id: str) -> str:
+    """The authlib client name for a provider id.
+
+    ``default`` maps to ``"oidc"`` so ``oauth.oidc`` continues to resolve; every other provider
+    registers under its own id.
+    """
+
+    return LEGACY_CLIENT_NAME if provider_id == DEFAULT_PROVIDER_ID else provider_id
+
+
+def get_client(provider_id: str = DEFAULT_PROVIDER_ID):
+    """Return the registered client for ``provider_id``, or None if it is not registered."""
+
+    return getattr(oauth, client_name(provider_id), None)
+
+
 def _has_required_config() -> bool:
+    """Whether the flat ``OIDC_*`` variables describe a usable client."""
     return bool(config.OIDC_CLIENT_ID and config.OIDC_CLIENT_SECRET and config.OIDC_DISCOVERY_URL)
+
+
+def _secret_env_key(provider_id: str) -> str:
+    """Config key holding a provider's client secret.
+
+    ``okta-eu`` becomes ``OIDC_CLIENT_SECRET_OKTA_EU``. Anything outside ``A-Z0-9`` collapses to
+    an underscore so a provider id that is legal in JSON is still a legal environment variable
+    name.
+    """
+
+    return "OIDC_CLIENT_SECRET_" + re.sub(r"[^A-Z0-9]+", "_", provider_id.upper())
+
+
+def _client_secret_for(provider_id: str) -> Optional[str]:
+    """Resolve a provider's client secret through the config chain."""
+
+    if provider_id == DEFAULT_PROVIDER_ID:
+        return config.OIDC_CLIENT_SECRET
+    return config_manager.get(_secret_env_key(provider_id))
 
 
 def _build_scope() -> str:
@@ -50,48 +114,119 @@ def _build_scope() -> str:
     return " ".join(unique)
 
 
-def ensure_oidc_client_registered() -> bool:
-    """Ensure the 'oidc' client is registered.
+def _client_settings(provider_id: str) -> Optional[Dict[str, Optional[str]]]:
+    """Gather what authlib needs to register ``provider_id``, or None if it cannot be built.
 
-    Returns False if config is incomplete or registration fails.
+    The default provider falls back to the flat ``OIDC_*`` variables when the registry has no
+    entry for it, so a deployment that configures an explicit registry without a ``default``
+    entry still behaves exactly as it does today.
     """
 
-    global _oidc_client_registered
+    provider = config.AUTH_PROVIDERS.by_id(provider_id)
 
-    if _oidc_client_registered:
+    if provider is None:
+        if provider_id != DEFAULT_PROVIDER_ID or not _has_required_config():
+            return None
+        return {
+            "client_id": config.OIDC_CLIENT_ID,
+            "client_secret": config.OIDC_CLIENT_SECRET,
+            "server_metadata_url": config.OIDC_DISCOVERY_URL,
+        }
+
+    if provider.type != "oidc":
+        # SAML has no authlib OAuth client, and a Kubernetes issuer is verified from its JWKS
+        # rather than driven through an authorization flow.
+        return None
+
+    client_id = provider.client_id or (config.OIDC_CLIENT_ID if provider_id == DEFAULT_PROVIDER_ID else None)
+    discovery_url = provider.discovery_url or (config.OIDC_DISCOVERY_URL if provider_id == DEFAULT_PROVIDER_ID else None)
+    client_secret = _client_secret_for(provider_id)
+
+    if not (client_id and client_secret and discovery_url):
+        return None
+
+    return {"client_id": client_id, "client_secret": client_secret, "server_metadata_url": discovery_url}
+
+
+def ensure_client_registered(provider_id: str = DEFAULT_PROVIDER_ID) -> bool:
+    """Ensure the authlib client for ``provider_id`` is registered.
+
+    Args:
+        provider_id: Registry id of the provider. Defaults to ``default``, which is the
+            synthesised single provider a legacy deployment has.
+
+    Returns:
+        False when the provider is unknown, is not an OIDC provider, has incomplete
+        configuration, or registration raised. Never propagates: one misconfigured provider must
+        not stop the others from working, and must not take the application down at startup.
+    """
+
+    if _registered.get(provider_id):
         return True
 
-    if not _has_required_config():
+    settings = _client_settings(provider_id)
+    if settings is None:
         return False
 
     try:
         oauth.register(
-            name="oidc",
-            client_id=config.OIDC_CLIENT_ID,
-            client_secret=config.OIDC_CLIENT_SECRET,
-            server_metadata_url=config.OIDC_DISCOVERY_URL,
+            name=client_name(provider_id),
             client_kwargs={
                 "scope": _build_scope(),
                 "verify": config.OIDC_VERIFY_SSL,
                 "code_challenge_method": config.OIDC_CODE_CHALLENGE,
             },
+            **settings,
         )
-        _oidc_client_registered = True
+        _registered[provider_id] = True
         return True
     except Exception as exc:
-        logger.warning(f"Failed to register OIDC client: {exc}")
+        logger.warning(f"Failed to register OIDC client for provider '{provider_id}': {exc}")
         return False
 
 
-def is_oidc_configured() -> bool:
-    """Return True if OIDC config is present and the client is registered."""
+def ensure_all_clients_registered() -> Dict[str, bool]:
+    """Register every OIDC provider in the registry, independently.
 
-    return ensure_oidc_client_registered()
+    Each provider is attempted on its own, so one that is misconfigured or whose discovery
+    document is unreachable leaves the rest usable — with several providers the alternative
+    would be one bad entry disabling login for everyone.
+
+    Returns:
+        ``{provider_id: registered}`` for every OIDC provider found. Empty when the registry
+        holds none.
+    """
+
+    results: Dict[str, bool] = {}
+    for provider in config.AUTH_PROVIDERS.providers:
+        if provider.type != "oidc":
+            continue
+        results[provider.id] = ensure_client_registered(provider.id)
+    if not results and _has_required_config():
+        # No registry entries at all, but flat configuration is present: keep the legacy client.
+        results[DEFAULT_PROVIDER_ID] = ensure_client_registered(DEFAULT_PROVIDER_ID)
+    return results
+
+
+def ensure_oidc_client_registered() -> bool:
+    """Ensure the legacy ``oidc`` client is registered.
+
+    Kept as the name the application and its tests already use; it is now the ``default``
+    provider's registration.
+    """
+
+    return ensure_client_registered(DEFAULT_PROVIDER_ID)
+
+
+def is_oidc_configured(provider_id: str = DEFAULT_PROVIDER_ID) -> bool:
+    """Return True if the provider's config is present and its client is registered."""
+
+    return ensure_client_registered(provider_id)
 
 
 def reset_oauth() -> None:
-    """Reset the OAuth instance and registration state (primarily for tests)."""
+    """Reset the OAuth instance and all registration state (primarily for tests)."""
 
-    global oauth, _oidc_client_registered
+    global oauth
     oauth = OAuth()
-    _oidc_client_registered = False
+    _registered.clear()

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -86,6 +86,23 @@ def _secret_env_key(provider_id: str) -> str:
     return "OIDC_CLIENT_SECRET_" + re.sub(r"[^A-Z0-9]+", "_", provider_id.upper())
 
 
+def _colliding_secret_keys() -> Dict[str, list]:
+    """Provider ids that would share a client-secret key, grouped by that key.
+
+    ``_secret_env_key`` collapses runs of non-alphanumeric characters, so ``okta-eu`` and
+    ``okta_eu`` — both legal, distinct registry ids — resolve to the same variable. Registering
+    either would give one provider the other's client secret, and the failure would surface as
+    an opaque ``invalid_client`` from the IdP rather than as a configuration error.
+
+    Detected rather than silently resolved: with no way to tell which provider the operator
+    meant, refusing both is the only answer that cannot cross-wire a credential.
+    """
+    by_key: Dict[str, list] = {}
+    for provider in config.AUTH_PROVIDERS.providers:
+        by_key.setdefault(_secret_env_key(provider.id), []).append(provider.id)
+    return {key: ids for key, ids in by_key.items() if len(ids) > 1}
+
+
 def _client_secret_for(provider_id: str) -> Optional[str]:
     """Resolve a provider's client secret through the config chain."""
 
@@ -117,15 +134,30 @@ def _build_scope() -> str:
 def _client_settings(provider_id: str) -> Optional[Dict[str, Optional[str]]]:
     """Gather what authlib needs to register ``provider_id``, or None if it cannot be built.
 
-    The default provider falls back to the flat ``OIDC_*`` variables when the registry has no
-    entry for it, so a deployment that configures an explicit registry without a ``default``
-    entry still behaves exactly as it does today.
+    The default provider falls back to the flat ``OIDC_*`` variables only when no registry was
+    configured at all, so a legacy deployment is unaffected while an explicit registry that
+    omits an OIDC provider is honoured rather than overridden.
     """
+
+    colliding = _colliding_secret_keys()
+    for key, ids in colliding.items():
+        if provider_id in ids:
+            logger.error(
+                "Providers %s all resolve to the same client-secret key %s; refusing to register any of them, "
+                "because one would be given another's credential. Rename them so their ids differ by more than punctuation.",
+                ", ".join(sorted(ids)),
+                key,
+            )
+            return None
 
     provider = config.AUTH_PROVIDERS.by_id(provider_id)
 
     if provider is None:
-        if provider_id != DEFAULT_PROVIDER_ID or not _has_required_config():
+        # Falling back to the flat OIDC_* variables is only correct when no registry was
+        # configured at all. If the operator wrote a registry that omits an OIDC provider, that
+        # omission *is* the configuration — leftover OIDC_* variables from before the migration
+        # must not resurrect a browser login path they removed.
+        if provider_id != DEFAULT_PROVIDER_ID or config.AUTH_PROVIDERS.source != "legacy" or not _has_required_config():
             return None
         return {
             "client_id": config.OIDC_CLIENT_ID,
@@ -202,8 +234,10 @@ def ensure_all_clients_registered() -> Dict[str, bool]:
         if provider.type != "oidc":
             continue
         results[provider.id] = ensure_client_registered(provider.id)
-    if not results and _has_required_config():
-        # No registry entries at all, but flat configuration is present: keep the legacy client.
+    if not results and config.AUTH_PROVIDERS.source == "legacy" and _has_required_config():
+        # No registry configured at all, but flat configuration is present: keep the legacy
+        # client. Gated on the registry being the legacy shim rather than merely holding no
+        # OIDC entry, so an explicit registry that omits one is honoured (#347 review).
         results[DEFAULT_PROVIDER_ID] = ensure_client_registered(DEFAULT_PROVIDER_ID)
     return results
 

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -139,14 +139,15 @@ def _client_settings(provider_id: str) -> Optional[Dict[str, Optional[str]]]:
     omits an OIDC provider is honoured rather than overridden.
     """
 
-    colliding = _colliding_secret_keys()
-    for key, ids in colliding.items():
+    for ids in _colliding_secret_keys().values():
         if provider_id in ids:
+            # The derived key name is deliberately not logged. It is only a variable name, not a
+            # value, but it is taint-tracked from the secret accessor and CodeQL flags it as
+            # clear-text logging of a secret — and the provider ids alone are enough to act on.
             logger.error(
-                "Providers %s all resolve to the same client-secret key %s; refusing to register any of them, "
+                "Providers %s resolve to the same client-secret configuration key; refusing to register any of them, "
                 "because one would be given another's credential. Rename them so their ids differ by more than punctuation.",
                 ", ".join(sorted(ids)),
-                key,
             )
             return None
 

--- a/mlflow_oidc_auth/oauth.py
+++ b/mlflow_oidc_auth/oauth.py
@@ -139,17 +139,18 @@ def _client_settings(provider_id: str) -> Optional[Dict[str, Optional[str]]]:
     omits an OIDC provider is honoured rather than overridden.
     """
 
-    for ids in _colliding_secret_keys().values():
-        if provider_id in ids:
-            # The derived key name is deliberately not logged. It is only a variable name, not a
-            # value, but it is taint-tracked from the secret accessor and CodeQL flags it as
-            # clear-text logging of a secret — and the provider ids alone are enough to act on.
-            logger.error(
-                "Providers %s resolve to the same client-secret configuration key; refusing to register any of them, "
-                "because one would be given another's credential. Rename them so their ids differ by more than punctuation.",
-                ", ".join(sorted(ids)),
-            )
-            return None
+    if any(provider_id in ids for ids in _colliding_secret_keys().values()):
+        # Only ``provider_id`` — the plain argument — is logged. Neither the derived key nor the
+        # id list from _colliding_secret_keys() appears here: both are dataflow-tainted from the
+        # secret accessor, and CodeQL reports logging either as clear-text exposure of a secret.
+        # Nothing is lost, because this runs once per provider, so every colliding provider
+        # still names itself on its own line.
+        logger.error(
+            "Provider '%s' shares a client-secret configuration key with another provider; refusing to register it, "
+            "because one of them would be given the other's credential. Rename them so their ids differ by more than punctuation.",
+            provider_id,
+        )
+        return None
 
     provider = config.AUTH_PROVIDERS.by_id(provider_id)
 

--- a/mlflow_oidc_auth/routers/health.py
+++ b/mlflow_oidc_auth/routers/health.py
@@ -110,12 +110,15 @@ async def health_check_startup() -> JSONResponse:
     Returns:
         200 if startup complete, 503 if still initializing or failed.
     """
-    from mlflow_oidc_auth.app import is_oidc_ready
+    from mlflow_oidc_auth.app import get_oidc_provider_status, is_oidc_ready
 
     oidc_ready = is_oidc_ready()
+    # Reported alongside the boolean because "ready" only means at least one provider works.
+    # Without this, a deployment with one broken provider looks entirely healthy (#315).
+    providers = get_oidc_provider_status()
 
     if oidc_ready:
-        return JSONResponse(content={"status": "started", "oidc_initialized": True})
+        return JSONResponse(content={"status": "started", "oidc_initialized": True, "providers": providers})
     else:
         # OIDC not initialized - might be missing config or startup in progress
         # Return 503 so Kubernetes knows startup is not complete
@@ -124,6 +127,7 @@ async def health_check_startup() -> JSONResponse:
             content={
                 "status": "initializing",
                 "oidc_initialized": False,
+                "providers": providers,
                 "message": "OIDC client not yet initialized. Check OIDC configuration.",
             },
         )

--- a/mlflow_oidc_auth/tests/test_oauth.py
+++ b/mlflow_oidc_auth/tests/test_oauth.py
@@ -496,8 +496,12 @@ class TestOidcClientRegistrationKwargs(unittest.TestCase):
         import mlflow_oidc_auth.oauth as oauth_mod
 
         with (
-            patch.object(oauth_mod, "_oidc_client_registered", False),
+            # Registration state is now per provider id rather than one global flag (#315).
+            patch.object(oauth_mod, "_registered", {}),
             patch.object(oauth_mod, "_has_required_config", return_value=True),
+            patch.object(
+                oauth_mod, "_client_settings", return_value={"client_id": "id", "client_secret": "s", "server_metadata_url": "https://idp/.well-known"}
+            ),
             patch.object(oauth_mod, "_build_scope", return_value="openid email"),
             patch.object(oauth_mod.oauth, "register") as mock_register,
             patch.object(oauth_mod.config, "OIDC_VERIFY_SSL", False),

--- a/mlflow_oidc_auth/tests/test_oauth_registry.py
+++ b/mlflow_oidc_auth/tests/test_oauth_registry.py
@@ -1,0 +1,200 @@
+"""One OAuth client per provider (issue #315).
+
+There used to be a single global client hardcoded as ``"oidc"`` behind a one-shot registration
+flag, which cannot express more than one identity provider — and, more subtly, cannot express
+"provider A registered, provider B failed", which is the state that matters once there are two.
+
+What these tests defend:
+
+* the legacy deployment is untouched — ``oauth.oidc`` still resolves, because ``default`` keeps
+  that authlib name;
+* providers register independently, so one bad entry does not disable login for everyone;
+* secrets come from the config chain, never from the registry JSON.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import mlflow_oidc_auth.oauth as oauth_mod
+from mlflow_oidc_auth.provider_registry import DEFAULT_PROVIDER_ID, ProviderConfig, RegistryLoadResult
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Every test starts with an empty authlib registry and no registration state."""
+    oauth_mod.reset_oauth()
+    yield
+    oauth_mod.reset_oauth()
+
+
+def provider(provider_id: str, **kwargs) -> ProviderConfig:
+    defaults = {
+        "audience": "mlflow",
+        "client_id": f"{provider_id}-client",
+        "discovery_url": f"https://{provider_id}.example.com/.well-known/openid-configuration",
+    }
+    defaults.update(kwargs)
+    return ProviderConfig(id=provider_id, **defaults)
+
+
+def with_registry(*providers):
+    """Patch the config registry with the given providers."""
+    return patch.object(oauth_mod.config, "AUTH_PROVIDERS", RegistryLoadResult(providers=list(providers), source="env"))
+
+
+def with_secrets(**secrets):
+    """Patch the config chain so per-provider secrets resolve."""
+    return patch.object(oauth_mod.config_manager, "get", lambda key, default=None: secrets.get(key, default))
+
+
+class TestLegacyDeploymentIsUnchanged:
+    def test_the_default_provider_registers_under_the_name_oidc(self):
+        """Every existing call site reaches the client as ``oauth.oidc``; renaming it to
+        ``default`` would be a breaking change for no benefit."""
+        assert oauth_mod.client_name(DEFAULT_PROVIDER_ID) == "oidc"
+
+    def test_another_provider_registers_under_its_own_id(self):
+        assert oauth_mod.client_name("okta") == "okta"
+
+    def test_flat_config_alone_still_registers(self):
+        """No registry entry at all, just the flat OIDC_* variables — exactly today's
+        deployment."""
+        with (
+            with_registry(),
+            patch.object(oauth_mod.config, "OIDC_CLIENT_ID", "id"),
+            patch.object(oauth_mod.config, "OIDC_CLIENT_SECRET", "secret"),
+            patch.object(oauth_mod.config, "OIDC_DISCOVERY_URL", "https://idp.example.com/.well-known/openid-configuration"),
+        ):
+            assert oauth_mod.ensure_oidc_client_registered() is True
+
+        assert oauth_mod.get_client() is not None
+        assert getattr(oauth_mod.oauth, "oidc", None) is not None
+
+    def test_registration_is_idempotent(self):
+        with (
+            with_registry(provider(DEFAULT_PROVIDER_ID)),
+            with_secrets(),
+            patch.object(oauth_mod.config, "OIDC_CLIENT_SECRET", "secret"),
+            patch.object(oauth_mod.oauth, "register") as register,
+        ):
+            assert oauth_mod.ensure_client_registered(DEFAULT_PROVIDER_ID) is True
+            assert oauth_mod.ensure_client_registered(DEFAULT_PROVIDER_ID) is True
+
+        assert register.call_count == 1, "a second call must not re-register"
+
+
+class TestMultipleProviders:
+    def test_each_provider_registers_independently(self):
+        with (
+            with_registry(provider("okta"), provider("entra")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1", OIDC_CLIENT_SECRET_ENTRA="s2"),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta": True, "entra": True}
+        assert oauth_mod.get_client("okta") is not None
+        assert oauth_mod.get_client("entra") is not None
+
+    def test_one_failing_provider_does_not_break_the_others(self):
+        """The acceptance criterion. With several providers, one unreachable discovery document
+        must not disable login for everyone."""
+        real_register = oauth_mod.oauth.register
+
+        def register(name, **kwargs):
+            if name == "broken":
+                raise RuntimeError("discovery document unreachable")
+            return real_register(name, **kwargs)
+
+        with (
+            with_registry(provider("okta"), provider("broken"), provider("entra")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1", OIDC_CLIENT_SECRET_BROKEN="s2", OIDC_CLIENT_SECRET_ENTRA="s3"),
+            patch.object(oauth_mod.oauth, "register", side_effect=register),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta": True, "broken": False, "entra": True}
+
+    def test_a_provider_with_no_secret_is_skipped_not_raised(self):
+        with (
+            with_registry(provider("okta"), provider("nosecret")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1"),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta": True, "nosecret": False}
+        assert oauth_mod.get_client("nosecret") is None
+
+    def test_non_oidc_providers_are_not_registered(self):
+        """SAML has no authlib OAuth client, and a Kubernetes issuer is verified from its JWKS
+        rather than driven through an authorization flow."""
+        with (
+            with_registry(provider("okta"), provider("cluster", type="k8s", interactive=False)),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1", OIDC_CLIENT_SECRET_CLUSTER="s2"),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta": True}
+
+    def test_an_unknown_provider_id_is_false_not_an_error(self):
+        with with_registry(provider("okta")), with_secrets(OIDC_CLIENT_SECRET_OKTA="s1"):
+            assert oauth_mod.ensure_client_registered("nope") is False
+
+    def test_registration_state_is_per_provider(self):
+        """A single global flag could not express "A registered, B failed" — which is the only
+        state that matters once there is more than one provider."""
+        with (
+            with_registry(provider("okta"), provider("nosecret")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1"),
+        ):
+            oauth_mod.ensure_all_clients_registered()
+
+            assert oauth_mod.ensure_client_registered("okta") is True
+            assert oauth_mod.ensure_client_registered("nosecret") is False
+
+
+class TestSecretsComeFromTheConfigChain:
+    """``ProviderConfig`` has no secret field on purpose: the registry is declarative config that
+    may live in a JSON file or an env var, and secrets belong in the secrets manager."""
+
+    @pytest.mark.parametrize(
+        "provider_id,expected_key",
+        [("okta", "OIDC_CLIENT_SECRET_OKTA"), ("okta-eu", "OIDC_CLIENT_SECRET_OKTA_EU"), ("entra.prod", "OIDC_CLIENT_SECRET_ENTRA_PROD")],
+    )
+    def test_the_secret_key_is_derived_from_the_provider_id(self, provider_id, expected_key):
+        """A provider id that is legal in JSON has to become a legal environment variable name."""
+        assert oauth_mod._secret_env_key(provider_id) == expected_key
+
+    def test_the_default_provider_uses_the_flat_secret(self):
+        with patch.object(oauth_mod.config, "OIDC_CLIENT_SECRET", "flat-secret"):
+            assert oauth_mod._client_secret_for(DEFAULT_PROVIDER_ID) == "flat-secret"
+
+    def test_the_secret_reaches_the_registered_client(self):
+        with (
+            with_registry(provider("okta")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="from-secrets-manager"),
+            patch.object(oauth_mod.oauth, "register") as register,
+        ):
+            oauth_mod.ensure_client_registered("okta")
+
+        assert register.call_args.kwargs["client_secret"] == "from-secrets-manager"
+
+    def test_the_registry_never_supplies_the_secret(self):
+        """Guards the design decision rather than an outcome: if someone later adds a
+        ``client_secret`` field to ProviderConfig, this is where it should be noticed."""
+        assert not hasattr(provider("okta"), "client_secret")
+
+
+class TestReset:
+    def test_reset_clears_clients_and_state(self):
+        with (
+            with_registry(provider("okta")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA="s1"),
+        ):
+            oauth_mod.ensure_client_registered("okta")
+            assert oauth_mod.get_client("okta") is not None
+
+            oauth_mod.reset_oauth()
+
+            assert oauth_mod.get_client("okta") is None
+            assert oauth_mod._registered == {}

--- a/mlflow_oidc_auth/tests/test_oauth_registry.py
+++ b/mlflow_oidc_auth/tests/test_oauth_registry.py
@@ -12,6 +12,7 @@ What these tests defend:
 * secrets come from the config chain, never from the registry JSON.
 """
 
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -58,10 +59,14 @@ class TestLegacyDeploymentIsUnchanged:
         assert oauth_mod.client_name("okta") == "okta"
 
     def test_flat_config_alone_still_registers(self):
-        """No registry entry at all, just the flat OIDC_* variables — exactly today's
-        deployment."""
+        """No registry configured, just the flat OIDC_* variables — exactly today's deployment.
+
+        ``source="legacy"`` is what "no registry configured" looks like; an *empty* registry with
+        ``source="env"`` means the operator wrote one and left it empty, which is a different
+        statement and is covered by TestAnExplicitRegistryIsNotOverridden.
+        """
         with (
-            with_registry(),
+            patch.object(oauth_mod.config, "AUTH_PROVIDERS", RegistryLoadResult(providers=[], source="legacy")),
             patch.object(oauth_mod.config, "OIDC_CLIENT_ID", "id"),
             patch.object(oauth_mod.config, "OIDC_CLIENT_SECRET", "secret"),
             patch.object(oauth_mod.config, "OIDC_DISCOVERY_URL", "https://idp.example.com/.well-known/openid-configuration"),
@@ -183,6 +188,102 @@ class TestSecretsComeFromTheConfigChain:
         """Guards the design decision rather than an outcome: if someone later adds a
         ``client_secret`` field to ProviderConfig, this is where it should be noticed."""
         assert not hasattr(provider("okta"), "client_secret")
+
+
+class TestAnExplicitRegistryIsNotOverridden:
+    """The registry is the operator's statement of which providers exist.
+
+    Leftover ``OIDC_*`` variables are the normal state after migrating to a registry, and must
+    not resurrect a browser login path the operator removed. Raised in review of #347.
+    """
+
+    def _flat_config(self, stack: ExitStack) -> None:
+        """Leftover flat variables, as they sit in the environment after a registry migration."""
+        stack.enter_context(patch.object(oauth_mod.config, "OIDC_CLIENT_ID", "legacy-id"))
+        stack.enter_context(patch.object(oauth_mod.config, "OIDC_CLIENT_SECRET", "legacy-secret"))
+        stack.enter_context(patch.object(oauth_mod.config, "OIDC_DISCOVERY_URL", "https://old-idp.example.com/.well-known/openid-configuration"))
+
+    def test_a_registry_with_no_oidc_provider_does_not_get_the_legacy_client(self):
+        """Machine-only deployment: a k8s provider and nothing else. The old flat variables are
+        still in the environment, and must stay inert."""
+        k8s = ProviderConfig(id="cluster", type="k8s", audience="a", interactive=False)
+        with ExitStack() as stack:
+            stack.enter_context(with_registry(k8s))
+            self._flat_config(stack)
+
+            results = oauth_mod.ensure_all_clients_registered()
+
+            assert results == {}
+            assert oauth_mod.get_client() is None
+            assert getattr(oauth_mod.oauth, "oidc", None) is None
+
+    def test_the_same_holds_for_a_direct_registration_call(self):
+        """``is_oidc_configured()`` reaches this path without going through
+        ``ensure_all_clients_registered``, so gating only the latter would leave the hole open."""
+        k8s = ProviderConfig(id="cluster", type="k8s", audience="a", interactive=False)
+        with ExitStack() as stack:
+            stack.enter_context(with_registry(k8s))
+            self._flat_config(stack)
+
+            assert oauth_mod.ensure_oidc_client_registered() is False
+            assert oauth_mod.is_oidc_configured() is False
+
+    def test_an_explicitly_empty_registry_does_not_get_the_legacy_client(self):
+        with ExitStack() as stack:
+            stack.enter_context(with_registry())
+            self._flat_config(stack)
+
+            assert oauth_mod.ensure_all_clients_registered() == {}
+
+    def test_a_legacy_deployment_still_gets_it(self):
+        """source='legacy' means no registry was configured at all — the case the fallback is
+        actually for."""
+        registry = RegistryLoadResult(providers=[], source="legacy")
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(oauth_mod.config, "AUTH_PROVIDERS", registry))
+            self._flat_config(stack)
+
+            assert oauth_mod.ensure_all_clients_registered() == {DEFAULT_PROVIDER_ID: True}
+
+
+class TestCollidingSecretKeys:
+    """Two legal ids resolving to one secret key would cross-wire credentials.
+
+    The failure would surface as an opaque ``invalid_client`` from the IdP rather than as a
+    configuration error. Raised in review of #347.
+    """
+
+    def test_colliding_providers_are_both_refused(self):
+        """Refused rather than resolved: with no way to tell which provider the operator meant,
+        registering either one risks giving it the other's secret."""
+        with (
+            with_registry(provider("okta-eu"), provider("okta_eu")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA_EU="shared"),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta-eu": False, "okta_eu": False}
+        assert oauth_mod.get_client("okta-eu") is None
+        assert oauth_mod.get_client("okta_eu") is None
+
+    def test_a_non_colliding_provider_alongside_them_still_registers(self):
+        """One bad pair must not disable an unrelated provider."""
+        with (
+            with_registry(provider("okta-eu"), provider("okta_eu"), provider("entra")),
+            with_secrets(OIDC_CLIENT_SECRET_OKTA_EU="shared", OIDC_CLIENT_SECRET_ENTRA="s"),
+        ):
+            results = oauth_mod.ensure_all_clients_registered()
+
+        assert results == {"okta-eu": False, "okta_eu": False, "entra": True}
+
+    @pytest.mark.parametrize("second_id", ["okta_eu", "okta.eu", "okta--eu"])
+    def test_punctuation_variants_all_collide(self, second_id):
+        with with_registry(provider("okta-eu"), provider(second_id)), with_secrets():
+            assert set(oauth_mod._colliding_secret_keys()) == {"OIDC_CLIENT_SECRET_OKTA_EU"}
+
+    def test_distinct_ids_do_not_collide(self):
+        with with_registry(provider("okta"), provider("entra")), with_secrets():
+            assert oauth_mod._colliding_secret_keys() == {}
 
 
 class TestReset:


### PR DESCRIPTION
Closes #315.

`oauth.py` held a single global authlib client hardcoded as `"oidc"` behind a one-shot
`_oidc_client_registered` flag. That cannot express more than one identity provider — and, more
subtly, cannot express *"provider A registered, provider B failed"*, which is the only state that
matters once there are two.

## What changed

Clients are registered **per provider id**, from the registry landed in #308, with per-provider
state instead of one global flag.

**The legacy name is preserved deliberately.** The `default` provider registers under the authlib
name `"oidc"`, so `oauth.oidc` keeps resolving for every existing call site in `routers/auth.py`
and every test that patches it. Renaming it to `default` would have been a breaking change for no
benefit. A deployment that configures no registry gets the synthesised `default` provider from
the flat `OIDC_*` variables, so nothing about it changes.

```python
ensure_all_clients_registered()   # -> {"okta": True, "broken": False, "entra": True}
```

Each provider is attempted on its own, so one unreachable discovery document does not disable
login for everyone — with several providers, the alternative is one bad entry taking down
authentication for all of them. Startup now logs which registered and which did not, naming them.

## Secrets stay out of the registry

`ProviderConfig` has no `client_secret` field, on purpose: the registry is declarative
configuration that may sit in a JSON file or an environment variable. Additional providers take
their secret from `OIDC_CLIENT_SECRET_<PROVIDER_ID>` resolved through the normal config chain, so
Vault, AWS Secrets Manager and Azure Key Vault keep working. `okta-eu` becomes
`OIDC_CLIENT_SECRET_OKTA_EU` — a provider id that is legal in JSON has to become a legal
environment variable name.

The `default` provider continues to read `OIDC_CLIENT_SECRET`, unchanged.

SAML and `k8s` providers are skipped: neither is driven through an authorization flow.

## Tests

`mlflow_oidc_auth/tests/test_oauth_registry.py` — 17 tests:

- the legacy path: `default` → name `"oidc"`, flat config alone still registers, and registration
  is idempotent (a second call does not re-register);
- **one failing provider does not break the others** — the acceptance criterion, driven by making
  one `register()` raise and asserting the other two still come up;
- a provider with no secret is skipped rather than raising, and an unknown id returns False;
- registration state is genuinely per provider;
- the secret reaches the client from the config chain, and the key derivation handles ids with
  `-` and `.`;
- a guard asserting `ProviderConfig` still has no `client_secret`, so if someone later adds one
  this is where it gets noticed.

**Existing tests: 111 passed untouched.** One changed — it patched the removed
`_oidc_client_registered` global and now patches the per-provider state, which is exactly the
"`default` indirection changed" the issue allows.

## No migration needed

I checked for ORM/migration drift before starting, since several recent PRs added columns:
`compare_metadata` reports 36 differences, **0 of which touch anything added in this epic**, and
the same 36 appear at `d1d44ef` — the commit before any of this work. The drift is pre-existing
(32 `modify_nullable` where models declare NOT NULL but the migrations created the columns
nullable, plus 4 unique-constraint naming mismatches on the workspace regex tables). Worth its own
issue; not touched here.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 3102 passed (x2 runs)
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 budget intact
python -m pyflakes mlflow_oidc_auth/oauth.py      # clean
```

Two pyflakes warnings remain in `app.py` (`typing.Any` unused, `app` redefined). Both are
pre-existing — confirmed identical at `HEAD` — and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
