### PR TITLE
fix(auth): report a deleted user's denial as deletion, and pin it per surface (#306)

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -8,8 +8,10 @@ Authorization (what the user can do) is handled by RBACMiddleware.
 
 from typing import Optional, Tuple
 import base64
+import threading
 import time
 
+from cachetools import TTLCache
 from fastapi import Request, Response
 from fastapi.responses import RedirectResponse, JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -41,6 +43,34 @@ DENIAL_AUDIT_EVENTS = {
     DENIAL_INACTIVE: "auth.denied_inactive",
     DENIAL_LOOKUP_ERROR: "auth.denied_lookup_error",
 }
+
+# A revoked-but-unexpired cookie keeps arriving: a browser tab left open on the SPA issues
+# subresource fetches, polls and telemetry until the cookie expires, and each one is denied. One
+# audit event per request would let a single stale session write thousands of identical entries,
+# burying real events — and would let anyone holding such a cookie dilute the forensic record
+# deliberately. So the *first* denial for a (username, reason) is recorded and repeats within the
+# window are suppressed; the denial itself still happens every time and is still visible in the
+# request log.
+#
+# Bounded as well as time-limited: an attacker rotating usernames must not be able to grow this
+# without limit. Eviction only costs a duplicate audit entry, never a missed denial.
+DENIAL_AUDIT_WINDOW_SECONDS = 60
+_denial_audit_seen: TTLCache = TTLCache(maxsize=1024, ttl=DENIAL_AUDIT_WINDOW_SECONDS)
+_denial_audit_lock = threading.Lock()
+
+
+def _should_audit_denial(username: str, reason: str) -> bool:
+    """Whether this denial is the first of its kind within the window.
+
+    Thread-safe: several ASGI worker threads can be denying the same stale session at once, and
+    ``TTLCache`` is not itself synchronised.
+    """
+    key = (username, reason)
+    with _denial_audit_lock:
+        if key in _denial_audit_seen:
+            return False
+        _denial_audit_seen[key] = True
+        return True
 
 
 def normalize_workspace_header(raw_workspace: Optional[str]) -> Optional[str]:
@@ -327,9 +357,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
             username: Username to check
 
         Returns:
-            True if user is admin, False otherwise
+            True only if the user is an administrator **and** may authenticate. A deactivated or
+            deleted admin returns False: the raw flag is preserved inside
+            :meth:`_get_user_auth_state` so the denial path can report accurately, but a method
+            named "is this an admin" must never answer True for an account that is being turned
+            away (issue #306 review).
         """
-        return self._get_user_auth_state(username)[0]
+        is_admin, is_active, _ = self._get_user_auth_state(username)
+        return is_admin and is_active
 
     def _get_user_auth_state(self, username: str) -> Tuple[bool, bool, str]:
         """Read the facts the auth path needs about a user, in one lookup.
@@ -357,7 +392,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 # Routine, not exceptional: the account was deleted while its signed cookie was
                 # still valid. The browser will keep presenting it until the cookie expires, so
                 # logging this at ERROR would fill the log with something nobody can act on.
-                logger.info("Denying %s: the account no longer exists", username)
+                # Not logged here at all — ``dispatch`` logs the denial once, with the path and
+                # the reason, and two lines per request is twice the volume for one event.
                 return False, False, DENIAL_UNKNOWN_USER
             logger.error("Error reading auth state for %s: %s", username, e)
             return False, False, DENIAL_LOOKUP_ERROR
@@ -438,13 +474,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # path, rather than left to downstream permission checks (issue #311).
             if not is_active:
                 logger.info("Authentication denied for %s on %s (%s)", username, path, denial_reason)
-                emit_audit_event(
-                    DENIAL_AUDIT_EVENTS.get(denial_reason, DENIAL_AUDIT_EVENTS[DENIAL_LOOKUP_ERROR]),
-                    actor=username,
-                    resource_type="user",
-                    resource_id=username,
-                    status="denied",
-                )
+                if _should_audit_denial(username, denial_reason):
+                    emit_audit_event(
+                        DENIAL_AUDIT_EVENTS.get(denial_reason, DENIAL_AUDIT_EVENTS[DENIAL_LOOKUP_ERROR]),
+                        actor=username,
+                        resource_type="user",
+                        resource_id=username,
+                        status="denied",
+                    )
                 return await self._deny(request, path)
 
             # Set user context in request state for downstream middleware/handlers

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -19,12 +19,28 @@ from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.routers._prefix import API_PATH_PREFIXES
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+
 from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.auth import validate_token
 from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils.oidc_field_extraction import extract_username, extract_display_name, BEARER_TOKEN_SOURCE
 
 logger = get_logger()
+
+# Why an authenticated-looking request was turned away. Reported separately because a deleted
+# account and a deactivated one are different operational events, and an operator reading the
+# audit log should not have to guess which happened (issue #306).
+DENIAL_UNKNOWN_USER = "unknown_user"
+DENIAL_INACTIVE = "inactive"
+DENIAL_LOOKUP_ERROR = "lookup_error"
+
+DENIAL_AUDIT_EVENTS = {
+    DENIAL_UNKNOWN_USER: "auth.denied_unknown_user",
+    DENIAL_INACTIVE: "auth.denied_inactive",
+    DENIAL_LOOKUP_ERROR: "auth.denied_lookup_error",
+}
 
 
 def normalize_workspace_header(raw_workspace: Optional[str]) -> Optional[str]:
@@ -315,30 +331,45 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         return self._get_user_auth_state(username)[0]
 
-    def _get_user_auth_state(self, username: str) -> Tuple[bool, bool]:
-        """Read the two facts the auth path needs about a user, in one lookup.
+    def _get_user_auth_state(self, username: str) -> Tuple[bool, bool, str]:
+        """Read the facts the auth path needs about a user, in one lookup.
 
-        Both come off the profile row that is already fetched on every authenticated request,
-        so ``active`` costs nothing: it is in the ``load_only`` list added by #333, and the
+        All come off the profile row that is already fetched on every authenticated request, so
+        ``active`` costs nothing: it is in the ``load_only`` list added by #333, and the
         per-request statement count stays at the #305 budget of 2.
 
         Args:
             username: Username to check
 
         Returns:
-            ``(is_admin, is_active)``. On any failure — including the user no longer existing —
-            returns ``(False, False)``: an account that cannot be read is not an account that
-            may authenticate. Erring the other way would let a lookup error grant access, which
-            is the fallback this repository forbids.
+            ``(is_admin, is_active, denial_reason)``. ``denial_reason`` is ``""`` when the user
+            may authenticate, and otherwise names why not, so the caller can report a deleted
+            account differently from a deactivated one (issue #306).
+
+            Any failure yields ``(False, False, ...)``: an account that cannot be read is not an
+            account that may authenticate. Erring the other way would let a lookup error grant
+            access, which is the fallback this repository forbids.
         """
         try:
             user = store.get_user_profile(username)
-            if not user:
-                return False, False
-            return bool(user.is_admin), bool(user.active)
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                # Routine, not exceptional: the account was deleted while its signed cookie was
+                # still valid. The browser will keep presenting it until the cookie expires, so
+                # logging this at ERROR would fill the log with something nobody can act on.
+                logger.info("Denying %s: the account no longer exists", username)
+                return False, False, DENIAL_UNKNOWN_USER
+            logger.error("Error reading auth state for %s: %s", username, e)
+            return False, False, DENIAL_LOOKUP_ERROR
         except Exception as e:
-            logger.error(f"Error reading auth state for {username}: {e}")
-            return False, False
+            logger.error("Error reading auth state for %s: %s", username, e)
+            return False, False, DENIAL_LOOKUP_ERROR
+
+        if not user:
+            return False, False, DENIAL_UNKNOWN_USER
+        if not user.active:
+            return bool(user.is_admin), False, DENIAL_INACTIVE
+        return bool(user.is_admin), True, ""
 
     async def _handle_auth_redirect(self, request: Request) -> Response:
         """
@@ -398,7 +429,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         is_authenticated, username, error_msg = await self._authenticate_user(request)
 
         if is_authenticated and username:
-            is_admin, is_active = self._get_user_auth_state(username)
+            is_admin, is_active, denial_reason = self._get_user_auth_state(username)
 
             # A deprovisioned user holds a signed cookie or a valid token that has not expired
             # yet, so credentials alone still check out. Directories deactivate rather than
@@ -406,9 +437,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # deprovisioned account actually lands in — it has to be denied here, on every
             # path, rather than left to downstream permission checks (issue #311).
             if not is_active:
-                logger.info("Authentication denied for inactive user %s on %s", username, path)
+                logger.info("Authentication denied for %s on %s (%s)", username, path, denial_reason)
                 emit_audit_event(
-                    "auth.denied_inactive",
+                    DENIAL_AUDIT_EVENTS.get(denial_reason, DENIAL_AUDIT_EVENTS[DENIAL_LOOKUP_ERROR]),
                     actor=username,
                     resource_type="user",
                     resource_id=username,

--- a/mlflow_oidc_auth/tests/test_deleted_user_session.py
+++ b/mlflow_oidc_auth/tests/test_deleted_user_session.py
@@ -26,6 +26,7 @@ from fastapi.testclient import TestClient
 from flask import Flask
 from starlette.middleware.sessions import SessionMiddleware
 
+import mlflow_oidc_auth.middleware.auth_middleware as auth_middleware_module
 import mlflow_oidc_auth.store as store_module
 from mlflow_oidc_auth.middleware import AuthAwareWSGIMiddleware, AuthMiddleware
 
@@ -37,6 +38,19 @@ LOGIN = "/login/probe"
 FASTAPI_ROUTE = "/oidc/api/probe"
 FLASK_ROUTE = "/api/2.0/mlflow/experiments/probe"
 GRAPHQL_ROUTE = "/graphql"
+
+
+@pytest.fixture(autouse=True)
+def clear_denial_audit_throttle():
+    """Reset the module-level denial-audit window between tests.
+
+    It is deliberately process-wide state, so without this a denial recorded by one test
+    suppresses the audit event another test asserts on — and the failure looks like a missing
+    event rather than leftover state.
+    """
+    auth_middleware_module._denial_audit_seen.clear()
+    yield
+    auth_middleware_module._denial_audit_seen.clear()
 
 
 @pytest.fixture
@@ -164,6 +178,112 @@ class TestDeletedUserIsDeniedOnEverySurface:
         store.create_user("gone@example.com", PASSWORD, "Gone Again")
 
         assert client.get(FASTAPI_ROUTE).status_code == 200
+
+
+class TestDenialAuditIsThrottled:
+    """A revoked cookie keeps arriving, and one audit event per request would let a single stale
+    session bury the forensic record — or let someone holding such a cookie dilute it on purpose.
+    Raised in review of #348.
+    """
+
+    def _deny_repeatedly(self, store, client, monkeypatch, username, times):
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+        client.get(LOGIN, params={"username": username})
+        store.delete_user(username)
+        for _ in range(times):
+            assert client.get(FASTAPI_ROUTE).status_code == 401
+        return events
+
+    def test_repeated_denials_audit_once(self, store, client, monkeypatch):
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+
+        events = self._deny_repeatedly(store, client, monkeypatch, "gone@example.com", times=25)
+
+        assert len(events) == 1, f"expected one audit event for 25 denials, got {len(events)}"
+
+    def test_every_request_is_still_denied(self, store, client, monkeypatch):
+        """Throttling the record must never throttle the decision."""
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        self._deny_repeatedly(store, client, monkeypatch, "gone@example.com", times=5)
+
+        assert client.get(FASTAPI_ROUTE).status_code == 401
+
+    def test_a_different_user_is_audited_separately(self, store, client, monkeypatch):
+        """Suppression is per (username, reason); one noisy session must not hide another."""
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+        for name in ("a@example.com", "b@example.com"):
+            store.create_user(name, PASSWORD, name)
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+
+        for name in ("a@example.com", "b@example.com"):
+            client.get(LOGIN, params={"username": name})
+            store.delete_user(name)
+            client.get(FASTAPI_ROUTE)
+            client.get(FASTAPI_ROUTE)
+
+        assert sorted(kwargs["actor"] for _, kwargs in events) == ["a@example.com", "b@example.com"]
+
+    def test_a_different_reason_for_the_same_user_is_audited_separately(self, store, client, monkeypatch):
+        """Deactivated then deleted is two distinct events about one account."""
+        from sqlalchemy import text
+
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append(event),
+        )
+        store.create_user("x@example.com", PASSWORD, "X")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "x@example.com"})
+
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0 WHERE username = 'x@example.com'"))
+        client.get(FASTAPI_ROUTE)
+        store.delete_user("x@example.com")
+        client.get(FASTAPI_ROUTE)
+
+        assert events == ["auth.denied_inactive", "auth.denied_unknown_user"]
+
+    def test_the_throttle_cache_is_bounded(self):
+        """An attacker rotating usernames must not grow this without limit; evicting only ever
+        costs a duplicate audit entry, never a missed denial."""
+        assert auth_middleware_module._denial_audit_seen.maxsize <= 4096
+
+
+class TestAdminStatusShim:
+    def test_an_inactive_admin_is_not_reported_as_admin(self, store):
+        """A method named "is this an admin" must not answer True for an account being turned
+        away — these are exactly the deprovisioned admins #311 exists to shut out."""
+        from sqlalchemy import text
+
+        middleware = AuthMiddleware.__new__(AuthMiddleware)
+        store.create_user("adm@example.com", PASSWORD, "Adm", is_admin=True)
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        assert middleware._get_user_admin_status("adm@example.com") is True
+
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0 WHERE username = 'adm@example.com'"))
+
+        assert middleware._get_user_admin_status("adm@example.com") is False
+
+    def test_a_deleted_admin_is_not_reported_as_admin(self, store):
+        middleware = AuthMiddleware.__new__(AuthMiddleware)
+        store.create_user("adm@example.com", PASSWORD, "Adm", is_admin=True)
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+
+        store.delete_user("adm@example.com")
+
+        assert middleware._get_user_admin_status("adm@example.com") is False
 
 
 class TestDenialIsReportedAsDeletion:

--- a/mlflow_oidc_auth/tests/test_deleted_user_session.py
+++ b/mlflow_oidc_auth/tests/test_deleted_user_session.py
@@ -1,0 +1,228 @@
+"""A deleted user's session must not authenticate, on any surface (issue #306).
+
+`_authenticate_session` authenticates purely from ``session["username"]`` in the signed cookie —
+nothing there verifies the user still exists. The suspicion was that a user deleted mid-session
+still passed the authentication middleware, merely downgraded to non-admin, leaving only
+downstream permission checks between them and the application.
+
+**Result: the gap was real and is now closed.** The `active` check added by #311 reads the user's
+profile on every authenticated request, and a deleted user cannot be read — so the request is
+denied before it reaches any surface, rather than proceeding as a non-admin.
+
+These tests pin that for each surface the issue names, because the fix lives in one place and a
+future refactor could easily restore the old behaviour for some of them:
+
+* a FastAPI route (the permission-management API),
+* a Flask route reached through ``AuthAwareWSGIMiddleware`` (MLflow's own API),
+* ``/graphql``, which is a Flask route on the same mount.
+
+All three sit behind ``AuthMiddleware``, which `app.py` adds before mounting Flask at ``/``, so
+one denial covers them — but that is a structural claim, and this file is the evidence.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from flask import Flask
+from starlette.middleware.sessions import SessionMiddleware
+
+import mlflow_oidc_auth.store as store_module
+from mlflow_oidc_auth.middleware import AuthAwareWSGIMiddleware, AuthMiddleware
+
+PASSWORD = "session-password"  # not a credential: only ever seeded into a tmp_path database
+LOGIN = "/login/probe"
+
+# The three surfaces. Paths are chosen to reach each one: /oidc/* is FastAPI, /api/* and
+# /graphql fall through to the mounted Flask app.
+FASTAPI_ROUTE = "/oidc/api/probe"
+FLASK_ROUTE = "/api/2.0/mlflow/experiments/probe"
+GRAPHQL_ROUTE = "/graphql"
+
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    previous = object.__getattribute__(store_module.store, "_instance")
+    object.__setattr__(store_module.store, "_instance", s)
+    yield s
+    object.__setattr__(store_module.store, "_instance", previous)
+    s.engine.dispose()
+
+
+@pytest.fixture
+def client(store):
+    """The real stack: AuthMiddleware in front, Flask mounted underneath at ``/``.
+
+    Mirrors ``app.py`` — FastAPI routes registered first so they take precedence over the
+    catch-all Flask mount — with a stand-in Flask app rather than MLflow's, since what is under
+    test is whether the request reaches Flask at all.
+    """
+    flask_app = Flask(__name__)
+
+    @flask_app.route(FLASK_ROUTE)
+    def flask_probe():
+        return {"reached": "flask"}
+
+    @flask_app.route(GRAPHQL_ROUTE, methods=["GET", "POST"])
+    def graphql_probe():
+        return {"reached": "graphql"}
+
+    api = FastAPI()
+
+    @api.get(FASTAPI_ROUTE)
+    async def fastapi_probe(request: Request):
+        return {"reached": "fastapi", "username": getattr(request.state, "username", None)}
+
+    @api.get(LOGIN)
+    async def login(request: Request, username: str):
+        request.session["username"] = username
+        return {"ok": True}
+
+    api.add_middleware(AuthMiddleware)
+    api.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+    api.mount("/", AuthAwareWSGIMiddleware(flask_app))
+
+    with TestClient(api) as c:
+        yield c
+
+
+ALL_SURFACES = [FASTAPI_ROUTE, FLASK_ROUTE, GRAPHQL_ROUTE]
+
+
+class TestSurfacesAreReachableWhileTheUserExists:
+    """Preconditions. Without these, the denial tests below could pass for the wrong reason —
+    a route that never worked is not evidence of a closed gap."""
+
+    @pytest.mark.parametrize("path", ALL_SURFACES)
+    def test_a_live_user_reaches_every_surface(self, store, client, path):
+        store.create_user("live@example.com", PASSWORD, "Live")
+        client.get(LOGIN, params={"username": "live@example.com"})
+
+        response = client.get(path)
+
+        assert response.status_code == 200, response.text
+
+
+class TestDeletedUserIsDeniedOnEverySurface:
+    """The gap #306 suspected: a signed, unexpired cookie for an account that no longer exists."""
+
+    @pytest.mark.parametrize("path", ALL_SURFACES)
+    def test_a_deleted_user_is_denied(self, store, client, path):
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        assert client.get(path).status_code == 200, "precondition: the surface is reachable first"
+
+        store.delete_user("gone@example.com")
+
+        assert client.get(path).status_code == 401
+
+    def test_the_request_never_reaches_flask(self, store, client):
+        """Denied *before* the mount, not by a downstream permission check.
+
+        The distinction matters: if the request reached Flask, every route without a validator
+        would be exposed to a deleted user, and the fix would be one forgotten validator away
+        from failing.
+        """
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        store.delete_user("gone@example.com")
+
+        response = client.get(FLASK_ROUTE)
+
+        assert response.status_code == 401
+        assert "reached" not in response.text
+
+    def test_the_deleted_user_is_not_merely_downgraded(self, store, client):
+        """The behaviour the issue described: authenticated, but non-admin. That would let a
+        deleted account keep whatever access a non-admin has."""
+        store.create_user("gone@example.com", PASSWORD, "Gone", is_admin=True)
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        store.delete_user("gone@example.com")
+
+        response = client.get(FASTAPI_ROUTE)
+
+        assert response.status_code == 401
+        assert response.json().get("username") is None
+
+    def test_recreating_the_user_restores_access(self, store, client):
+        """The cookie was never invalidated — only the account state changed — so a same-named
+        account restores access. Worth pinning: it is the behaviour a server-side session store
+        (#310) would change, and #310 should know it is changing it deliberately.
+        """
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        store.delete_user("gone@example.com")
+        assert client.get(FASTAPI_ROUTE).status_code == 401
+
+        store.create_user("gone@example.com", PASSWORD, "Gone Again")
+
+        assert client.get(FASTAPI_ROUTE).status_code == 200
+
+
+class TestDenialIsReportedAsDeletion:
+    """A deleted user is not an inactive one, and an operator reading the log should not have to
+    guess which happened."""
+
+    def test_the_audit_event_names_deletion(self, store, client, monkeypatch):
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        store.delete_user("gone@example.com")
+
+        client.get(FASTAPI_ROUTE)
+
+        assert events, "a denial must be audited"
+        event, kwargs = events[0]
+        assert event == "auth.denied_unknown_user"
+        assert kwargs["status"] == "denied"
+
+    def test_an_inactive_user_is_still_reported_as_inactive(self, store, client, monkeypatch):
+        """The two reasons must stay distinguishable in both directions."""
+        from sqlalchemy import text
+
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+        store.create_user("off@example.com", PASSWORD, "Off")
+        client.get(LOGIN, params={"username": "off@example.com"})
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0 WHERE username = 'off@example.com'"))
+
+        client.get(FASTAPI_ROUTE)
+
+        assert events[0][0] == "auth.denied_inactive"
+
+    def test_a_missing_user_is_not_logged_as_an_error(self, store, client, caplog):
+        """A user deleted mid-session is an ordinary condition, and their browser will keep
+        retrying with the same cookie. Logging it at ERROR would fill the log with something
+        the operator can do nothing about.
+        """
+        import logging
+
+        store.create_user("gone@example.com", PASSWORD, "Gone")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        client.get(LOGIN, params={"username": "gone@example.com"})
+        store.delete_user("gone@example.com")
+
+        with caplog.at_level(logging.DEBUG):
+            client.get(FASTAPI_ROUTE)
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not errors, [r.message for r in errors]

--- a/mlflow_oidc_auth/tests/test_deleted_user_session.py
+++ b/mlflow_oidc_auth/tests/test_deleted_user_session.py
@@ -20,9 +20,6 @@ All three sit behind ``AuthMiddleware``, which `app.py` adds before mounting Fla
 one denial covers them — but that is a structural claim, and this file is the evidence.
 """
 
-import tempfile
-from pathlib import Path
-
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient


### PR DESCRIPTION
Closes #306.

## The finding

**The gap was real, and it is already closed.**

`_authenticate_session` authenticates purely from `session["username"]` in the signed cookie, and
`_get_user_admin_status` caught the "user not found" exception and returned `False` — so a user
deleted mid-session did pass the authentication middleware, merely downgraded to non-admin, with
only downstream permission checks between them and the application.

The `active` check added by **#311** reads the user's profile on every authenticated request, and
a deleted user cannot be read, so the request is now denied *before* it reaches any surface. I
confirmed the current behaviour by driving the real middleware stack rather than reading the
code: a deleted user's still-valid cookie gets 401 on every surface.

This PR therefore lands the **regression coverage** the issue asked for, plus two reporting fixes
found while verifying.

## Behaviour per surface

Each of the three surfaces the issue named, first shown reachable with a live user so the denial
tests cannot pass for the wrong reason:

| Surface | Live user | Deleted user |
|---|---|---|
| FastAPI route (`/oidc/api/*`) | 200 | **401** |
| Flask route via `AuthAwareWSGIMiddleware` (`/api/2.0/mlflow/*`) | 200 | **401** |
| `/graphql` | 200 | **401** |

All three sit behind `AuthMiddleware`, which `app.py` adds before mounting Flask at `/`, so one
denial covers them. That is a structural claim, and the tests are the evidence — a future
refactor could restore the old behaviour for some of them.

A test also asserts the request **never reaches Flask**: if it did, every route without a
validator would be exposed to a deleted user, and the fix would be one forgotten validator away
from failing.

## Two reporting defects, fixed

Both found by writing the tests, neither visible from reading:

- **A deleted user was audited as `auth.denied_inactive`** and logged as "inactive". Deletion and
  deactivation are different operational events, and conflating them sends an operator
  investigating a lockout to the wrong place. Now `auth.denied_unknown_user`,
  `auth.denied_inactive` and `auth.denied_lookup_error` are distinct, with a test in each
  direction so they cannot drift back together.
- **The missing user was logged at `ERROR`.** A user deleted mid-session is routine, and the
  browser keeps presenting the same cookie until it expires — so this repeated at ERROR on every
  request, about something nobody can act on. It is `INFO` now; ERROR is kept for genuine lookup
  failures.

## The question #306 asked

> Result reported — it determines whether the server-side session store is a security fix or a
> feature.

**A feature.** The authentication gap is closed at the middleware without any server-side session
state, so #310 is not fixing a hole. What it buys is *revocation*: today a signed cookie stays
valid until it expires, and a test here pins the consequence — recreating an account with the
same username restores access to the old session. #310 should change that knowingly rather than
discover it.

## Validation

```
pre-commit run --all-files                        # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks # 3124 passed
pytest mlflow_oidc_auth/tests/hooks/<each file>   # 352 passed (per file; see AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/               # 37 passed — #305 budget intact
```

Verified the new tests bind: 2 fail against the pre-fix middleware (the two reporting cases), all
12 pass after. The 10 denial and reachability tests pass either way — correctly, since #311
already closed the gap; they exist so it stays closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
