### PR TITLE
feat(auth): move browser sessions server-side (#310)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,19 +113,48 @@ These settings only apply when `MLFLOW_ENABLE_WORKSPACES=true`.
 
 ## Sessions
 
-The plugin uses Starlette's built-in cookie-based sessions:
+Browser sessions are **server-side**: a row in the `auth_sessions` table of the auth database.
+The cookie carries only an opaque identifier, so a session can be ended by the server rather
+than merely forgotten by the browser.
 
-- Session data is stored client-side in a **signed cookie** (not encrypted — do not store secrets in sessions)
-- No server-side session backend (Redis, database) is required
-- The cookie is signed with `SECRET_KEY` — all replicas **must** share the same key
-- Sessions survive server restarts only if `SECRET_KEY` is explicitly configured
+- The identifier is resolved against the database on **every** request, uncached, so revoking a
+  session takes effect on the next request — no TTL to wait out
+- Deactivating or deleting a user revokes their live sessions immediately, and records a
+  `session.revoked` audit event
+- Logging out revokes the row. If revocation fails, logout returns **503** rather than
+  reporting success, because a cleared cookie does not end a session that is still live
+- The cookie is still signed with `SECRET_KEY` — all replicas **must** share the same key, and
+  it must be set explicitly for sessions to survive a restart
+- The cookie is signed but **not** encrypted; nothing secret belongs in it
+
+**Session expiry is absolute, not rolling.** A session's lifetime is fixed at login to
+`SESSION_COOKIE_MAX_AGE_SECONDS` (two weeks by default) and is not extended by activity, so a
+continuously active user re-authenticates with the identity provider every two weeks. The
+browser cookie's own `Max-Age` is refreshed on each response, but the server-side row is what
+decides, and it is not. Lower the value to shorten the window; there is no setting that makes
+it rolling.
+
+**Sessions are not swept automatically.** Every login inserts a row and an expired one is simply
+refused, so the table grows until an operator prunes it:
+
+```bash
+mlflow-oidc db prune-sessions --url postgresql://user:pass@host/auth_db
+```
+
+Add `--dry-run` to see the count without deleting. Revoked-but-unexpired rows are kept until
+their expiry, so "was this session revoked, and when?" stays answerable. Running it from cron is
+the expected deployment.
+
+**Upgrading:** the session format changed in this release. Cookies issued by an earlier version
+no longer authenticate — they carried the username directly, which is exactly what could not be
+revoked — so every user logs in again once after the upgrade. No configuration change is needed.
 
 Additional session cookie settings:
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | `SESSION_COOKIE_NAME` | String | `session` | Session cookie name |
-| `SESSION_COOKIE_MAX_AGE_SECONDS` | Integer | `1209600` (2 weeks) | Session expiry time in seconds, if set to `0` then the cookie will last as long as the browser session |
+| `SESSION_COOKIE_MAX_AGE_SECONDS` | Integer | `1209600` (2 weeks) | Absolute session lifetime in seconds, fixed at login and not extended by activity. `0` makes the *cookie* last only as long as the browser session; the server-side session still expires after two weeks |
 | `SESSION_COOKIE_SAMESITE` | String | `lax` | SameSite flag prevents the browser from sending session cookie along with cross-site requests |
 | `SESSION_COOKIE_SECURE` | Boolean | `false` | Indicate that the "Secure" flag should be set (can be used with HTTPS only), set this to `true` in production to ensure the session cookie is only sent over HTTPS |
 

--- a/mlflow_oidc_auth/db/cli.py
+++ b/mlflow_oidc_auth/db/cli.py
@@ -72,3 +72,38 @@ def restore_admin(url: str, username: str) -> None:
         )
     finally:
         engine.dispose()
+
+
+@commands.command(name="prune-sessions")
+@click.option("--url", required=True, help="Database URL, e.g. sqlite:///auth.db")
+@click.option("--dry-run", is_flag=True, help="Report how many rows would be deleted, and delete nothing.")
+def prune_sessions(url: str, dry_run: bool) -> None:
+    """Delete expired server-side sessions (issue #310).
+
+    Housekeeping, not correctness: an expired session already fails to resolve, so leaving the
+    rows in place is safe but unbounded — every login inserts one and nothing else removes them.
+    A deployment with a few hundred logins a day accumulates six figures of dead rows in a year.
+
+    Revoked-but-unexpired sessions are kept until their expiry, so that "was this session
+    revoked, and when?" stays answerable for the lifetime the session would have had.
+
+    Run it from cron, or by hand. It is safe to run concurrently with a live server.
+    """
+    from datetime import datetime, timezone
+
+    from mlflow_oidc_auth.db.models import SqlAuthSession
+
+    cutoff = datetime.now(timezone.utc).replace(tzinfo=None)
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as conn:
+            expired = conn.execute(
+                sqlalchemy.select(sqlalchemy.func.count()).select_from(SqlAuthSession).where(SqlAuthSession.expires_at <= cutoff)
+            ).scalar_one()
+            if dry_run:
+                click.echo(f"{expired} expired session(s) would be deleted")
+                return
+            conn.execute(sqlalchemy.delete(SqlAuthSession).where(SqlAuthSession.expires_at <= cutoff))
+        click.echo(f"deleted {expired} expired session(s)")
+    finally:
+        engine.dispose()

--- a/mlflow_oidc_auth/db/models/identity.py
+++ b/mlflow_oidc_auth/db/models/identity.py
@@ -45,6 +45,10 @@ class SqlAuthSession(Base):
     ``session_id`` is an opaque 256-bit value chosen by the application; the column is sized for
     either common encoding. ``encrypted_tokens`` holds provider token material that the
     application encrypts before it ever reaches this column.
+
+    Rows are **not** swept automatically: one is inserted per login and an expired one is simply
+    refused by ``AuthSessionRepository.resolve``. Deleting them is an operator action —
+    ``mlflow-oidc db prune-sessions`` — because a deployment may want the history retained.
     """
 
     __tablename__ = "auth_sessions"

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -280,9 +280,25 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if hasattr(request, "session"):
                 try:
                     session = request.session
-                    username = session.get("username")
-                    if not username:
+                    session_id = session.get("session_id")
+                    if not session_id:
+                        # No server-side session id. A cookie predating #310 lands here and is
+                        # treated as unauthenticated, which is the deliberate upgrade path: the
+                        # old format carried the username itself, so honouring it would keep
+                        # exactly the sessions that cannot be revoked.
                         return False, None, "No session authentication"
+
+                    resolved = store.resolve_auth_session(session_id)
+                    if resolved is None:
+                        # Unknown, revoked or expired — indistinguishable on purpose.
+                        session.clear()
+                        return False, None, "Session not recognised"
+
+                    username = resolved.username
+                    # Stash the resolved row so dispatch does not look the user up again. The
+                    # join already returned admin and active, so the session path costs one
+                    # statement rather than two (#305 budget).
+                    request.state.resolved_session = resolved
 
                     if self._is_session_expired(session):
                         # Try a silent refresh first; only force re-login if it fails.
@@ -465,7 +481,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
         is_authenticated, username, error_msg = await self._authenticate_user(request)
 
         if is_authenticated and username:
-            is_admin, is_active, denial_reason = self._get_user_auth_state(username)
+            resolved = getattr(request.state, "resolved_session", None)
+            if resolved is not None:
+                # Already read, in the same statement that validated the session.
+                is_admin, is_active = resolved.is_admin, resolved.is_active
+                denial_reason = "" if is_active else DENIAL_INACTIVE
+            else:
+                is_admin, is_active, denial_reason = self._get_user_auth_state(username)
 
             # A deprovisioned user holds a signed cookie or a valid token that has not expired
             # yet, so credentials alone still check out. Directories deactivate rather than

--- a/mlflow_oidc_auth/repository/__init__.py
+++ b/mlflow_oidc_auth/repository/__init__.py
@@ -21,6 +21,7 @@ from mlflow_oidc_auth.repository.registered_model_permission_group import (
     RegisteredModelPermissionGroupRepository,
 )
 from mlflow_oidc_auth.repository.user import UserRepository
+from mlflow_oidc_auth.repository.auth_session import AuthSessionRepository
 from mlflow_oidc_auth.repository.user_identity import UserIdentityRepository
 from mlflow_oidc_auth.repository.experiment_permission_regex import (
     ExperimentPermissionRegexRepository,
@@ -111,6 +112,7 @@ __all__ = [
     "RegisteredModelPermissionGroupRepository",
     "UserRepository",
     "UserIdentityRepository",
+    "AuthSessionRepository",
     "ExperimentPermissionRegexRepository",
     "ExperimentPermissionGroupRegexRepository",
     "RegisteredModelPermissionRegexRepository",

--- a/mlflow_oidc_auth/repository/auth_session.py
+++ b/mlflow_oidc_auth/repository/auth_session.py
@@ -1,0 +1,183 @@
+"""Server-side sessions (issue #310).
+
+The session used to live entirely in the browser cookie: Starlette signed a dict with
+``SECRET_KEY`` and the server kept nothing, so a valid cookie stayed valid until it expired and
+there was nothing to revoke. Sessions are now rows, and the cookie carries only an opaque
+identifier.
+
+The table landed with the Phase 0 migration (#333); this is the data access over it.
+
+**The lookup is one statement.** ``resolve`` joins ``auth_sessions`` to ``users`` and returns
+everything the authentication path needs — session validity, username, admin and active flags —
+because that path runs on every request and its statement count is a budget (#305), not an
+implementation detail. A second round trip for the user would double it.
+"""
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, List, Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from sqlalchemy.orm import Session
+
+from mlflow_oidc_auth.db.models import SqlAuthSession, SqlUser
+from mlflow_oidc_auth.repository.user import normalize_username
+
+# 256 bits, per the issue. ``token_urlsafe`` returns ~43 characters for 32 bytes; the column is
+# sized to 255 so the encoding is not a constraint.
+SESSION_ID_BYTES = 32
+
+
+@dataclass(frozen=True)
+class ResolvedSession:
+    """Everything the auth path needs about a session, from one lookup.
+
+    Attributes:
+        username: The session's user.
+        is_admin: Whether that user is an administrator.
+        is_active: Whether the account may authenticate.
+        expires_at: When the session stops being valid.
+    """
+
+    username: str
+    is_admin: bool
+    is_active: bool
+    expires_at: Optional[datetime] = None
+
+
+def _now() -> datetime:
+    """Naive UTC, matching the DateTime columns the migration created."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class AuthSessionRepository:
+    """Creates, resolves and revokes server-side sessions."""
+
+    def __init__(self, session_maker):
+        self._Session: Callable[[], Session] = session_maker
+
+    def create(self, username: str, expires_at: datetime, provider_id: Optional[str] = None) -> str:
+        """Open a session for ``username`` and return its opaque identifier.
+
+        The identifier is generated here rather than derived from anything about the user: it is
+        the only thing the cookie will carry, so it must not encode identity or be guessable.
+
+        Parameters:
+            username: Identity key of the user logging in.
+            expires_at: When the session should stop being valid.
+            provider_id: Registry id of the provider that authenticated them, when known.
+
+        Returns:
+            The session id to place in the cookie.
+
+        Raises:
+            MlflowException: If the user does not exist. Raised with a proper error code rather
+                than a bare ``ValueError``, which the managed session would rewrite into an
+                opaque ``INTERNAL_ERROR``.
+        """
+        username = normalize_username(username)
+        session_id = secrets.token_urlsafe(SESSION_ID_BYTES)
+        with self._Session(read_only=False) as session:
+            user = session.query(SqlUser.id).filter(SqlUser.username == username).one_or_none()
+            if user is None:
+                raise MlflowException(f"cannot open a session for unknown user '{username}'", RESOURCE_DOES_NOT_EXIST)
+            session.add(
+                SqlAuthSession(
+                    session_id=session_id,
+                    user_id=user[0],
+                    provider_id=provider_id,
+                    expires_at=expires_at.replace(tzinfo=None) if expires_at.tzinfo else expires_at,
+                )
+            )
+            session.flush()
+        return session_id
+
+    def resolve(self, session_id: str) -> Optional[ResolvedSession]:
+        """Resolve a session id to its user, in a single statement.
+
+        Returns None when the session is unknown, revoked or expired — the three ways a cookie
+        can be presented and not be honoured. The caller cannot distinguish them, which is
+        deliberate: a revoked session and a forged one should look identical from outside.
+
+        Expiry is part of this statement rather than a Python check on the returned row, so an
+        expired session is never materialised and cannot be honoured by a caller that forgets to
+        look. The cutoff is the application clock, matching the naive-UTC values ``create``
+        writes — the database clock is deliberately not involved, since mixing the two is what
+        makes expiry behave differently on a replica.
+        """
+        if not session_id:
+            return None
+        with self._Session() as session:
+            row = (
+                session.query(SqlUser.username, SqlUser.is_admin, SqlUser.active, SqlAuthSession.expires_at)
+                .join(SqlAuthSession, SqlAuthSession.user_id == SqlUser.id)
+                .filter(
+                    SqlAuthSession.session_id == session_id,
+                    SqlAuthSession.revoked_at.is_(None),
+                    SqlAuthSession.expires_at > _now(),
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            return ResolvedSession(username=row[0], is_admin=bool(row[1]), is_active=bool(row[2]), expires_at=row[3])
+
+    def revoke(self, session_id: str) -> bool:
+        """Revoke one session. Returns True if it was live until now.
+
+        Idempotent: revoking an already-revoked session reports False rather than raising, so a
+        double logout is not an error.
+        """
+        with self._Session(read_only=False) as session:
+            updated = (
+                session.query(SqlAuthSession)
+                .filter(SqlAuthSession.session_id == session_id, SqlAuthSession.revoked_at.is_(None))
+                .update({SqlAuthSession.revoked_at: _now()}, synchronize_session=False)
+            )
+            return bool(updated)
+
+    def revoke_all_for_user(self, username: str) -> int:
+        """Revoke every live session belonging to ``username``.
+
+        This is what makes deprovisioning real: deactivating an account (#311) or deleting it
+        can now end the sessions it already has, rather than waiting out their cookies.
+
+        Returns:
+            How many sessions were revoked.
+        """
+        username = normalize_username(username)
+        with self._Session(read_only=False) as session:
+            user = session.query(SqlUser.id).filter(SqlUser.username == username).one_or_none()
+            if user is None:
+                return 0
+            return int(
+                session.query(SqlAuthSession)
+                .filter(SqlAuthSession.user_id == user[0], SqlAuthSession.revoked_at.is_(None))
+                .update({SqlAuthSession.revoked_at: _now()}, synchronize_session=False)
+            )
+
+    def list_live_for_user(self, username: str) -> List[str]:
+        """Session ids currently live for ``username``. Intended for tests and administration."""
+        username = normalize_username(username)
+        with self._Session() as session:
+            rows = (
+                session.query(SqlAuthSession.session_id)
+                .join(SqlUser, SqlAuthSession.user_id == SqlUser.id)
+                .filter(SqlUser.username == username, SqlAuthSession.revoked_at.is_(None), SqlAuthSession.expires_at > _now())
+                .all()
+            )
+            return [row[0] for row in rows]
+
+    def delete_expired(self, before: Optional[datetime] = None) -> int:
+        """Delete sessions that expired before ``before`` (default: now).
+
+        Housekeeping, not correctness — ``resolve`` already refuses an expired session. Provided
+        so a deployment can keep the table from growing without reaching into it by hand.
+        """
+        cutoff = before or _now()
+        if cutoff.tzinfo:
+            cutoff = cutoff.replace(tzinfo=None)
+        with self._Session(read_only=False) as session:
+            return int(session.query(SqlAuthSession).filter(SqlAuthSession.expires_at <= cutoff).delete(synchronize_session=False))

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -13,9 +13,32 @@ from sqlalchemy.orm import load_only, noload, selectinload
 from sqlalchemy.orm import Session
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from mlflow_oidc_auth.db.models import SqlGroup, SqlUser
+from mlflow_oidc_auth.db.models import SqlAuthSession, SqlGroup, SqlUser
 from mlflow_oidc_auth.entities import User
+from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.repository.utils import get_user
+
+logger = get_logger()
+
+
+def _audit_sessions_revoked(username: str, count: int, reason: str) -> None:
+    """Record that a user's live sessions were ended.
+
+    Emitted from the repository rather than a router so every caller is covered — the admin API
+    today, a SCIM sync later. This is the event an operator looks for when asking whether a
+    deprovisioned account still had access: before server-side sessions there was nothing to
+    revoke, so there was nothing to record (#310).
+    """
+    from mlflow_oidc_auth.audit import emit_audit_event
+
+    emit_audit_event(
+        "session.revoked",
+        actor=username,
+        resource_type="user",
+        resource_id=username,
+        detail={"sessions": count, "reason": reason},
+    )
+
 
 # Hash method for secrets stored in ``users.password_hash`` (issue #336).
 #
@@ -266,6 +289,7 @@ class UserRepository:
         from werkzeug.security import generate_password_hash
 
         username = normalize_username(username)
+        sessions_revoked = 0
         with self._Session(read_only=False) as session:
             user = get_user(session, username)
             if password is not None:
@@ -287,13 +311,34 @@ class UserRepository:
                 user.is_service_account = is_service_account
             if active is not None:
                 user.active = active
+                if active is False:
+                    # Deprovisioning that leaves live sessions running is cosmetic — the whole
+                    # point of #310. Revoked here rather than in the router so every caller
+                    # inherits it, including a future SCIM sync (#324).
+                    revoked = (
+                        session.query(SqlAuthSession)
+                        .filter(SqlAuthSession.user_id == user.id, SqlAuthSession.revoked_at.is_(None))
+                        .update({SqlAuthSession.revoked_at: datetime.now(timezone.utc).replace(tzinfo=None)}, synchronize_session=False)
+                    )
+                    if revoked:
+                        logger.info("Deactivating %s revoked %d live session(s)", username, revoked)
+                        # Recorded, not emitted: an audit line written inside the transaction
+                        # would claim the sessions were revoked even if the commit then failed,
+                        # and that claim is exactly what an operator relies on.
+                        sessions_revoked = revoked
             if managed_by is not None:
                 user.managed_by = managed_by
             session.flush()
-            return user.to_mlflow_entity()
+            entity = user.to_mlflow_entity()
+
+        # Past the ``with``: the transaction has committed, so the event is true when written.
+        if sessions_revoked:
+            _audit_sessions_revoked(username, sessions_revoked, "user_deactivated")
+        return entity
 
     def delete(self, username: str) -> None:
         username = normalize_username(username)
+        deleted_sessions = 0
         with self._Session(read_only=False) as session:
             user = get_user(session, username)
             if user is None:
@@ -317,6 +362,7 @@ class UserRepository:
                 SqlRegisteredModelRegexPermission,
                 SqlScorerPermission,
                 SqlScorerRegexPermission,
+                SqlAuthSession,
                 SqlUserGroup,
                 SqlUserIdentity,
                 SqlWorkspacePermission,
@@ -324,6 +370,12 @@ class UserRepository:
             )
 
             user_id = user.id
+
+            # Server-side sessions (#310). Same foreign-key requirement as the identities below:
+            # a user holding a live session could not otherwise be deleted at all.
+            live_sessions = session.query(SqlAuthSession).filter(SqlAuthSession.user_id == user_id, SqlAuthSession.revoked_at.is_(None)).count()
+            session.query(SqlAuthSession).filter(SqlAuthSession.user_id == user_id).delete(synchronize_session=False)
+            deleted_sessions = live_sessions
 
             # External identities (#309/#333). The Phase 0 backfill gave *every* pre-existing
             # user a row here, so without this every account that predates that migration is
@@ -365,6 +417,10 @@ class UserRepository:
 
             session.delete(user)
             session.flush()
+
+        # Emitted after the commit, for the same reason as in ``update``.
+        if deleted_sessions:
+            _audit_sessions_revoked(username, deleted_sessions, "user_deleted")
 
     def authenticate(self, username: str, password: str) -> bool:
         username = normalize_username(username)

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -7,6 +7,7 @@ This router handles OIDC authentication flows including login, logout, and callb
 import secrets
 import time
 from collections.abc import Awaitable
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from urllib.parse import urlencode
 
@@ -18,11 +19,18 @@ from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.oauth import is_oidc_configured, oauth
+from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils import get_configured_or_dynamic_redirect_uri, extract_username, extract_display_name
 
 from ._prefix import UI_ROUTER_PREFIX
 
 logger = get_logger()
+
+# Lifetime for a server-side session when the cookie itself carries no expiry. A cookie with no
+# max_age lasts until the browser closes, which is unbounded from the server's point of view — and
+# a row that never expires is a row that can never be swept (#310).
+DEFAULT_SESSION_LIFETIME_SECONDS = 14 * 24 * 60 * 60
+
 
 auth_router = APIRouter(
     tags=["auth"],
@@ -313,6 +321,18 @@ async def login(request: Request):
         raise HTTPException(status_code=500, detail="Failed to initiate OIDC login")
 
 
+def _open_server_session(username: str) -> str:
+    """Open a server-side session for ``username`` and return its opaque id.
+
+    The row's lifetime mirrors the cookie's, so a session cannot outlive the credential that
+    carries it, and an unbounded cookie still yields a bounded row — one that never expires
+    could never be swept.
+    """
+    max_age = config.SESSION_COOKIE_MAX_AGE_SECONDS or DEFAULT_SESSION_LIFETIME_SECONDS
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=max_age)
+    return store.create_auth_session(username, expires_at=expires_at)
+
+
 @auth_router.get(LOGOUT)
 async def logout(request: Request):
     """
@@ -331,8 +351,26 @@ async def logout(request: Request):
     try:
         # Get and clear session (using Starlette's built-in session)
         session = request.session
-        username = session.get("username")
+        # request.state is set by AuthMiddleware for an authenticated request; read it
+        # defensively so logout never fails on the way out.
+        username = getattr(getattr(request, "state", None), "username", None)
+        session_id = session.get("session_id")
         session.clear()
+
+        if session_id:
+            # Revoke the row, not just the cookie: clearing the cookie alone left the session
+            # usable by anyone who had already copied it (#310).
+            #
+            # A failure here is not cosmetic and must not be swallowed by the handler's outer
+            # ``except``: the cookie is gone from *this* browser, but the session stays live for
+            # its full lifetime, and telling the user they are logged out when a copied cookie
+            # still works is the worst of both. Surface it.
+            try:
+                store.revoke_auth_session(session_id)
+            except Exception as exc:
+                logger.error("Logout could not revoke session for %s: %s", username or "<unknown>", exc)
+                emit_audit_event("auth.logout_failed", actor=username, detail={"reason": "revocation_failed"})
+                raise HTTPException(status_code=503, detail="Logout failed: the session could not be revoked. Please try again.")
 
         if username:
             logger.info(f"User {username} logged out successfully")
@@ -364,6 +402,9 @@ async def logout(request: Request):
         auth_url = _build_ui_url(request, "/auth")
         return RedirectResponse(url=auth_url, status_code=302)
 
+    except HTTPException:
+        # Revocation failure. The user must be told, not redirected to a page that implies success.
+        raise
     except Exception as e:
         logger.error(f"Error during logout: {e}")
         # Still clear session even if redirect fails - redirect to auth page
@@ -416,8 +457,33 @@ async def callback(request: Request):
             return RedirectResponse(url=auth_error_url, status_code=302)
 
         if username:
-            # Successful authentication
-            session["username"] = username
+            # Successful authentication. The cookie carries an opaque session id; the row it
+            # names is what can be revoked (#310). ``username`` is no longer written to the
+            # cookie — authenticating from it is precisely what could not be revoked.
+            #
+            # Retire whatever session the browser arrived with *before* minting the new one.
+            # Without this, a second login in the same browser leaves the previous user's
+            # ``session_id`` in the cookie next to the new login's refresh token: if opening the
+            # new session then fails, the browser stays authenticated as the previous user and
+            # goes on refreshing that session with the new user's IdP grant.
+            previous_session_id = session.pop("session_id", None)
+            session.pop("username", None)  # pre-#310 key; nothing reads it, so do not carry it
+            if previous_session_id:
+                try:
+                    store.revoke_auth_session(previous_session_id)
+                except Exception as exc:  # revoking is best-effort; the cookie no longer names it
+                    logger.warning("Could not revoke the previous session on re-login: %s", exc)
+
+            try:
+                session["session_id"] = _open_server_session(username)
+            except Exception as exc:
+                # The user is provisioned earlier in this callback, so this should not happen —
+                # but a login that cannot open a session must fail as a login, not as a stack
+                # trace. The cookie is cleared so the failure cannot leave the browser holding a
+                # half-authenticated state or another user's credentials.
+                logger.error("Could not open a session for %s: %s", username, exc)
+                session.clear()
+                return RedirectResponse(url=_build_ui_url(request, "/auth", {"error": "session_error"}), status_code=302)
             session["authenticated"] = True
 
             logger.info(f"User {username} authenticated successfully via OIDC")
@@ -459,7 +525,10 @@ async def auth_status(request: Request):
     """
     try:
         session = request.session
-        username = session.get("username")
+        # Resolve the opaque session id rather than reading a username from the cookie (#310).
+        # A query here is fine: this is a status endpoint, not the per-request auth path.
+        resolved = store.resolve_auth_session(session.get("session_id", ""))
+        username = resolved.username if resolved else None
         is_authenticated = bool(username)
 
         return JSONResponse(

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -321,6 +321,35 @@ async def login(request: Request):
         raise HTTPException(status_code=500, detail="Failed to initiate OIDC login")
 
 
+# Everything a completed login leaves in the cookie. All of it belongs to the user who logged
+# in, so all of it has to go when a different login starts in the same browser.
+_LOGIN_SESSION_KEYS = ("session_id", "username", "authenticated", "refresh_token", "expires_at")
+
+
+def _retire_previous_login(session) -> None:
+    """Drop — and revoke — whatever login this browser was already carrying.
+
+    Called before the token exchange, not after. ``_persist_session_auth`` deliberately keeps an
+    existing ``refresh_token`` when the new token response carries none (many IdPs only emit one
+    on the first exchange), so anything still here when the exchange runs is inherited by the
+    next user: their session would then be refreshed with the previous user's grant, and would
+    die when *that* user was deprovisioned rather than when they were.
+
+    The old session is revoked outright rather than merely forgotten. Its id is leaving the
+    cookie either way, so nothing the user can still reach is being taken from them — and if
+    this login fails, a session belonging to whoever was here before should not survive it.
+    """
+    previous_session_id = session.pop("session_id", None)
+    for key in _LOGIN_SESSION_KEYS:
+        session.pop(key, None)
+
+    if previous_session_id:
+        try:
+            store.revoke_auth_session(previous_session_id)
+        except Exception as exc:  # best effort: the cookie no longer names it regardless
+            logger.warning("Could not revoke the previous session on re-login: %s", exc)
+
+
 def _open_server_session(username: str) -> str:
     """Open a server-side session for ``username`` and return its opaque id.
 
@@ -355,7 +384,6 @@ async def logout(request: Request):
         # defensively so logout never fails on the way out.
         username = getattr(getattr(request, "state", None), "username", None)
         session_id = session.get("session_id")
-        session.clear()
 
         if session_id:
             # Revoke the row, not just the cookie: clearing the cookie alone left the session
@@ -365,12 +393,24 @@ async def logout(request: Request):
             # ``except``: the cookie is gone from *this* browser, but the session stays live for
             # its full lifetime, and telling the user they are logged out when a copied cookie
             # still works is the worst of both. Surface it.
+            #
+            # Revoked *before* the cookie is cleared. Clearing first would delete the only copy
+            # of the session id the browser has, so the 503 below would ask the user to retry
+            # something they can no longer do: the retry would find no id, take the success
+            # path, and leave the session live for its full lifetime.
             try:
                 store.revoke_auth_session(session_id)
             except Exception as exc:
                 logger.error("Logout could not revoke session for %s: %s", username or "<unknown>", exc)
-                emit_audit_event("auth.logout_failed", actor=username, detail={"reason": "revocation_failed"})
+                emit_audit_event(
+                    "auth.logout_failed",
+                    actor=username or "<unknown>",
+                    detail={"reason": "revocation_failed"},
+                    status="denied",
+                )
                 raise HTTPException(status_code=503, detail="Logout failed: the session could not be revoked. Please try again.")
+
+        session.clear()
 
         if username:
             logger.info(f"User {username} logged out successfully")
@@ -443,6 +483,11 @@ async def callback(request: Request):
         # Get session (using Starlette's built-in session)
         session = request.session
 
+        # A new login supersedes whatever this browser was carrying, and must not inherit any of
+        # it. This runs before the exchange because the exchange writes into the same cookie.
+        # ``oauth_state`` and ``redirect_after_login`` belong to *this* login and are untouched.
+        _retire_previous_login(session)
+
         # Process OIDC callback using FastAPI-native implementation
         username, errors = await _process_oidc_callback_fastapi(request, session)
 
@@ -460,20 +505,8 @@ async def callback(request: Request):
             # Successful authentication. The cookie carries an opaque session id; the row it
             # names is what can be revoked (#310). ``username`` is no longer written to the
             # cookie — authenticating from it is precisely what could not be revoked.
-            #
-            # Retire whatever session the browser arrived with *before* minting the new one.
-            # Without this, a second login in the same browser leaves the previous user's
-            # ``session_id`` in the cookie next to the new login's refresh token: if opening the
-            # new session then fails, the browser stays authenticated as the previous user and
-            # goes on refreshing that session with the new user's IdP grant.
-            previous_session_id = session.pop("session_id", None)
-            session.pop("username", None)  # pre-#310 key; nothing reads it, so do not carry it
-            if previous_session_id:
-                try:
-                    store.revoke_auth_session(previous_session_id)
-                except Exception as exc:  # revoking is best-effort; the cookie no longer names it
-                    logger.warning("Could not revoke the previous session on re-login: %s", exc)
-
+            # Any previous login was already retired before the exchange, so nothing in this
+            # cookie belongs to anyone else by the time the new session id is written.
             try:
                 session["session_id"] = _open_server_session(username)
             except Exception as exc:
@@ -528,7 +561,10 @@ async def auth_status(request: Request):
         # Resolve the opaque session id rather than reading a username from the cookie (#310).
         # A query here is fine: this is a status endpoint, not the per-request auth path.
         resolved = store.resolve_auth_session(session.get("session_id", ""))
-        username = resolved.username if resolved else None
+        # ``resolve`` reports the active flag rather than filtering on it, so the middleware can
+        # audit "deactivated" separately. Here a deactivated account is simply not authenticated
+        # — reporting otherwise would render a logged-in UI that 401s on its first API call.
+        username = resolved.username if resolved and resolved.is_active else None
         is_authenticated = bool(username)
 
         return JSONResponse(

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -63,6 +63,7 @@ from mlflow_oidc_auth.repository import (
     GatewayModelDefinitionPermissionGroupRegexRepository,
     UserRepository,
     UserIdentityRepository,
+    AuthSessionRepository,
     WorkspacePermissionRepository,
     WorkspaceGroupPermissionRepository,
 )
@@ -84,6 +85,7 @@ class SqlAlchemyStore:
         self.ManagedSessionMaker = _get_managed_session_maker(SessionMaker, self.db_type)
         self.user_repo = UserRepository(self.ManagedSessionMaker)
         self.user_identity_repo = UserIdentityRepository(self.ManagedSessionMaker)
+        self.auth_session_repo = AuthSessionRepository(self.ManagedSessionMaker)
         self.experiment_repo = ExperimentPermissionRepository(self.ManagedSessionMaker)
         self.experiment_group_repo = ExperimentPermissionGroupRepository(self.ManagedSessionMaker)
         self.group_repo = GroupRepository(self.ManagedSessionMaker)
@@ -324,6 +326,22 @@ class SqlAlchemyStore:
         is_service_account=False,
     ):
         return self.user_repo.create(username, password, display_name, is_admin, is_service_account)
+
+    def create_auth_session(self, username: str, expires_at, provider_id: Optional[str] = None) -> str:
+        """Open a server-side session and return its opaque id (issue #310)."""
+        return self.auth_session_repo.create(username, expires_at, provider_id)
+
+    def resolve_auth_session(self, session_id: str):
+        """Resolve a session id to its user in one statement, or None if it is not honoured."""
+        return self.auth_session_repo.resolve(session_id)
+
+    def revoke_auth_session(self, session_id: str) -> bool:
+        """Revoke one session. True if it was live until now."""
+        return self.auth_session_repo.revoke(session_id)
+
+    def revoke_all_auth_sessions(self, username: str) -> int:
+        """Revoke every live session for a user. Returns how many were revoked."""
+        return self.auth_session_repo.revoke_all_for_user(username)
 
     def has_user(self, username: str) -> bool:
         return self.user_repo.exist(username)

--- a/mlflow_oidc_auth/tests/db/test_prune_sessions_cli.py
+++ b/mlflow_oidc_auth/tests/db/test_prune_sessions_cli.py
@@ -1,0 +1,78 @@
+"""``mlflow-oidc db prune-sessions`` (issue #310 follow-up).
+
+Every login inserts a row into ``auth_sessions`` and nothing else removes one, so without a
+sweep the table grows without bound. Correctness never depended on it — an expired session is
+refused by ``resolve`` either way — which is precisely why it needs a test: a housekeeping
+command that silently deletes nothing looks exactly like one that works.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow_oidc_auth.db.cli import commands
+
+PASSWORD = "prune-password"  # not a credential: only ever seeded into a tmp_path database
+
+
+def _in(seconds: int) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+@pytest.fixture
+def db(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    url = f"sqlite:///{tmp_path / 'auth.db'}"
+    store = SqlAlchemyStore()
+    store.init_db(url)
+    store.create_user("alice@example.com", PASSWORD, "Alice")
+    yield store, url
+    store.engine.dispose()
+
+
+def _run(url, *args):
+    result = CliRunner().invoke(commands, ["prune-sessions", "--url", url, *args])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+class TestPruneSessions:
+    def test_expired_sessions_are_deleted(self, db):
+        store, url = db
+        store.create_auth_session("alice@example.com", expires_at=_in(-1))
+
+        output = _run(url)
+
+        assert "deleted 1" in output
+        assert store.auth_session_repo.delete_expired() == 0, "nothing left to sweep"
+
+    def test_live_sessions_are_kept(self, db):
+        store, url = db
+        live = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        _run(url)
+
+        assert store.resolve_auth_session(live) is not None
+
+    def test_a_revoked_but_unexpired_session_is_kept(self, db):
+        """So "was this revoked, and when?" stays answerable for the life the session would
+        have had."""
+        store, url = db
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        store.revoke_auth_session(sid)
+
+        output = _run(url)
+
+        assert "deleted 0" in output
+        assert store.auth_session_repo.list_live_for_user("alice@example.com") == []
+
+    def test_dry_run_deletes_nothing(self, db):
+        store, url = db
+        store.create_auth_session("alice@example.com", expires_at=_in(-1))
+
+        output = _run(url, "--dry-run")
+
+        assert "1 expired session(s) would be deleted" in output
+        assert store.auth_session_repo.delete_expired() == 1, "the row is still there"

--- a/mlflow_oidc_auth/tests/middleware/conftest.py
+++ b/mlflow_oidc_auth/tests/middleware/conftest.py
@@ -52,6 +52,17 @@ def mock_store():
         display_name="Regular User",
     )
 
+    # Server-side sessions (#310): the auth path resolves a cookie's opaque session id to its
+    # user in one lookup, so the mock has to answer that as well as the profile queries.
+    from mlflow_oidc_auth.repository.auth_session import ResolvedSession
+
+    _sessions = {
+        "sid-user": ResolvedSession(username="user@example.com", is_admin=False, is_active=True),
+        "sid-admin": ResolvedSession(username="admin@example.com", is_admin=True, is_active=True),
+    }
+    store_mock.resolve_auth_session.side_effect = lambda session_id: _sessions.get(session_id)
+    store_mock.revoke_auth_session.return_value = True
+
     # Mock store methods
     store_mock.get_user.side_effect = lambda username: {
         "admin@example.com": admin_user,

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -20,6 +20,17 @@ from mlflow_oidc_auth.middleware.auth_middleware import AuthMiddleware
 class TestAuthMiddleware:
     """Test suite for AuthMiddleware functionality."""
 
+    @pytest.fixture(autouse=True)
+    def _default_store(self, mock_store, monkeypatch):
+        """Point the middleware at the mock store by default.
+
+        Session authentication resolves the cookie's opaque id through the store (#310), so a
+        test that does not patch it would otherwise reach the real lazy singleton and try to
+        open a database. Tests that patch the store explicitly still win inside their own
+        ``with`` block.
+        """
+        monkeypatch.setattr("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store)
+
     @pytest.fixture
     def auth_middleware(self, test_fastapi_app):
         """Create AuthMiddleware instance for testing."""
@@ -235,7 +246,7 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_authenticate_session_success(self, auth_middleware, create_mock_request):
         """Test successful session authentication."""
-        request = create_mock_request(session={"username": "user@example.com"})
+        request = create_mock_request(session={"session_id": "sid-user"})
 
         success, username, error = await auth_middleware._authenticate_session(request)
 
@@ -297,7 +308,7 @@ class TestAuthMiddleware:
     async def test_authenticate_session_unexpired_passes_through(self, auth_middleware, create_mock_request):
         """A session with a future ``expires_at`` is allowed without touching the IdP."""
         future = 9999999999  # year 2286
-        request = create_mock_request(session={"username": "user@example.com", "expires_at": future})
+        request = create_mock_request(session={"session_id": "sid-user", "expires_at": future})
 
         success, username, error = await auth_middleware._authenticate_session(request)
 
@@ -310,7 +321,7 @@ class TestAuthMiddleware:
         """Expired sessions without a refresh token are cleared and rejected."""
         from mlflow_oidc_auth.middleware import auth_middleware as middleware_mod
 
-        session = {"username": "user@example.com", "expires_at": 100}  # 1970, well past
+        session = {"session_id": "sid-user", "expires_at": 100}  # 1970, well past
 
         # Patch refresh helper to confirm no successful refresh path
         from unittest.mock import AsyncMock, patch as _patch
@@ -333,7 +344,7 @@ class TestAuthMiddleware:
         from mlflow_oidc_auth.middleware import auth_middleware as middleware_mod
 
         session = {
-            "username": "user@example.com",
+            "session_id": "sid-user",
             "expires_at": 100,
             "refresh_token": "rt-123",
         }
@@ -361,7 +372,7 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_authenticate_session_no_expires_at_unchanged(self, auth_middleware, create_mock_request):
         """Sessions predating this feature (no ``expires_at``) keep working."""
-        request = create_mock_request(session={"username": "user@example.com"})
+        request = create_mock_request(session={"session_id": "sid-user"})
 
         success, username, error = await auth_middleware._authenticate_session(request)
 
@@ -402,12 +413,12 @@ class TestAuthMiddleware:
     @pytest.mark.asyncio
     async def test_authenticate_user_session_fallback(self, auth_middleware, create_mock_request):
         """Test that session auth is used when no header auth is present."""
-        request = create_mock_request(session={"username": "session_user@example.com"})
+        request = create_mock_request(session={"session_id": "sid-user"})
 
         success, username, error = await auth_middleware._authenticate_user(request)
 
         assert success is True
-        assert username == "session_user@example.com"
+        assert username == "user@example.com"
         assert error == ""
 
     @pytest.mark.asyncio
@@ -507,7 +518,7 @@ class TestAuthMiddleware:
     async def test_dispatch_authenticated_user(self, auth_middleware, create_mock_request, mock_store):
         """Test dispatch for authenticated user sets request state correctly."""
         with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
-            request = create_mock_request(path="/protected", session={"username": "user@example.com"})
+            request = create_mock_request(path="/protected", session={"session_id": "sid-user"})
 
             # Mock call_next
             async def mock_call_next(req):
@@ -531,7 +542,7 @@ class TestAuthMiddleware:
     async def test_dispatch_authenticated_admin(self, auth_middleware, create_mock_request, mock_store):
         """Test dispatch for authenticated admin user sets admin status correctly."""
         with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
-            request = create_mock_request(path="/protected", session={"username": "admin@example.com"})
+            request = create_mock_request(path="/protected", session={"session_id": "sid-admin"})
 
             # Mock call_next
             async def mock_call_next(req):
@@ -768,7 +779,7 @@ class TestAuthMiddleware:
             patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store),
             patch("mlflow_oidc_auth.middleware.auth_middleware.logger", mock_logger),
         ):
-            request = create_mock_request(path="/protected", session={"username": "user@example.com"})
+            request = create_mock_request(path="/protected", session={"session_id": "sid-user"})
 
             # Mock call_next
             async def mock_call_next(req):
@@ -840,7 +851,7 @@ class TestAuthMiddleware:
         """Test that request state is properly isolated between requests."""
         with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
             # First request
-            request1 = create_mock_request(path="/protected", session={"username": "user@example.com"})
+            request1 = create_mock_request(path="/protected", session={"session_id": "sid-user"})
 
             # Mock call_next
             async def mock_call_next(req):
@@ -849,7 +860,7 @@ class TestAuthMiddleware:
             await auth_middleware.dispatch(request1, mock_call_next)
 
             # Second request with different user
-            request2 = create_mock_request(path="/protected", session={"username": "admin@example.com"})
+            request2 = create_mock_request(path="/protected", session={"session_id": "sid-admin"})
 
             await auth_middleware.dispatch(request2, mock_call_next)
 
@@ -864,7 +875,7 @@ class TestAuthMiddleware:
     async def test_dispatch_asgi_scope_injection(self, auth_middleware, create_mock_request, mock_store):
         """Test that ASGI scope is properly injected for WSGI compatibility."""
         with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
-            request = create_mock_request(path="/protected", session={"username": "admin@example.com"})
+            request = create_mock_request(path="/protected", session={"session_id": "sid-admin"})
 
             # Verify scope doesn't have auth info initially
             assert "mlflow_oidc_auth" not in request.scope

--- a/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
+++ b/mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py
@@ -15,10 +15,15 @@ The budget, measured by ``scripts/bench_auth_path.py`` and recorded in
 scenario         SQL statements
 ===============  ===================
 unprotected      0
-session          2
+session          1
 bearer           2
 basic            3
 ===============  ===================
+
+The session path was 2 until #310 moved sessions server-side: resolving the cookie's opaque id
+joins ``auth_sessions`` to ``users`` and returns the session's validity together with the admin
+and active flags, so the request that used to cost a lookup *and* a profile read now costs one
+statement. Lower is allowed; it simply has to be acknowledged here rather than drift.
 
 **No task may raise these numbers.** A change that needs more per-request data must fit
 it into the existing statements (widen the ``load_only``) or cache it — not add a query.
@@ -28,6 +33,7 @@ See ``conftest.py`` for why round-trips, not query cost, are the metric.
 
 import base64
 import time
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import pytest
@@ -122,7 +128,8 @@ def client(bound_store):
     async def login(request: Request, username: str):
         # "/login" is an unprotected prefix, so this runs without authentication and
         # mints the same session the OIDC callback would.
-        request.session["username"] = username
+        # Mirrors the OIDC callback since #310: the cookie carries only an opaque session id.
+        request.session["session_id"] = store_module.store.create_auth_session(username, expires_at=datetime.now(timezone.utc) + timedelta(hours=8))
         return {"ok": True}
 
     app.add_middleware(AuthMiddleware)
@@ -156,18 +163,19 @@ class TestAuthPathQueryBudget:
 
         assert counts == [0, 0, 0], counter.report()
 
-    def test_session_authenticated_request_issues_two_queries(self, client, counter, auth_user):
-        """The browser path: session lookup is free, the admin check costs 2 statements.
+    def test_session_authenticated_request_issues_one_query(self, client, counter, auth_user):
+        """The browser path costs a single statement since #310.
 
-        Issue #305 claimed ``_get_user_admin_status`` issues 2 uncached queries on every
-        authenticated request. This is that claim, pinned: ``get_profile`` emits a
-        ``load_only`` select on ``users`` plus a ``selectinload`` for ``groups``.
+        Resolving the opaque session id joins ``auth_sessions`` to ``users``, so the session's
+        validity and the user's admin and active flags all come back together. The two-statement
+        profile read this used to perform — the ``load_only`` select plus a ``selectinload`` for
+        groups the auth path never used — is gone from this path.
         """
         client.get(LOGIN_PATH, params={"username": auth_user})
 
         counts = _count_requests(counter, lambda: client.get(PROTECTED_PATH))
 
-        assert counts == [2, 2, 2], counter.report()
+        assert counts == [1, 1, 1], counter.report()
 
     def test_bearer_authenticated_request_issues_two_queries(self, client, counter, auth_user, bearer_token):
         """The API path: with provisioning off (the default), only the admin check runs."""

--- a/mlflow_oidc_auth/tests/repository/test_auth_session.py
+++ b/mlflow_oidc_auth/tests/repository/test_auth_session.py
@@ -1,0 +1,204 @@
+"""Server-side sessions (issue #310).
+
+The session used to be the cookie: Starlette signed a dict holding the username and the server
+kept no record, so a valid cookie stayed valid until it expired and there was nothing to revoke.
+These tests hold the property that made the change worth making — **revocation takes effect on
+the next request**, not whenever the cookie happens to lapse.
+
+Deliberately no caching sits in front of ``resolve``: a cache would put a window between
+revoking a session and the session stopping, which is the one thing this issue exists to remove.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from mlflow.exceptions import MlflowException
+
+TOKEN = "session-token"  # not a credential: only ever seeded into a tmp_path database
+
+
+def _in(seconds: int) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    # A second admin, so the last-active-admin invariant (#311) never masks a failure here.
+    s.create_user("keeper@example.com", TOKEN, "Keeper", is_admin=True)
+    s.create_user("alice@example.com", TOKEN, "Alice")
+    yield s
+    s.engine.dispose()
+
+
+class TestCreateAndResolve:
+    def test_a_session_resolves_to_its_user(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        resolved = store.resolve_auth_session(sid)
+
+        assert resolved is not None
+        assert resolved.username == "alice@example.com"
+        assert resolved.is_admin is False
+        assert resolved.is_active is True
+
+    def test_resolve_returns_the_users_admin_flag(self, store):
+        sid = store.create_auth_session("keeper@example.com", expires_at=_in(3600))
+
+        assert store.resolve_auth_session(sid).is_admin is True
+
+    def test_the_id_is_not_derived_from_the_user(self, store):
+        """The cookie carries only this value, so it must not encode identity or be guessable."""
+        first = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        second = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        assert first != second
+        assert "alice" not in first
+        assert len(first) >= 32
+
+    def test_a_username_is_normalized_on_the_way_in(self, store):
+        sid = store.create_auth_session("ALICE@example.com", expires_at=_in(3600))
+
+        assert store.resolve_auth_session(sid).username == "alice@example.com"
+
+    def test_a_session_cannot_be_opened_for_an_unknown_user(self, store):
+        with pytest.raises(MlflowException) as excinfo:
+            store.create_auth_session("nobody@example.com", expires_at=_in(3600))
+
+        assert excinfo.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
+class TestRejection:
+    """The three ways a cookie is presented and not honoured. All look identical from outside."""
+
+    def test_an_unknown_id_does_not_resolve(self, store):
+        assert store.resolve_auth_session("not-a-session") is None
+
+    def test_an_empty_id_does_not_resolve(self, store):
+        assert store.resolve_auth_session("") is None
+
+    def test_an_expired_session_does_not_resolve(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(-1))
+
+        assert store.resolve_auth_session(sid) is None
+
+    def test_a_revoked_session_does_not_resolve(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        store.revoke_auth_session(sid)
+
+        assert store.resolve_auth_session(sid) is None
+
+
+class TestRevocation:
+    def test_revocation_takes_effect_immediately(self, store):
+        """The point of the issue: no TTL, no cache, no window."""
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        assert store.resolve_auth_session(sid) is not None
+
+        store.revoke_auth_session(sid)
+
+        assert store.resolve_auth_session(sid) is None
+
+    def test_revoking_twice_is_not_an_error(self, store):
+        """A double logout is ordinary, not exceptional."""
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        assert store.revoke_auth_session(sid) is True
+        assert store.revoke_auth_session(sid) is False
+
+    def test_revoking_an_unknown_id_reports_nothing_revoked(self, store):
+        assert store.revoke_auth_session("not-a-session") is False
+
+    def test_revoke_all_ends_every_session_a_user_has(self, store):
+        sids = [store.create_auth_session("alice@example.com", expires_at=_in(3600)) for _ in range(3)]
+
+        assert store.revoke_all_auth_sessions("alice@example.com") == 3
+
+        assert [store.resolve_auth_session(sid) for sid in sids] == [None, None, None]
+
+    def test_revoke_all_leaves_other_users_alone(self, store):
+        mine = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        theirs = store.create_auth_session("keeper@example.com", expires_at=_in(3600))
+
+        store.revoke_all_auth_sessions("alice@example.com")
+
+        assert store.resolve_auth_session(mine) is None
+        assert store.resolve_auth_session(theirs) is not None
+
+    def test_revoke_all_for_an_unknown_user_revokes_nothing(self, store):
+        assert store.revoke_all_auth_sessions("nobody@example.com") == 0
+
+
+class TestDeprovisioning:
+    """Deactivating or deleting an account has to end the sessions it already has."""
+
+    def test_deactivating_a_user_ends_their_sessions(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        store.update_user("alice@example.com", active=False)
+
+        assert store.resolve_auth_session(sid) is None
+
+    def test_deleting_a_user_ends_their_sessions(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        store.delete_user("alice@example.com")
+
+        assert store.resolve_auth_session(sid) is None
+
+    def test_reactivating_a_user_does_not_bring_sessions_back(self, store):
+        """Revocation is one-way. A reactivated user logs in again."""
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        store.update_user("alice@example.com", active=False)
+
+        store.update_user("alice@example.com", active=True)
+
+        assert store.resolve_auth_session(sid) is None
+
+
+class TestHousekeeping:
+    def test_expired_rows_can_be_swept(self, store):
+        expired = store.create_auth_session("alice@example.com", expires_at=_in(-1))
+        live = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        assert store.auth_session_repo.delete_expired() == 1
+
+        assert store.resolve_auth_session(expired) is None
+        assert store.resolve_auth_session(live) is not None
+
+    def test_live_sessions_can_be_listed(self, store):
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        revoked = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+        store.revoke_auth_session(revoked)
+
+        assert store.auth_session_repo.list_live_for_user("alice@example.com") == [sid]
+
+
+class TestQueryBudget:
+    def test_resolving_a_session_is_one_statement(self, store):
+        """The auth path runs this on every request; its statement count is a budget (#305).
+
+        A second round trip for the user's admin and active flags would double it — which is why
+        ``resolve`` joins rather than looking the user up separately.
+        """
+        from sqlalchemy import event
+
+        sid = store.create_auth_session("alice@example.com", expires_at=_in(3600))
+
+        statements = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        event.listen(store.engine, "before_cursor_execute", record)
+        try:
+            store.resolve_auth_session(sid)
+        finally:
+            event.remove(store.engine, "before_cursor_execute", record)
+
+        selects = [s for s in statements if s.strip().upper().startswith("SELECT")]
+        assert len(selects) == 1, f"expected one SELECT, got {len(selects)}: {selects}"

--- a/mlflow_oidc_auth/tests/routers/conftest.py
+++ b/mlflow_oidc_auth/tests/routers/conftest.py
@@ -70,6 +70,11 @@ def mock_store():
     """Mock the store module with comprehensive user and permission data."""
     store_mock = MagicMock()
 
+    # Server-side sessions (#310). A bare MagicMock return would be *truthy*, so a request with
+    # no cookie would resolve to a mock "session" and look authenticated. Default to no session;
+    # a test that wants one sets this explicitly.
+    store_mock.resolve_auth_session.return_value = None
+
     # Mock users
     admin_user = User(
         id_=1,

--- a/mlflow_oidc_auth/tests/routers/conftest.py
+++ b/mlflow_oidc_auth/tests/routers/conftest.py
@@ -74,6 +74,8 @@ def mock_store():
     # no cookie would resolve to a mock "session" and look authenticated. Default to no session;
     # a test that wants one sets this explicitly.
     store_mock.resolve_auth_session.return_value = None
+    store_mock.create_auth_session.return_value = "sid-mock"
+    store_mock.revoke_auth_session.return_value = True
 
     # Mock users
     admin_user = User(
@@ -359,6 +361,11 @@ def _patch_router_stores(mock_store):
     patches = [
         patch("mlflow_oidc_auth.store.store", mock_store),
         patch("mlflow_oidc_auth.utils.request_helpers_fastapi.store", mock_store),
+        # The auth router binds ``store`` at import, so patching the singleton does not reach it.
+        # Without this the OIDC callback opens a *real* session row against whatever database
+        # the lazy singleton last pointed at — which passes in isolation and fails when the
+        # whole suite shares a process.
+        patch("mlflow_oidc_auth.routers.auth.store", mock_store),
         patch("mlflow_oidc_auth.utils.batch_permissions.store", mock_store),
         patch("mlflow_oidc_auth.routers.registered_model_permissions.store", mock_store),
         patch("mlflow_oidc_auth.routers.user_permissions.store", mock_store),

--- a/mlflow_oidc_auth/tests/routers/shared_fixtures.py
+++ b/mlflow_oidc_auth/tests/routers/shared_fixtures.py
@@ -35,6 +35,11 @@ def mock_store():
     """Mock the store module with comprehensive user and permission data."""
     store_mock = MagicMock()
 
+    # Server-side sessions (#310). Returning a bare MagicMock here would be *truthy*, so an
+    # unauthenticated request would look authenticated — default to "no session" and let a test
+    # opt in explicitly.
+    store_mock.resolve_auth_session.return_value = None
+
     # Mock users
     admin_user = User(
         id_=1,

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -7,6 +7,8 @@ and auth status with various scenarios including success, failure, and edge case
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from types import SimpleNamespace
+
 import pytest
 from authlib.jose.errors import BadSignatureError
 from fastapi import HTTPException
@@ -270,7 +272,10 @@ class TestCallbackEndpoint:
             result = await callback(request)
 
             # Verify session was updated
-            assert request.session["username"] == "test@example.com"
+            # The cookie carries an opaque session id, not the username: authenticating from a
+            # cookie-carried username is exactly what could not be revoked (#310).
+            assert "username" not in request.session
+            assert request.session["session_id"]
             assert request.session["authenticated"] is True
 
             # Verify redirect to home page
@@ -372,9 +377,11 @@ class TestAuthStatusEndpoint:
     @pytest.mark.asyncio
     async def test_auth_status_authenticated(self, mock_request_with_session, mock_config):
         """Test auth status for authenticated user."""
-        request = mock_request_with_session({"username": "test@example.com", "authenticated": True})
+        # Since #310 the cookie carries only an opaque session id; the username comes from the row.
+        request = mock_request_with_session({"session_id": "sid-test"})
 
-        with patch("mlflow_oidc_auth.routers.auth.config", mock_config):
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config), patch("mlflow_oidc_auth.routers.auth.store") as mock_store:
+            mock_store.resolve_auth_session.return_value = SimpleNamespace(username="test@example.com", is_admin=False, is_active=True)
             result = await auth_status(request)
 
             assert isinstance(result, JSONResponse)

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -391,6 +391,21 @@ class TestAuthStatusEndpoint:
             assert '"provider":"Test Provider"' in content
 
     @pytest.mark.asyncio
+    async def test_auth_status_deactivated_user_is_not_authenticated(self, mock_request_with_session, mock_config):
+        """``resolve`` reports the active flag rather than filtering on it, so the endpoint has
+        to apply the check — otherwise the SPA renders a logged-in shell for an account every
+        API call will 401."""
+        request = mock_request_with_session({"session_id": "sid-inactive"})
+
+        with patch("mlflow_oidc_auth.routers.auth.config", mock_config), patch("mlflow_oidc_auth.routers.auth.store") as mock_store:
+            mock_store.resolve_auth_session.return_value = SimpleNamespace(username="gone@example.com", is_admin=False, is_active=False)
+            result = await auth_status(request)
+
+            content = result.body.decode()
+            assert '"authenticated":false' in content
+            assert '"username":null' in content
+
+    @pytest.mark.asyncio
     async def test_auth_status_unauthenticated(self, mock_request_with_session, mock_config):
         """Test auth status for unauthenticated user."""
         request = mock_request_with_session({})

--- a/mlflow_oidc_auth/tests/test_deleted_user_session.py
+++ b/mlflow_oidc_auth/tests/test_deleted_user_session.py
@@ -20,6 +20,8 @@ All three sit behind ``AuthMiddleware``, which `app.py` adds before mounting Fla
 one denial covers them — but that is a structural claim, and this file is the evidence.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
@@ -92,7 +94,7 @@ def client(store):
 
     @api.get(LOGIN)
     async def login(request: Request, username: str):
-        request.session["username"] = username
+        request.session["session_id"] = store_module.store.create_auth_session(username, expires_at=datetime.now(timezone.utc) + timedelta(hours=8))
         return {"ok": True}
 
     api.add_middleware(AuthMiddleware)
@@ -164,10 +166,13 @@ class TestDeletedUserIsDeniedOnEverySurface:
         assert response.status_code == 401
         assert response.json().get("username") is None
 
-    def test_recreating_the_user_restores_access(self, store, client):
-        """The cookie was never invalidated — only the account state changed — so a same-named
-        account restores access. Worth pinning: it is the behaviour a server-side session store
-        (#310) would change, and #310 should know it is changing it deliberately.
+    def test_recreating_the_user_does_not_revive_the_old_session(self, store, client):
+        """The acceptance criterion #310 exists for.
+
+        Before server-side sessions the cookie was never invalidated — only the account state
+        changed — so an account recreated with the same username silently restored access to a
+        session that belonged to the deleted one. The session is now a row, deleted with its
+        user, and the cookie names something that no longer exists.
         """
         store.create_user("gone@example.com", PASSWORD, "Gone")
         store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
@@ -177,7 +182,7 @@ class TestDeletedUserIsDeniedOnEverySurface:
 
         store.create_user("gone@example.com", PASSWORD, "Gone Again")
 
-        assert client.get(FASTAPI_ROUTE).status_code == 200
+        assert client.get(FASTAPI_ROUTE).status_code == 401
 
 
 class TestDenialAuditIsThrottled:
@@ -187,13 +192,23 @@ class TestDenialAuditIsThrottled:
     """
 
     def _deny_repeatedly(self, store, client, monkeypatch, username, times):
+        """Log in, deactivate out-of-band, then hammer a protected route.
+
+        Deactivation rather than deletion: a deleted user's session row goes with them, so the
+        request is simply unauthenticated and never reaches the denial path. An inactive user
+        still resolves — the join finds the row and reports ``active=False`` — which is the case
+        the denial audit exists for.
+        """
+        from sqlalchemy import text
+
         events = []
         monkeypatch.setattr(
             "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
             lambda event, **kwargs: events.append((event, kwargs)),
         )
         client.get(LOGIN, params={"username": username})
-        store.delete_user(username)
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0 WHERE username = :u"), {"u": username})
         for _ in range(times):
             assert client.get(FASTAPI_ROUTE).status_code == 401
         return events
@@ -225,9 +240,12 @@ class TestDenialAuditIsThrottled:
             store.create_user(name, PASSWORD, name)
         store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
 
+        from sqlalchemy import text
+
         for name in ("a@example.com", "b@example.com"):
             client.get(LOGIN, params={"username": name})
-            store.delete_user(name)
+            with store.engine.begin() as conn:
+                conn.execute(text("UPDATE users SET active = 0 WHERE username = :u"), {"u": name})
             client.get(FASTAPI_ROUTE)
             client.get(FASTAPI_ROUTE)
 
@@ -249,10 +267,10 @@ class TestDenialAuditIsThrottled:
         with store.engine.begin() as conn:
             conn.execute(text("UPDATE users SET active = 0 WHERE username = 'x@example.com'"))
         client.get(FASTAPI_ROUTE)
-        store.delete_user("x@example.com")
         client.get(FASTAPI_ROUTE)
 
-        assert events == ["auth.denied_inactive", "auth.denied_unknown_user"]
+        # One event for the inactive account, not one per request.
+        assert events == ["auth.denied_inactive"]
 
     def test_the_throttle_cache_is_bounded(self):
         """An attacker rotating usernames must not grow this without limit; evicting only ever
@@ -290,22 +308,53 @@ class TestDenialIsReportedAsDeletion:
     """A deleted user is not an inactive one, and an operator reading the log should not have to
     guess which happened."""
 
-    def test_the_audit_event_names_deletion(self, store, client, monkeypatch):
+    def test_a_deleted_users_session_is_revoked_rather_than_denied(self, store, client, monkeypatch):
+        """Deletion ends the session at the source.
+
+        Before #310 a deleted user kept presenting a valid cookie and was turned away on every
+        request; the audit event recorded each refusal. The session row now goes with the user,
+        so there is one ``session.revoked`` event at deletion instead of an endless stream of
+        denials — the same information, recorded once, at the moment it happened.
+        """
         events = []
+        # The repository imports ``emit_audit_event`` inside the function, so the patch has to
+        # land on the audit module itself — patching the repository's namespace would silently
+        # create an attribute nothing reads.
         monkeypatch.setattr(
-            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            "mlflow_oidc_auth.audit.emit_audit_event",
             lambda event, **kwargs: events.append((event, kwargs)),
         )
         store.create_user("gone@example.com", PASSWORD, "Gone")
         store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
         client.get(LOGIN, params={"username": "gone@example.com"})
+
         store.delete_user("gone@example.com")
+
+        assert client.get(FASTAPI_ROUTE).status_code == 401
+        revoked = [kwargs for event, kwargs in events if event == "session.revoked"]
+        assert len(revoked) == 1, f"expected one session.revoked event, got {[e for e, _ in events]}"
+        assert revoked[0]["actor"] == "gone@example.com"
+        assert revoked[0]["detail"]["reason"] == "user_deleted"
+        assert revoked[0]["detail"]["sessions"] == 1
+
+    def test_the_inactive_denial_is_still_named(self, store, client, monkeypatch):
+        events = []
+        monkeypatch.setattr(
+            "mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event",
+            lambda event, **kwargs: events.append((event, kwargs)),
+        )
+        from sqlalchemy import text
+
+        store.create_user("off@example.com", PASSWORD, "Off")
+        client.get(LOGIN, params={"username": "off@example.com"})
+        with store.engine.begin() as conn:
+            conn.execute(text("UPDATE users SET active = 0 WHERE username = 'off@example.com'"))
 
         client.get(FASTAPI_ROUTE)
 
         assert events, "a denial must be audited"
         event, kwargs = events[0]
-        assert event == "auth.denied_unknown_user"
+        assert event == "auth.denied_inactive"
         assert kwargs["status"] == "denied"
 
     def test_an_inactive_user_is_still_reported_as_inactive(self, store, client, monkeypatch):

--- a/mlflow_oidc_auth/tests/test_routers_auth.py
+++ b/mlflow_oidc_auth/tests/test_routers_auth.py
@@ -669,6 +669,41 @@ class TestSessionHandoverOnReLogin:
         assert req.session["session_id"] == "sid-second"
 
     @pytest.mark.asyncio
+    async def test_the_previous_users_refresh_token_is_not_inherited(self, monkeypatch):
+        """The finding this ordering exists for.
+
+        ``_persist_session_auth`` keeps an existing refresh token when the new token response
+        carries none, so retiring the old login *after* the exchange would hand the next user
+        the previous user's grant — their session would then outlive their own IdP session and
+        die with someone else's.
+        """
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+        seen = {}
+
+        async def _proc(request, session):
+            # Stands in for the token exchange: records what the previous login left behind,
+            # then persists a token response that carries no refresh token of its own.
+            seen["at_exchange"] = dict(session)
+            auth_router_mod._persist_session_auth(session, {"expires_at": 4102444800})
+            return "second@example.com", []
+
+        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
+        monkeypatch.setattr(auth_router_mod, "_open_server_session", lambda username: "sid-second")
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: True)
+        monkeypatch.setattr(config, "OIDC_USE_REFRESH_TOKEN", True)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-first"
+        req.session["refresh_token"] = "rt-first"
+        req.session["expires_at"] = 100
+
+        await auth_router_mod.callback(req)
+
+        assert "refresh_token" not in seen["at_exchange"], "the exchange must not see the previous login's token"
+        assert "refresh_token" not in req.session
+        assert req.session["session_id"] == "sid-second"
+
+    @pytest.mark.asyncio
     async def test_a_failure_to_open_a_session_clears_the_cookie(self, monkeypatch):
         monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
 
@@ -711,6 +746,48 @@ class TestLogoutSurfacesRevocationFailure:
             await auth_router_mod.logout(req)
 
         assert excinfo.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_the_session_id_survives_a_failed_revocation(self, monkeypatch):
+        """So the 503's advice to retry is advice the user can act on.
+
+        Clearing the cookie first would delete the only copy of the session id: the retry would
+        find nothing to revoke, take the success path, and leave the session live.
+        """
+
+        def _boom(session_id):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", _boom)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-live"
+
+        with pytest.raises(HTTPException):
+            await auth_router_mod.logout(req)
+
+        assert req.session.get("session_id") == "sid-live"
+
+    @pytest.mark.asyncio
+    async def test_the_failure_is_audited_as_a_failure(self, monkeypatch):
+        """A denied outcome recorded with the default status "success" is invisible to the
+        query an operator actually runs."""
+        events = []
+        monkeypatch.setattr(auth_router_mod, "emit_audit_event", lambda event, **kwargs: events.append((event, kwargs)))
+
+        def _boom(session_id):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", _boom)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-live"
+
+        with pytest.raises(HTTPException):
+            await auth_router_mod.logout(req)
+
+        assert [e for e, _ in events] == ["auth.logout_failed"]
+        assert events[0][1]["status"] == "denied"
 
     @pytest.mark.asyncio
     async def test_a_successful_logout_revokes_the_row(self, monkeypatch):

--- a/mlflow_oidc_auth/tests/test_routers_auth.py
+++ b/mlflow_oidc_auth/tests/test_routers_auth.py
@@ -169,7 +169,7 @@ async def test_login_no_authorize_redirect_raises(monkeypatch):
 @pytest.mark.asyncio
 async def test_logout_with_end_session_endpoint(monkeypatch):
     req = DummyRequest()
-    req.session["username"] = "bob"
+    req.session["session_id"] = "sid-bob"
     import types
 
     monkeypatch.setattr(auth_router_mod.oauth, "oidc", types.SimpleNamespace(), raising=False)
@@ -191,7 +191,7 @@ async def test_logout_with_end_session_endpoint(monkeypatch):
 @pytest.mark.asyncio
 async def test_logout_without_end_session_endpoint(monkeypatch):
     req = DummyRequest()
-    req.session["username"] = "bob"
+    req.session["session_id"] = "sid-bob"
     # ensure oidc client exists and remove server_metadata
     import types
 
@@ -251,6 +251,8 @@ async def test_callback_success_redirects(monkeypatch):
         return "User@Example.COM", []
 
     monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _fake_proc2)
+    # The callback now opens a server-side session row (#310); the fake user has none.
+    monkeypatch.setattr(auth_router_mod, "_open_server_session", lambda username: "sid-opened")
 
     req = DummyRequest()
     # case False -> redirect to base url
@@ -292,9 +294,15 @@ async def test_auth_status(monkeypatch):
 
     # authenticated
     req2 = DummyRequest()
-    req2.session["username"] = "bob"
+    req2.session["session_id"] = "sid-bob"
     import json
+    from types import SimpleNamespace
 
+    monkeypatch.setattr(
+        auth_router_mod.store,
+        "resolve_auth_session",
+        lambda sid: SimpleNamespace(username="bob", is_admin=False, is_active=True) if sid == "sid-bob" else None,
+    )
     monkeypatch.setattr(config, "OIDC_PROVIDER_DISPLAY_NAME", "Prov")
     res2 = await auth_router_mod.auth_status(req2)
     payload = json.loads(res2.body)
@@ -629,3 +637,91 @@ async def test_process_oidc_callback_final_except(monkeypatch):
 
     email, errors = await auth_router_mod._process_oidc_callback_fastapi(req, session)
     assert "Failed to process authentication response" in errors[0]
+
+
+class TestSessionHandoverOnReLogin:
+    """Two logins in the same browser must not leave the first user's session id in the cookie.
+
+    Found by security review of #310: the callback writes the new login's refresh token into the
+    cookie *before* opening the session row. If opening it then failed and the old ``session_id``
+    were still there, the browser would stay authenticated as the previous user and go on
+    refreshing that session with the new user's IdP grant.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_previous_session_is_revoked_and_replaced(self, monkeypatch):
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+
+        async def _proc(request, session):
+            return "second@example.com", []
+
+        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
+        monkeypatch.setattr(auth_router_mod, "_open_server_session", lambda username: "sid-second")
+        revoked = []
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: revoked.append(sid) or True)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-first"
+
+        await auth_router_mod.callback(req)
+
+        assert revoked == ["sid-first"]
+        assert req.session["session_id"] == "sid-second"
+
+    @pytest.mark.asyncio
+    async def test_a_failure_to_open_a_session_clears_the_cookie(self, monkeypatch):
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+
+        async def _proc(request, session):
+            return "second@example.com", []
+
+        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
+
+        def _boom(username):
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(auth_router_mod, "_open_server_session", _boom)
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: True)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-first"
+        req.session["refresh_token"] = "rt-second"  # written by _persist_session_auth already
+
+        res = await auth_router_mod.callback(req)
+
+        assert isinstance(res, RedirectResponse)
+        assert "session_error" in res.headers["location"]
+        assert req.session == {}, "a failed login must not leave any credential in the cookie"
+
+
+class TestLogoutSurfacesRevocationFailure:
+    """Telling a user they are logged out while the session stays live is the worst outcome."""
+
+    @pytest.mark.asyncio
+    async def test_a_revocation_failure_is_not_reported_as_success(self, monkeypatch):
+        def _boom(session_id):
+            raise RuntimeError("database is down")
+
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", _boom)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-live"
+
+        with pytest.raises(HTTPException) as excinfo:
+            await auth_router_mod.logout(req)
+
+        assert excinfo.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_a_successful_logout_revokes_the_row(self, monkeypatch):
+        revoked = []
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: revoked.append(sid) or True)
+        monkeypatch.setattr(auth_router_mod.oauth, "oidc", types.SimpleNamespace(), raising=False)
+
+        req = DummyRequest()
+        req.session["session_id"] = "sid-live"
+
+        res = await auth_router_mod.logout(req)
+
+        assert revoked == ["sid-live"]
+        assert isinstance(res, RedirectResponse)

--- a/mlflow_oidc_auth/tests/test_server_side_sessions_e2e.py
+++ b/mlflow_oidc_auth/tests/test_server_side_sessions_e2e.py
@@ -9,6 +9,7 @@ worth holding at this level because both are invisible from the repository:
    and cannot revoke — which is the whole defect. Everyone logs in again once, deliberately.
 """
 
+import base64
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -24,6 +25,12 @@ PROTECTED = "/e2e/protected"
 LOGIN = "/login/e2e"
 LEGACY_LOGIN = "/login/e2e-legacy"
 USERNAME = "session-e2e@example.com"
+
+
+def _basic(username: str, token: str) -> dict:
+    """An Authorization header for the username/token pair MLflow clients use."""
+    encoded = base64.b64encode(f"{username}:{token}".encode()).decode()
+    return {"Authorization": f"Basic {encoded}"}
 
 
 @pytest.fixture
@@ -156,4 +163,78 @@ class TestForcedReLogin:
 
         client.get(LOGIN)
 
+        assert client.get(PROTECTED).status_code == 200
+
+
+class TestUserTokensAreIndependentOfSessions:
+    """Sessions moved server-side; user tokens did not.
+
+    Both credentials name the same account, so the two now have to be shown not to interfere:
+    a browser session must not be needed to use a token, revoking sessions must not disable a
+    token, and rotating a token must not log the browser out. Deprovisioning is the one place
+    they *must* agree — a deactivated user is refused on either.
+    """
+
+    def test_a_token_authenticates_with_no_cookie_at_all(self, client, store):
+        response = client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD))
+
+        assert response.status_code == 200
+        assert response.json()["username"] == USERNAME
+
+    def test_a_wrong_token_is_refused(self, client):
+        assert client.get(PROTECTED, headers=_basic(USERNAME, "not-the-token")).status_code == 401
+
+    def test_a_token_still_works_after_every_session_is_revoked(self, client, store):
+        """Revocation ends browser sessions. It is not a way to disable API access."""
+        client.get(LOGIN)
+        store.revoke_all_auth_sessions(USERNAME)
+        assert client.get(PROTECTED).status_code == 401, "precondition: the cookie is dead"
+
+        assert client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD)).status_code == 200
+
+    def test_rotating_the_token_does_not_end_the_browser_session(self, store, client):
+        """The session is a row of its own; it does not hang off the password hash."""
+        client.get(LOGIN)
+        store.update_user(USERNAME, password="rotated-token", password_expiration=None)
+
+        assert client.get(PROTECTED).status_code == 200
+
+    def test_rotating_the_token_invalidates_the_old_one(self, client, store):
+        store.update_user(USERNAME, password="rotated-token", password_expiration=None)
+
+        assert client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD)).status_code == 401
+        assert client.get(PROTECTED, headers=_basic(USERNAME, "rotated-token")).status_code == 200
+
+    def test_a_cookie_is_ignored_when_a_token_is_presented(self, client, store):
+        """The Authorization header wins outright, so a revoked session cannot leak its stale
+        admin or active flags into a token-authenticated request."""
+        client.get(LOGIN)
+        store.revoke_all_auth_sessions(USERNAME)
+
+        response = client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD))
+
+        assert response.status_code == 200
+        assert response.json()["username"] == USERNAME
+
+    def test_deactivating_the_user_refuses_both_credentials(self, client, store):
+        """The one place the two must agree."""
+        client.get(LOGIN)
+        store.update_user(USERNAME, active=False)
+
+        assert client.get(PROTECTED).status_code == 401
+        assert client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD)).status_code == 401
+
+    def test_deleting_the_user_refuses_both_credentials(self, client, store):
+        client.get(LOGIN)
+        store.delete_user(USERNAME)
+
+        assert client.get(PROTECTED).status_code == 401
+        assert client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD)).status_code == 401
+
+    def test_an_expired_token_is_refused_while_the_session_still_works(self, client, store):
+        """Token expiry and session expiry are separate clocks, and neither drives the other."""
+        client.get(LOGIN)
+        store.update_user(USERNAME, password=PASSWORD, password_expiration=datetime.now(timezone.utc) - timedelta(seconds=1))
+
+        assert client.get(PROTECTED, headers=_basic(USERNAME, PASSWORD)).status_code == 401
         assert client.get(PROTECTED).status_code == 200

--- a/mlflow_oidc_auth/tests/test_server_side_sessions_e2e.py
+++ b/mlflow_oidc_auth/tests/test_server_side_sessions_e2e.py
@@ -1,0 +1,159 @@
+"""Server-side sessions, end to end through the real middleware (issue #310).
+
+The repository tests prove the rows behave; these prove the *request* does. Two properties are
+worth holding at this level because both are invisible from the repository:
+
+1. **Revoking a session ends the next request**, with no TTL and no cache in between.
+2. **A cookie minted before this change no longer authenticates.** The old cookie carried the
+   username itself; honouring one would mean honouring a credential the server has no record of
+   and cannot revoke — which is the whole defect. Everyone logs in again once, deliberately.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+import mlflow_oidc_auth.store as store_module
+from mlflow_oidc_auth.middleware import AuthMiddleware
+
+PASSWORD = "session-e2e-password"  # not a credential: only ever seeded into a tmp_path database
+PROTECTED = "/e2e/protected"
+LOGIN = "/login/e2e"
+LEGACY_LOGIN = "/login/e2e-legacy"
+USERNAME = "session-e2e@example.com"
+
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    s.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+    s.create_user(USERNAME, PASSWORD, "Session E2E")
+    yield s
+    s.engine.dispose()
+
+
+@pytest.fixture
+def client(store):
+    """A TestClient over the real ``AuthMiddleware``, with the store singleton pointed at ``store``.
+
+    Middleware order mirrors ``app.py`` — Auth then Session, which makes Session the outer one,
+    so ``request.session`` exists by the time ``AuthMiddleware`` reads it.
+    """
+    previous = object.__getattribute__(store_module.store, "_instance")
+    object.__setattr__(store_module.store, "_instance", store)
+
+    app = FastAPI()
+
+    @app.get(PROTECTED)
+    async def protected(request: Request):
+        return {"username": getattr(request.state, "username", None)}
+
+    @app.get(LOGIN)
+    async def login(request: Request):
+        # "/login" is an unprotected prefix. Mints the same cookie the OIDC callback does.
+        request.session["session_id"] = store_module.store.create_auth_session(USERNAME, expires_at=datetime.now(timezone.utc) + timedelta(hours=8))
+        return {"ok": True}
+
+    @app.get(LEGACY_LOGIN)
+    async def legacy_login(request: Request):
+        # The pre-#310 cookie: the username, signed, and nothing on the server.
+        request.session["username"] = USERNAME
+        return {"ok": True}
+
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        object.__setattr__(store_module.store, "_instance", previous)
+
+
+class TestSessionAuthentication:
+    def test_a_session_cookie_authenticates(self, client):
+        client.get(LOGIN)
+
+        response = client.get(PROTECTED)
+
+        assert response.status_code == 200
+        assert response.json()["username"] == USERNAME
+
+    def test_no_cookie_is_rejected(self, client):
+        assert client.get(PROTECTED).status_code == 401
+
+    def test_an_unknown_session_id_is_rejected(self, client):
+        client.get(LOGIN)
+        client.cookies.clear()
+
+        assert client.get(PROTECTED).status_code == 401
+
+
+class TestRevocationEndsTheNextRequest:
+    """No TTL, no cache: the request after the revocation fails."""
+
+    def test_revoking_the_session_ends_it(self, client, store):
+        client.get(LOGIN)
+        assert client.get(PROTECTED).status_code == 200
+        session_id = store.auth_session_repo.list_live_for_user(USERNAME)[0]
+
+        store.revoke_auth_session(session_id)
+
+        assert client.get(PROTECTED).status_code == 401
+
+    def test_revoking_every_session_ends_it(self, client, store):
+        client.get(LOGIN)
+        assert client.get(PROTECTED).status_code == 200
+
+        store.revoke_all_auth_sessions(USERNAME)
+
+        assert client.get(PROTECTED).status_code == 401
+
+    def test_deactivating_the_user_ends_it(self, client, store):
+        client.get(LOGIN)
+        assert client.get(PROTECTED).status_code == 200
+
+        store.update_user(USERNAME, active=False)
+
+        assert client.get(PROTECTED).status_code == 401
+
+    def test_deleting_the_user_ends_it(self, client, store):
+        client.get(LOGIN)
+        assert client.get(PROTECTED).status_code == 200
+
+        store.delete_user(USERNAME)
+
+        assert client.get(PROTECTED).status_code == 401
+
+
+class TestForcedReLogin:
+    """The deliberate upgrade cost: existing cookies stop working when this ships."""
+
+    def test_a_pre_310_cookie_does_not_authenticate(self, client):
+        client.get(LEGACY_LOGIN)
+
+        response = client.get(PROTECTED)
+
+        assert response.status_code == 401
+
+    def test_a_pre_310_cookie_cannot_be_upgraded_by_naming_a_real_user(self, client, store):
+        """The username in the old cookie is not evidence of anything — it never was signed by us
+        in a way tied to a server record. It must not be trusted to mint a new session."""
+        client.get(LEGACY_LOGIN)
+        client.get(PROTECTED)
+
+        assert store.auth_session_repo.list_live_for_user(USERNAME) == []
+
+    def test_logging_in_again_works(self, client):
+        client.get(LEGACY_LOGIN)
+        assert client.get(PROTECTED).status_code == 401
+
+        client.get(LOGIN)
+
+        assert client.get(PROTECTED).status_code == 200

--- a/mlflow_oidc_auth/tests/test_user_lifecycle.py
+++ b/mlflow_oidc_auth/tests/test_user_lifecycle.py
@@ -12,6 +12,8 @@ the three are tested together because they are one safety story.
 import base64
 import time
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from authlib.jose import JsonWebKey, jwt
 from click.testing import CliRunner
@@ -77,7 +79,9 @@ def client(bound_store):
 
     @app.get(LOGIN)
     async def login(request: Request, username: str):
-        request.session["username"] = username
+        # Mirrors the OIDC callback: the cookie carries only an opaque session id, and the row
+        # it names is what can be revoked (#310).
+        request.session["session_id"] = store_module.store.create_auth_session(username, expires_at=datetime.now(timezone.utc) + timedelta(hours=8))
         return {"ok": True}
 
     app.add_middleware(AuthMiddleware)
@@ -161,9 +165,9 @@ class TestInactiveUserIsDeniedOnEveryAuthPath:
 
 
 class TestInactiveDenialCostsNoExtraQuery:
-    def test_the_statement_count_is_unchanged(self, store, client):
-        """``active`` rides along in the ``load_only`` list #333 added, so the #305 budget of 2
-        statements per authenticated request still holds."""
+    def test_the_statement_count_is_one(self, store, client):
+        """``active`` comes back from the session join itself since #310, so the check costs
+        nothing and the session path is a single statement."""
         from sqlalchemy import event
 
         store.create_user("q@example.com", PASSWORD, "Q")
@@ -182,7 +186,7 @@ class TestInactiveDenialCostsNoExtraQuery:
         finally:
             event.remove(store.engine, "before_cursor_execute", listener)
 
-        assert len(statements) == 2, statements
+        assert len(statements) == 1, statements
 
 
 class TestLastActiveAdminInvariant:

--- a/mlflow_oidc_auth/tests/utils/test_request_helpers_fastapi.py
+++ b/mlflow_oidc_auth/tests/utils/test_request_helpers_fastapi.py
@@ -6,6 +6,7 @@ including parameter extraction, authentication, and user information retrieval.
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import asyncio
 
@@ -46,6 +47,24 @@ class TestRequestHelpersFastAPI(unittest.TestCase):
 
         asyncio.run(test_async())
 
+    def test_get_username_from_session_ignores_a_deactivated_user(self):
+        """``resolve`` reports the active flag rather than filtering on it, so the middleware can
+        audit "deactivated" separately. This helper feeds ``is_authenticated``, which is a
+        dependency of an endpoint on an unprotected prefix, and must apply the check itself."""
+
+        async def test_async():
+            mock_request = MagicMock(spec=Request)
+            mock_request.state = MagicMock()
+            mock_request.state.username = None
+            mock_request.session = {"session_id": "sid-inactive"}
+
+            with patch("mlflow_oidc_auth.store.store") as mock_store:
+                mock_store.resolve_auth_session.return_value = SimpleNamespace(username="gone@example.com", is_active=False)
+                result = await get_username_from_session(mock_request)
+            self.assertIsNone(result)
+
+        asyncio.run(test_async())
+
     def test_get_username_from_session_with_session_fallback(self):
         """Test username extraction from session fallback."""
 
@@ -53,9 +72,11 @@ class TestRequestHelpersFastAPI(unittest.TestCase):
             mock_request = MagicMock(spec=Request)
             mock_request.state = MagicMock()
             mock_request.state.username = None
-            mock_request.session = {"username": "session_user"}
+            mock_request.session = {"session_id": "sid-1"}
 
-            result = await get_username_from_session(mock_request)
+            with patch("mlflow_oidc_auth.store.store") as mock_store:
+                mock_store.resolve_auth_session.return_value = SimpleNamespace(username="session_user", is_active=True)
+                result = await get_username_from_session(mock_request)
             self.assertEqual(result, "session_user")
 
         asyncio.run(test_async())
@@ -83,9 +104,11 @@ class TestRequestHelpersFastAPI(unittest.TestCase):
             # Remove username attribute
             if hasattr(mock_request.state, "username"):
                 delattr(mock_request.state, "username")
-            mock_request.session = {"username": "session_user"}
+            mock_request.session = {"session_id": "sid-1"}
 
-            result = await get_username_from_session(mock_request)
+            with patch("mlflow_oidc_auth.store.store") as mock_store:
+                mock_store.resolve_auth_session.return_value = SimpleNamespace(username="session_user", is_active=True)
+                result = await get_username_from_session(mock_request)
             self.assertEqual(result, "session_user")
 
         asyncio.run(test_async())

--- a/mlflow_oidc_auth/utils/request_helpers_fastapi.py
+++ b/mlflow_oidc_auth/utils/request_helpers_fastapi.py
@@ -43,15 +43,23 @@ async def get_username_from_session(request: Request) -> Optional[str]:
         if hasattr(request.state, "username"):
             logger.debug(f"Request state username value: {request.state.username}")
 
-    # Fallback to session for backward compatibility
+    # Fallback to the server-side session. Since #310 the cookie carries only an opaque id, so
+    # the username comes from the row it names — never from the cookie itself, which is what
+    # made a session impossible to revoke.
     try:
+        from mlflow_oidc_auth.store import store
+
         session = request.session
-        username = session.get("username")
-        if username:
-            logger.debug(f"Username from session: {username}")
-            return username
+        resolved = store.resolve_auth_session(session.get("session_id", ""))
+        # ``resolve`` reports the account's active flag rather than filtering on it, so the
+        # middleware can tell "no session" from "deactivated user" and audit the latter. This
+        # helper has no such need and must not treat a deactivated user as authenticated —
+        # ``is_authenticated`` is a dependency of an endpoint on an unprotected prefix.
+        if resolved and resolved.is_active:
+            logger.debug(f"Username from session: {resolved.username}")
+            return resolved.username
         else:
-            logger.debug("No username found in session")
+            logger.debug("No usable session found")
     except Exception as e:
         logger.debug(f"Error accessing session: {e}")
 


### PR DESCRIPTION
Closes #310 (slice A: sessions become rows and can be revoked. The admin-facing "list and revoke my sessions" API is not in this diff — see *Deliberate deviations*.)

## The problem

The session **was** the cookie. Starlette signed a dict holding the username; the server kept no record. A valid cookie therefore stayed valid until it expired, and there was nothing to revoke:

- logout cleared the cookie from one browser, and did nothing to a copy of it,
- deactivating an account left its sessions running,
- deleting a user left a signed cookie naming someone who no longer existed.

## What changed

Sessions are rows in `auth_sessions` (the table landed with #333; this is the behaviour over it). The cookie carries only an opaque 256-bit id from `secrets.token_urlsafe`, and every request resolves it against the database.

- `mlflow_oidc_auth/repository/auth_session.py` (new) — `create` / `resolve` / `revoke` / `revoke_all_for_user` / `list_live_for_user` / `delete_expired`.
- `AuthMiddleware._authenticate_session` reads `session["session_id"]`, resolves it, and stashes the result on `request.state` so `dispatch` does not look it up twice.
- The OIDC callback opens the row; logout revokes it.
- `UserRepository.update(active=False)` and `delete()` revoke the user's live sessions and emit a `session.revoked` audit event.

**Revocation takes effect on the next request.** No cache sits in front of resolution, deliberately — a TTL there would reintroduce precisely the window this issue exists to close.

## Query budget (#305)

Resolution is **one statement**: it joins `auth_sessions` to `users` and returns session validity together with the username, admin and active flags. So the session path *drops*:

| scenario | before | after |
|---|---|---|
| unprotected | 0 | 0 |
| **session** | **2** | **1** |
| bearer | 2 | 2 |
| basic | 3 | 3 |

The two-statement profile read the session path used to perform — a `load_only` select plus a `selectinload` of groups the auth path never used — is gone. `mlflow_oidc_auth/tests/perf/test_auth_path_baseline.py` is updated and pins the new number exactly, so a regression *and* a silent improvement both have to be acknowledged in a diff.

## Breaking change: everyone logs in again, once

Cookies minted before this change do not authenticate. Honouring one would mean honouring a credential the server has no record of and cannot revoke — the defect itself. On deploy, users are redirected to log in; nothing else is required of an operator.

## Deliberate deviations

- **No cache.** Stated above; it would trade away the acceptance criterion.
- **No session-management API in this diff.** `revoke_all_auth_sessions` and `list_live_for_user` exist in the store but have no router yet, so today the only ways to end someone's session are logout, deactivate, or delete. "User reports a stolen laptop" is answered by deactivating the account. The API is slice B.
- **`last_seen_at` is written by nothing.** Only absolute expiry exists; idle timeout would need it.

## Review findings fixed in this PR

A `security-reviewer` pass over the diff found two behaviours worth fixing before merge, both now covered by tests:

1. **Re-login left the previous user's session id in the cookie.** The callback writes the new login's refresh token into the cookie *before* opening the session row. If opening it then failed, the browser stayed authenticated as the previous user — and would go on refreshing that session with the new user's IdP grant. The callback now retires the incoming session first and clears the cookie entirely on failure.
2. **Logout reported success when revocation failed.** The revoke call sat inside the handler's broad `except`, so a database outage produced a normal "logged out" page while the row stayed live for its full lifetime. It now returns 503 and audits `auth.logout_failed`.

Also from that pass: the audit events are emitted after the transaction commits (an event written inside it could claim sessions were revoked when the commit then failed); `get_username_from_session` now applies the active check itself, since it feeds `is_authenticated` on an unprotected prefix; and a `session.revoked` assertion that had been dropped from `test_deleted_user_session.py` is restored — its `monkeypatch` target was wrong, so it had been patching a name nothing read.

## Validation

```
pre-commit run --all-files                             # passed
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks      # 3199 passed, 14 skipped
pytest mlflow_oidc_auth/tests/hooks/<each file>        # 352 passed (run file by file, per AGENTS.md)
pytest mlflow_oidc_auth/tests/perf/                    # 37 passed
```

New tests: `tests/repository/test_auth_session.py` (21), `tests/test_server_side_sessions_e2e.py` (10, through the real middleware), plus negative cases for re-login and logout failure in `tests/test_routers_auth.py`. Negative paths covered: unknown id, empty id, expired, revoked, revoke-all, deactivated user, deleted user, and a pre-#310 cookie — including that a pre-#310 cookie cannot mint a new session by naming a real user.

No frontend files changed, so `yarn test`/`yarn lint` were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)