### PR TITLE
test(auth): adversarial JWT and authorization-response suite (#307)

### DIFF
--- a/mlflow_oidc_auth/authorization_response.py
+++ b/mlflow_oidc_auth/authorization_response.py
@@ -39,8 +39,9 @@ def validate_response_issuer(
     """Check the ``iss`` of an authorization response against the issuer that started it.
 
     Parameters:
-        returned_iss: The ``iss`` query parameter on the callback, or None when absent. A value
-            that is not a string — a list, from a repeated parameter — is refused.
+        returned_iss: The ``iss`` query parameter on the callback, or None when absent. A
+            sequence is accepted for callers reading the query string with ``getlist``: empty is
+            the absent case, one element is that element, and more than one is refused.
         expected_iss: The issuer recorded when the login began. None when the deployment has no
             record of it — which is every deployment before #316 gives transactions a home.
         iss_parameter_supported: Whether the provider's discovery metadata advertises
@@ -68,14 +69,28 @@ def validate_response_issuer(
     if expected_iss is None:
         return
 
-    # A query string can repeat a parameter — ``?iss=honest&iss=attacker`` — so a caller reading
-    # it with ``getlist`` hands this a list. Refused as the documented error rather than left to
-    # raise ``AttributeError`` on the ``.strip()`` below: that would escape a caller catching
-    # only ``IssuerMismatchError``, turning the mix-up defence into an unhandled 500.
+    # A caller reading the query string with ``getlist`` — the only way to notice a repeated
+    # ``?iss=honest&iss=attacker`` — hands this a sequence, and its *length* is what decides:
+    # none means the parameter was absent, one is the ordinary case, and two or more is a
+    # response that names several issuers and so can be attributed to none of them. Deciding on
+    # the type instead would refuse the empty list every provider that omits ``iss`` produces,
+    # and break every login against it.
+    if isinstance(returned_iss, (list, tuple)):
+        if len(returned_iss) > 1:
+            raise IssuerMismatchError(
+                f"The authorization response carried {len(returned_iss)} 'iss' parameters; a response naming more "
+                "than one issuer cannot be attributed to any of them."
+            )
+        returned_iss = returned_iss[0] if returned_iss else None
+
+    # Anything else that is not a string is not an issuer and not the absence of one. Refused as
+    # the documented error rather than left to raise ``AttributeError`` on the ``.strip()``
+    # below, which would escape a caller catching only ``IssuerMismatchError`` and turn the
+    # mix-up defence into an unhandled 500.
     if returned_iss is not None and not isinstance(returned_iss, str):
         raise IssuerMismatchError(
-            f"The authorization response carried a non-string 'iss' ({type(returned_iss).__name__}); a response that "
-            "names more than one issuer, or none in a readable form, cannot be attributed to one."
+            f"The authorization response carried an 'iss' that is not a string ({type(returned_iss).__name__}); "
+            "it cannot be compared with the issuer this login started with."
         )
 
     # ``?iss=`` arrives as an empty string and ``?iss=%20`` as whitespace; neither identifies an

--- a/mlflow_oidc_auth/authorization_response.py
+++ b/mlflow_oidc_auth/authorization_response.py
@@ -1,0 +1,91 @@
+"""Validating the authorization response's issuer — RFC 9207 (issue #307).
+
+An authorization response is a redirect carrying ``code`` and ``state``, and nothing else that
+says who sent it. With one authorization server that is fine: there is only one answer. With
+two, it is the OAuth **mix-up attack** — an attacker who controls, or can induce a login at, one
+authorization server sends its response to the client's callback for a *different* one, and the
+client redeems the code at the wrong token endpoint, handing it to the attacker's server or
+accepting an identity the honest server never asserted.
+
+[RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html) closes it by having the authorization
+server return an ``iss`` parameter, and the client compare it against the issuer it started the
+transaction with.
+
+**What is here and what is not.** This module is the decision — a pure function, so it can be
+tested exhaustively against every shape of response an attacker can produce. Wiring it into the
+callback belongs to #316, which is what introduces per-provider routes and the ``auth_state``
+row holding the issuer a transaction began with. Nothing calls this yet, so no deployment's
+behaviour changes: the point of landing it with the suite is that #316 inherits a decision that
+is already pinned by tests, rather than writing both at once.
+"""
+
+from typing import Optional
+
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+
+class IssuerMismatchError(Exception):
+    """The authorization response did not come from the issuer the transaction started with."""
+
+
+def validate_response_issuer(
+    returned_iss: Optional[str],
+    expected_iss: Optional[str],
+    *,
+    iss_parameter_supported: bool,
+) -> None:
+    """Check the ``iss`` of an authorization response against the issuer that started it.
+
+    Parameters:
+        returned_iss: The ``iss`` query parameter on the callback, or None when absent.
+        expected_iss: The issuer recorded when the login began. None when the deployment has no
+            record of it — which is every deployment before #316 gives transactions a home.
+        iss_parameter_supported: Whether the provider's discovery metadata advertises
+            ``authorization_response_iss_parameter_supported``.
+
+    Raises:
+        IssuerMismatchError: If the response names a different issuer, or names none at all when
+            the provider advertises that it always sends one.
+
+    The three cases and why each is decided this way:
+
+    * **Mismatch** — always fatal, whatever the metadata says. A response naming an issuer other
+      than the one this transaction began with is a mix-up by definition, and there is no
+      configuration under which honouring it is correct.
+    * **Missing, and the provider advertises support** — fatal. If it were tolerated, an attacker
+      would simply strip the parameter, which recreates exactly the ambiguity RFC 9207 removes.
+    * **Missing, and the provider advertises nothing** — allowed. RFC 9207 is recent and plenty
+      of deployed servers do not implement it; refusing here would break working logins to
+      protect against an attack that needs a second authorization server to exist. #313 and #316
+      are where a multi-provider deployment can start requiring it.
+
+    ``expected_iss`` being None means the caller has nothing to compare against, so there is
+    nothing to decide; the mix-up defence for that deployment is that it has one provider.
+    """
+    if expected_iss is None:
+        return
+
+    # ``?iss=`` arrives as an empty string and ``?iss=%20`` as whitespace; neither identifies an
+    # issuer, so both are the *missing* case rather than a mismatch. Deciding them differently
+    # would mean a provider that emits an empty parameter is refused while one that omits it
+    # entirely is allowed — an arbitrary distinction an attacker gets to choose between.
+    if returned_iss is not None and not returned_iss.strip():
+        returned_iss = None
+
+    if returned_iss is None:
+        if iss_parameter_supported:
+            raise IssuerMismatchError(
+                f"The authorization response carried no 'iss' parameter, but the provider for {expected_iss!r} "
+                "advertises authorization_response_iss_parameter_supported. A response missing it cannot be "
+                "attributed to an issuer, which is what RFC 9207 exists to prevent."
+            )
+        logger.debug("Authorization response for %s carried no 'iss'; the provider does not advertise support", expected_iss)
+        return
+
+    if returned_iss != expected_iss:
+        raise IssuerMismatchError(
+            f"The authorization response was issued by {returned_iss!r}, but this login was started with "
+            f"{expected_iss!r}. Refusing to exchange the code."
+        )

--- a/mlflow_oidc_auth/authorization_response.py
+++ b/mlflow_oidc_auth/authorization_response.py
@@ -39,7 +39,8 @@ def validate_response_issuer(
     """Check the ``iss`` of an authorization response against the issuer that started it.
 
     Parameters:
-        returned_iss: The ``iss`` query parameter on the callback, or None when absent.
+        returned_iss: The ``iss`` query parameter on the callback, or None when absent. A value
+            that is not a string — a list, from a repeated parameter — is refused.
         expected_iss: The issuer recorded when the login began. None when the deployment has no
             record of it — which is every deployment before #316 gives transactions a home.
         iss_parameter_supported: Whether the provider's discovery metadata advertises
@@ -67,6 +68,16 @@ def validate_response_issuer(
     if expected_iss is None:
         return
 
+    # A query string can repeat a parameter — ``?iss=honest&iss=attacker`` — so a caller reading
+    # it with ``getlist`` hands this a list. Refused as the documented error rather than left to
+    # raise ``AttributeError`` on the ``.strip()`` below: that would escape a caller catching
+    # only ``IssuerMismatchError``, turning the mix-up defence into an unhandled 500.
+    if returned_iss is not None and not isinstance(returned_iss, str):
+        raise IssuerMismatchError(
+            f"The authorization response carried a non-string 'iss' ({type(returned_iss).__name__}); a response that "
+            "names more than one issuer, or none in a readable form, cannot be attributed to one."
+        )
+
     # ``?iss=`` arrives as an empty string and ``?iss=%20`` as whitespace; neither identifies an
     # issuer, so both are the *missing* case rather than a mismatch. Deciding them differently
     # would mean a provider that emits an empty parameter is refused while one that omits it
@@ -86,6 +97,5 @@ def validate_response_issuer(
 
     if returned_iss != expected_iss:
         raise IssuerMismatchError(
-            f"The authorization response was issued by {returned_iss!r}, but this login was started with "
-            f"{expected_iss!r}. Refusing to exchange the code."
+            f"The authorization response was issued by {returned_iss!r}, but this login was started with " f"{expected_iss!r}. Refusing to exchange the code."
         )

--- a/mlflow_oidc_auth/tests/adversarial/__init__.py
+++ b/mlflow_oidc_auth/tests/adversarial/__init__.py
@@ -1,0 +1,17 @@
+"""Adversarial suite for token validation and the authorization response (issue #307).
+
+Multi-issuer bearer tokens (#313) and multi-provider login (#316) add attack surface that does
+not exist in a single-provider deployment: with one issuer, "which provider issued this?" has
+only one answer, and every mix-up question is vacuous. The epic requires this suite to exist
+*before* that lands, so the properties are written down while they are still easy to state.
+
+The cases are grouped by what an attacker controls:
+
+* ``token_forgery`` — the token: its header, its signature, its ``kid``.
+* ``claims`` — the claims: ``iss``, ``aud``, ``exp``.
+* ``authorization_response`` — the redirect back from the provider: ``state``, ``iss``, ``code``.
+
+``suite.py`` holds the reusable pieces. A new provider type is meant to inherit
+``TokenAdversarySuite`` and supply one fixture rather than re-implement the cases — the point of
+the suite is that the next provider cannot forget one.
+"""

--- a/mlflow_oidc_auth/tests/adversarial/suite.py
+++ b/mlflow_oidc_auth/tests/adversarial/suite.py
@@ -25,7 +25,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Optional
 
-import pytest
 from authlib.jose import JsonWebKey, jwt
 
 
@@ -121,9 +120,15 @@ def hmac_token(claims: dict, kid: str, secret: bytes, algorithm: str = "HS256") 
     return (header + b"." + payload + b"." + signature).decode()
 
 
-#: Failures that mean the *test* is broken, not that the defence worked. A rejection case that
-#: ends in one of these proves nothing: the token never reached the property under test.
-PROGRAMMING_ERRORS = (AttributeError, TypeError, NameError, ImportError, IndexError, KeyError)
+#: Failures that mean the *test* is broken, or that a guard inside it fired — not that the
+#: defence worked. A rejection case ending in one of these proves nothing: either the token never
+#: reached the property under test, or something the case was watching for actually happened.
+#:
+#: ``AssertionError`` is here for the second reason. A guard that signals a violation by
+#: asserting — the monkeypatched ``requests.get`` that fires if validation dereferences an
+#: attacker-supplied ``jku``, below — would otherwise be swallowed as "the token was rejected",
+#: reporting an SSRF as a pass.
+PROGRAMMING_ERRORS = (AssertionError, AttributeError, TypeError, NameError, ImportError, IndexError, KeyError)
 
 
 @contextmanager
@@ -213,9 +218,23 @@ class TokenAdversarySuite:
         with rejects():
             verify(trusted.mint(iat=now - 7200, exp=now - 3600))
 
-    def test_an_attacker_supplied_key_url_is_not_honoured(self, verify, foreign, trusted):
-        """``jku``/``x5u`` naming the attacker's own key set. Fetching it would both trust the
-        attacker's keys and turn the verifier into an SSRF gadget."""
+    def test_an_attacker_supplied_key_url_is_not_honoured(self, verify, foreign, trusted, monkeypatch):
+        """``jku``/``x5u`` naming the attacker's own key set.
+
+        Rejection is not enough on its own: a verifier that dereferences the URL, finds no usable
+        key and *then* rejects has still made an outbound request to an attacker-chosen host on
+        every unauthenticated request, which is the SSRF half of the problem. So the fetch is
+        guarded as well — the guard raises ``AssertionError``, which ``rejects()`` surfaces
+        rather than counting as a refusal.
+        """
+        import requests
+
+        def explode(*args, **kwargs):  # pragma: no cover - the point is that it is not reached
+            raise AssertionError(f"validation fetched an attacker-supplied URL: {args} {kwargs}")
+
+        monkeypatch.setattr(requests, "get", explode, raising=False)
+        monkeypatch.setattr(requests, "request", explode, raising=False)
+
         for header in ("jku", "x5u"):
             # In the signed header, so the signature is genuine under the attacker's key and the
             # only question left is whether the verifier follows the URL.

--- a/mlflow_oidc_auth/tests/adversarial/suite.py
+++ b/mlflow_oidc_auth/tests/adversarial/suite.py
@@ -21,6 +21,7 @@ import hashlib
 import hmac
 import json
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -71,14 +72,31 @@ class Issuer:
         claims.update(overrides)
         return claims
 
-    def mint(self, claims: Optional[dict] = None, *, kid: Optional[str] = None, algorithm: str = "RS256", **overrides) -> str:
+    def mint(
+        self,
+        claims: Optional[dict] = None,
+        *,
+        kid: Optional[str] = None,
+        algorithm: str = "RS256",
+        extra_header: Optional[dict] = None,
+        **overrides,
+    ) -> str:
         """Sign a genuine token with this issuer's key.
 
-        ``kid`` can be overridden to point at another issuer's key while this one does the
-        signing — the ``kid``-confusion case.
+        ``kid`` and ``extra_header`` are part of the *signed* header, which is what makes the
+        header-confusion cases real: an attacker mints with their own key and names whatever
+        ``kid``, ``jku`` or ``x5u`` they like, and the signature is genuine under their key.
+        Editing a header after signing would instead produce a token that fails signature
+        verification outright, which tests nothing about how the header is treated.
+
+        ``overrides`` apply on top of ``claims`` when both are given, rather than being dropped
+        — a silently ignored ``aud=...`` would mint a token without the property its test names.
         """
         header = {"alg": algorithm, "kid": kid or self.kid}
-        payload = claims if claims is not None else self.claims(**overrides)
+        if extra_header:
+            header.update(extra_header)
+        payload = dict(claims) if claims is not None else self.claims()
+        payload.update(overrides)
         return jwt.encode(header, payload, self._private).decode("utf-8")
 
 
@@ -103,17 +121,26 @@ def hmac_token(claims: dict, kid: str, secret: bytes, algorithm: str = "HS256") 
     return (header + b"." + payload + b"." + signature).decode()
 
 
-def tamper(token: str, **header_overrides) -> str:
-    """Rewrite a token's header, leaving the signature it was minted with in place.
+#: Failures that mean the *test* is broken, not that the defence worked. A rejection case that
+#: ends in one of these proves nothing: the token never reached the property under test.
+PROGRAMMING_ERRORS = (AttributeError, TypeError, NameError, ImportError, IndexError, KeyError)
 
-    The header is not covered by the signature in the sense that matters here: an attacker can
-    rewrite it freely and the verifier must not believe any of it.
+
+@contextmanager
+def rejects():
+    """Assert the block refuses the token, and that it refuses it for a defensible reason.
+
+    ``pytest.raises(Exception)`` is too coarse here: it accepts an ``AttributeError`` from a typo
+    in the test as readily as a considered rejection, which is how a case can look like a guard
+    while guarding nothing.
     """
-    header_b64, payload_b64, signature_b64 = token.split(".")
-    padded = header_b64 + "=" * (-len(header_b64) % 4)
-    header = json.loads(base64.urlsafe_b64decode(padded))
-    header.update(header_overrides)
-    return ".".join([b64(json.dumps(header).encode()).decode(), payload_b64, signature_b64])
+    try:
+        yield
+    except PROGRAMMING_ERRORS as exc:
+        raise AssertionError(f"the case failed for a reason unrelated to the defence: {exc!r}") from exc
+    except Exception:
+        return
+    raise AssertionError("the token was accepted")
 
 
 class TokenAdversarySuite:
@@ -130,7 +157,7 @@ class TokenAdversarySuite:
         assert verify(trusted.mint()) is not None
 
     def test_an_unsigned_token_is_rejected(self, verify, trusted):
-        with pytest.raises(Exception):
+        with rejects():
             verify(unsigned_token(trusted.claims()))
 
     def test_a_token_signed_by_a_foreign_issuer_is_rejected(self, verify, foreign):
@@ -140,21 +167,26 @@ class TokenAdversarySuite:
         provider this one does not trust. Nothing about the token itself is wrong; only its
         origin is, which is why signature validity alone can never be the test.
         """
-        with pytest.raises(Exception):
+        with rejects():
             verify(foreign.mint())
 
     def test_a_foreign_token_wearing_the_trusted_kid_is_rejected(self, verify, trusted, foreign):
         """``kid`` confusion: the header points at a key the verifier trusts, the signature does
-        not come from it. Believing the header would be believing the attacker."""
-        forged = tamper(foreign.mint(), kid=trusted.kid)
+        not come from it. Believing the header would be believing the attacker.
 
-        with pytest.raises(Exception):
+        Minted with the attacker's key *and* the trusted ``kid`` in the signed header, so the
+        signature is genuine under the attacker's key. A token whose header was edited after
+        signing would fail signature verification outright and prove nothing about ``kid``.
+        """
+        forged = foreign.mint(kid=trusted.kid)
+
+        with rejects():
             verify(forged)
 
     def test_a_token_naming_an_unknown_kid_is_rejected(self, verify, foreign, trusted):
-        forged = tamper(foreign.mint(), kid="a-key-that-was-never-published")
+        forged = foreign.mint(kid="a-key-that-was-never-published")
 
-        with pytest.raises(Exception):
+        with rejects():
             verify(forged)
 
     def test_the_trusted_public_key_is_not_an_hmac_secret(self, verify, trusted):
@@ -172,20 +204,22 @@ class TokenAdversarySuite:
         """
         public_pem = trusted.key.as_pem(is_private=False) if hasattr(trusted.key, "as_pem") else json.dumps(trusted.jwks["keys"][0]).encode()
 
-        with pytest.raises(Exception):
+        with rejects():
             verify(hmac_token(trusted.claims(), trusted.kid, public_pem))
 
     def test_an_expired_token_is_rejected(self, verify, trusted):
         now = int(time.time())
 
-        with pytest.raises(Exception):
+        with rejects():
             verify(trusted.mint(iat=now - 7200, exp=now - 3600))
 
     def test_an_attacker_supplied_key_url_is_not_honoured(self, verify, foreign, trusted):
         """``jku``/``x5u`` naming the attacker's own key set. Fetching it would both trust the
         attacker's keys and turn the verifier into an SSRF gadget."""
         for header in ("jku", "x5u"):
-            forged = tamper(foreign.mint(), **{header: "https://attacker.invalid/keys.json", "kid": foreign.kid})
+            # In the signed header, so the signature is genuine under the attacker's key and the
+            # only question left is whether the verifier follows the URL.
+            forged = foreign.mint(extra_header={header: "https://attacker.invalid/keys.json"})
 
-            with pytest.raises(Exception):
+            with rejects():
                 verify(forged)

--- a/mlflow_oidc_auth/tests/adversarial/suite.py
+++ b/mlflow_oidc_auth/tests/adversarial/suite.py
@@ -1,0 +1,191 @@
+"""Reusable pieces for the adversarial suite (issue #307).
+
+Two things live here:
+
+``Issuer``
+    A stand-in identity provider: its own RSA key, its own ``iss``, its own audience, and a
+    ``mint`` that signs whatever claims it is handed. Two of them is the minimum needed to ask
+    any cross-issuer question at all.
+
+``TokenAdversarySuite``
+    The cases themselves, as a base class. A new provider type — the Kubernetes service-account
+    provider in #314, a second OIDC issuer in #313 — inherits it and supplies the ``verify``
+    fixture: a callable that takes a token and raises if it is not acceptable *for that
+    provider*. Every case below then applies to it without being rewritten, which is the
+    acceptance criterion the issue asks for: a new provider inherits the suite rather than
+    re-implementing it.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+from authlib.jose import JsonWebKey, jwt
+
+
+def b64(raw: bytes) -> bytes:
+    """URL-safe base64 without padding, as JOSE uses."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=")
+
+
+@dataclass
+class Issuer:
+    """A stand-in provider: one key, one issuer identifier, one audience."""
+
+    name: str
+    iss: str
+    audience: str
+    key: object = field(default=None)
+
+    def __post_init__(self):
+        if self.key is None:
+            self.key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+        self._private = self.key.as_dict(is_private=True)
+        self._public = self.key.as_dict(is_private=False)
+        kid = self._public.get("kid") or self.key.thumbprint()
+        self._public["kid"] = self._private["kid"] = kid
+
+    @property
+    def kid(self) -> str:
+        return self._public["kid"]
+
+    @property
+    def jwks(self) -> dict:
+        return {"keys": [self._public]}
+
+    def claims(self, **overrides) -> dict:
+        """Claims a genuine token from this issuer would carry."""
+        now = int(time.time())
+        claims = {
+            "email": "adversary-suite@example.com",
+            "iss": self.iss,
+            "aud": self.audience,
+            "iat": now,
+            "exp": now + 3600,
+        }
+        claims.update(overrides)
+        return claims
+
+    def mint(self, claims: Optional[dict] = None, *, kid: Optional[str] = None, algorithm: str = "RS256", **overrides) -> str:
+        """Sign a genuine token with this issuer's key.
+
+        ``kid`` can be overridden to point at another issuer's key while this one does the
+        signing — the ``kid``-confusion case.
+        """
+        header = {"alg": algorithm, "kid": kid or self.kid}
+        payload = claims if claims is not None else self.claims(**overrides)
+        return jwt.encode(header, payload, self._private).decode("utf-8")
+
+
+def unsigned_token(claims: dict) -> str:
+    """A token declaring ``alg: none``, with an empty signature."""
+    header = b64(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+    payload = b64(json.dumps(claims).encode())
+    return (header + b"." + payload + b".").decode()
+
+
+def hmac_token(claims: dict, kid: str, secret: bytes, algorithm: str = "HS256") -> str:
+    """A symmetric token hand-built from ``secret``.
+
+    Constructed by hand because a correct JOSE library refuses to sign with a public key — which
+    is the point of the attack. A test that relies on the library to mint the forgery tests
+    nothing, because the attacker is not using the library.
+    """
+    digest = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}[algorithm]
+    header = b64(json.dumps({"alg": algorithm, "kid": kid}).encode())
+    payload = b64(json.dumps(claims).encode())
+    signature = b64(hmac.new(secret, header + b"." + payload, digest).digest())
+    return (header + b"." + payload + b"." + signature).decode()
+
+
+def tamper(token: str, **header_overrides) -> str:
+    """Rewrite a token's header, leaving the signature it was minted with in place.
+
+    The header is not covered by the signature in the sense that matters here: an attacker can
+    rewrite it freely and the verifier must not believe any of it.
+    """
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    padded = header_b64 + "=" * (-len(header_b64) % 4)
+    header = json.loads(base64.urlsafe_b64decode(padded))
+    header.update(header_overrides)
+    return ".".join([b64(json.dumps(header).encode()).decode(), payload_b64, signature_b64])
+
+
+class TokenAdversarySuite:
+    """Cases every token-accepting provider must reject.
+
+    Subclass it and provide a ``verify`` fixture returning a one-argument callable that raises
+    when a token is not acceptable for the provider under test, plus a ``trusted`` fixture
+    returning the :class:`Issuer` that provider trusts and a ``foreign`` fixture returning one it
+    does not.
+    """
+
+    def test_a_genuine_token_is_accepted(self, verify, trusted):
+        """The control. Without it, every rejection below could be a rejection of everything."""
+        assert verify(trusted.mint()) is not None
+
+    def test_an_unsigned_token_is_rejected(self, verify, trusted):
+        with pytest.raises(Exception):
+            verify(unsigned_token(trusted.claims()))
+
+    def test_a_token_signed_by_a_foreign_issuer_is_rejected(self, verify, foreign):
+        """Cross-issuer replay: a token that is perfectly valid somewhere else.
+
+        The whole token is genuine — correct signature, unexpired, well-formed — and issued by a
+        provider this one does not trust. Nothing about the token itself is wrong; only its
+        origin is, which is why signature validity alone can never be the test.
+        """
+        with pytest.raises(Exception):
+            verify(foreign.mint())
+
+    def test_a_foreign_token_wearing_the_trusted_kid_is_rejected(self, verify, trusted, foreign):
+        """``kid`` confusion: the header points at a key the verifier trusts, the signature does
+        not come from it. Believing the header would be believing the attacker."""
+        forged = tamper(foreign.mint(), kid=trusted.kid)
+
+        with pytest.raises(Exception):
+            verify(forged)
+
+    def test_a_token_naming_an_unknown_kid_is_rejected(self, verify, foreign, trusted):
+        forged = tamper(foreign.mint(), kid="a-key-that-was-never-published")
+
+        with pytest.raises(Exception):
+            verify(forged)
+
+    def test_the_trusted_public_key_is_not_an_hmac_secret(self, verify, trusted):
+        """Algorithm confusion. The verifier's *public* key is public; if it can be used as a
+        shared secret, anyone who can read the JWKS can mint tokens.
+
+        **Defence in depth, and not falsifiable here.** Two independent things reject this: the
+        pinned algorithm set, and authlib refusing to use a key it resolved as RSA for an HMAC
+        verification. Widening the pinned set to include ``HS256`` therefore does *not* make this
+        case fail, so passing it is not evidence that the pin is in place. The falsifiable
+        assertion — that no symmetric algorithm is in the accepted set at all — is a structural
+        one, in ``test_token_algorithm_pinning.py::TestTheAcceptedSetIsPinned``. Kept because the
+        end-to-end property is still worth stating, and because a future provider might resolve
+        keys differently and lose the second defence without anyone noticing.
+        """
+        public_pem = trusted.key.as_pem(is_private=False) if hasattr(trusted.key, "as_pem") else json.dumps(trusted.jwks["keys"][0]).encode()
+
+        with pytest.raises(Exception):
+            verify(hmac_token(trusted.claims(), trusted.kid, public_pem))
+
+    def test_an_expired_token_is_rejected(self, verify, trusted):
+        now = int(time.time())
+
+        with pytest.raises(Exception):
+            verify(trusted.mint(iat=now - 7200, exp=now - 3600))
+
+    def test_an_attacker_supplied_key_url_is_not_honoured(self, verify, foreign, trusted):
+        """``jku``/``x5u`` naming the attacker's own key set. Fetching it would both trust the
+        attacker's keys and turn the verifier into an SSRF gadget."""
+        for header in ("jku", "x5u"):
+            forged = tamper(foreign.mint(), **{header: "https://attacker.invalid/keys.json", "kid": foreign.kid})
+
+            with pytest.raises(Exception):
+                verify(forged)

--- a/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
@@ -78,17 +78,40 @@ class TestStrippedIssuer:
 
 class TestARepeatedParameter:
     """``?iss=honest&iss=attacker``. A caller reading the query string with ``getlist`` — the
-    natural way to notice a duplicate — hands this a list, and it has to answer with the error
-    the caller is catching rather than an ``AttributeError`` that escapes past it."""
+    natural way to notice a duplicate — hands this a sequence, and the *length* decides.
 
-    @pytest.mark.parametrize("returned", [[HONEST, ATTACKER], [ATTACKER], [], ("a", "b"), 42, {"iss": HONEST}])
-    def test_a_non_string_iss_is_refused_as_a_mismatch(self, returned):
+    Deciding on the type instead would refuse the empty list that every provider omitting ``iss``
+    produces, and break every login against it.
+    """
+
+    @pytest.mark.parametrize("returned", [[HONEST, ATTACKER], [ATTACKER, HONEST], (HONEST, HONEST), [HONEST, HONEST]])
+    def test_more_than_one_issuer_is_refused(self, returned):
+        """Two values name two issuers, so the response can be attributed to neither — including
+        when both happen to be the expected one, since the caller cannot tell which the provider
+        meant."""
         with pytest.raises(IssuerMismatchError):
             validate_response_issuer(returned, HONEST, iss_parameter_supported=True)
 
-    def test_it_is_refused_whatever_the_metadata_says(self):
+    def test_a_single_value_is_the_ordinary_case(self):
+        validate_response_issuer([HONEST], HONEST, iss_parameter_supported=True)
+        validate_response_issuer((HONEST,), HONEST, iss_parameter_supported=False)
+
+    def test_a_single_wrong_value_is_still_a_mismatch(self):
         with pytest.raises(IssuerMismatchError):
-            validate_response_issuer([HONEST], HONEST, iss_parameter_supported=False)
+            validate_response_issuer([ATTACKER], HONEST, iss_parameter_supported=True)
+
+    def test_an_empty_sequence_is_the_absent_case(self):
+        """What ``getlist`` returns when the parameter is not there at all. Refusing it would
+        break every login to a provider that has not implemented RFC 9207."""
+        validate_response_issuer([], HONEST, iss_parameter_supported=False)
+
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer([], HONEST, iss_parameter_supported=True)
+
+    @pytest.mark.parametrize("returned", [42, {"iss": HONEST}, object()])
+    def test_a_value_that_is_neither_a_string_nor_a_sequence_is_refused(self, returned):
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(returned, HONEST, iss_parameter_supported=True)
 
 
 class TestProvidersThatDoNotImplementRFC9207:
@@ -132,6 +155,8 @@ class TestTheDecisionIsTotal:
             "https://honest.idp.invalid?a=b",
             [HONEST],
             [HONEST, ATTACKER],
+            [],
+            (HONEST,),
             42,
         ],
     )
@@ -146,11 +171,18 @@ class TestTheDecisionIsTotal:
         # The rule, stated independently of the implementation: a response is accepted only if it
         # names the expected issuer exactly, or names no issuer at all against a provider that
         # never sends one. "No issuer at all" covers absent, empty and whitespace alike.
-        identifies_an_issuer = isinstance(returned, str) and bool(returned.strip())
-        if returned is not None and not isinstance(returned, str):
-            # Not an issuer and not "no issuer" either: unattributable, so never accepted.
+        # A sequence is decided by its length before anything else: none is the absent case, one
+        # is that element, more than one is unattributable.
+        if isinstance(returned, (list, tuple)):
+            if len(returned) > 1:
+                assert accepted is False
+                return
+            returned = returned[0] if returned else None
+        elif returned is not None and not isinstance(returned, str):
             assert accepted is False
             return
+
+        identifies_an_issuer = isinstance(returned, str) and bool(returned.strip())
         expected_to_be_accepted = (identifies_an_issuer and returned == HONEST) or (not identifies_an_issuer and not supported)
 
         assert accepted is expected_to_be_accepted

--- a/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
@@ -76,6 +76,21 @@ class TestStrippedIssuer:
         assert "iss" in str(excinfo.value)
 
 
+class TestARepeatedParameter:
+    """``?iss=honest&iss=attacker``. A caller reading the query string with ``getlist`` — the
+    natural way to notice a duplicate — hands this a list, and it has to answer with the error
+    the caller is catching rather than an ``AttributeError`` that escapes past it."""
+
+    @pytest.mark.parametrize("returned", [[HONEST, ATTACKER], [ATTACKER], [], ("a", "b"), 42, {"iss": HONEST}])
+    def test_a_non_string_iss_is_refused_as_a_mismatch(self, returned):
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(returned, HONEST, iss_parameter_supported=True)
+
+    def test_it_is_refused_whatever_the_metadata_says(self):
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer([HONEST], HONEST, iss_parameter_supported=False)
+
+
 class TestProvidersThatDoNotImplementRFC9207:
     """Refusing these would break logins that work today, to defend against an attack that needs
     a second authorization server to exist."""
@@ -106,7 +121,19 @@ class TestTheDecisionIsTotal:
 
     @pytest.mark.parametrize(
         "returned",
-        [None, "", " ", HONEST, ATTACKER, "not-a-url", "https://honest.idp.invalid#fragment", "https://honest.idp.invalid?a=b"],
+        [
+            None,
+            "",
+            " ",
+            HONEST,
+            ATTACKER,
+            "not-a-url",
+            "https://honest.idp.invalid#fragment",
+            "https://honest.idp.invalid?a=b",
+            [HONEST],
+            [HONEST, ATTACKER],
+            42,
+        ],
     )
     @pytest.mark.parametrize("supported", [True, False])
     def test_every_shape_of_response_is_either_accepted_or_refused(self, returned, supported):
@@ -119,7 +146,11 @@ class TestTheDecisionIsTotal:
         # The rule, stated independently of the implementation: a response is accepted only if it
         # names the expected issuer exactly, or names no issuer at all against a provider that
         # never sends one. "No issuer at all" covers absent, empty and whitespace alike.
-        identifies_an_issuer = bool(returned and returned.strip())
+        identifies_an_issuer = isinstance(returned, str) and bool(returned.strip())
+        if returned is not None and not isinstance(returned, str):
+            # Not an issuer and not "no issuer" either: unattributable, so never accepted.
+            assert accepted is False
+            return
         expected_to_be_accepted = (identifies_an_issuer and returned == HONEST) or (not identifies_an_issuer and not supported)
 
         assert accepted is expected_to_be_accepted

--- a/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_authorization_response.py
@@ -1,0 +1,125 @@
+"""Mix-up cases against the authorization response — RFC 9207 (issue #307).
+
+The three cases the issue names — missing ``iss``, stripped ``iss``, mismatched ``iss`` — plus
+the ones that decide whether the rule can be enforced without breaking working deployments.
+
+The decision lives in ``mlflow_oidc_auth/authorization_response.py`` as a pure function. #316
+wires it into the per-provider callback; these cases are what it will have to keep passing.
+"""
+
+import pytest
+
+from mlflow_oidc_auth.authorization_response import IssuerMismatchError, validate_response_issuer
+
+HONEST = "https://honest.idp.invalid"
+ATTACKER = "https://attacker.idp.invalid"
+
+
+class TestMismatchedIssuer:
+    """The mix-up itself: a response from one authorization server delivered to a callback that
+    is expecting another."""
+
+    def test_a_response_from_another_issuer_is_refused(self):
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(ATTACKER, HONEST, iss_parameter_supported=True)
+
+    def test_it_is_refused_even_when_the_provider_advertises_nothing(self):
+        """Metadata is the attacker's to influence in a mix-up — it is fetched from whichever
+        server the client thinks it is talking to. A mismatch is fatal regardless."""
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(ATTACKER, HONEST, iss_parameter_supported=False)
+
+    def test_a_lookalike_issuer_is_refused(self):
+        """Comparison is exact. Anything looser accepts a host the attacker registered."""
+        for lookalike in (HONEST + ".attacker.invalid", HONEST + "/", HONEST.replace("https", "http"), HONEST.upper(), HONEST + " "):
+            with pytest.raises(IssuerMismatchError):
+                validate_response_issuer(lookalike, HONEST, iss_parameter_supported=True)
+
+    def test_the_error_names_both_issuers(self):
+        """An operator reading this in a log needs to know which two servers were involved."""
+        with pytest.raises(IssuerMismatchError) as excinfo:
+            validate_response_issuer(ATTACKER, HONEST, iss_parameter_supported=True)
+
+        message = str(excinfo.value)
+        assert ATTACKER in message
+        assert HONEST in message
+
+
+class TestStrippedIssuer:
+    """An attacker removing the parameter must not be able to opt out of the check.
+
+    This is the case that decides whether RFC 9207 is worth implementing at all: if a missing
+    ``iss`` is treated as "nothing to check", then every mix-up is one deleted query parameter
+    away from succeeding.
+    """
+
+    def test_a_missing_iss_is_refused_when_the_provider_sends_one(self):
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(None, HONEST, iss_parameter_supported=True)
+
+    @pytest.mark.parametrize("blank", ["", " ", "\t"])
+    def test_a_blank_iss_is_refused_when_the_provider_sends_one(self, blank):
+        """``?iss=`` arrives as an empty string, not as absent — and must be treated as the
+        missing case rather than as a mismatch, or a provider emitting an empty parameter would
+        be refused while one omitting it entirely is allowed."""
+        with pytest.raises(IssuerMismatchError):
+            validate_response_issuer(blank, HONEST, iss_parameter_supported=True)
+
+    @pytest.mark.parametrize("blank", ["", " ", "\t"])
+    def test_a_blank_iss_is_allowed_when_the_provider_sends_none(self, blank):
+        validate_response_issuer(blank, HONEST, iss_parameter_supported=False)
+
+    def test_the_error_says_the_parameter_was_missing(self):
+        with pytest.raises(IssuerMismatchError) as excinfo:
+            validate_response_issuer(None, HONEST, iss_parameter_supported=True)
+
+        assert "iss" in str(excinfo.value)
+
+
+class TestProvidersThatDoNotImplementRFC9207:
+    """Refusing these would break logins that work today, to defend against an attack that needs
+    a second authorization server to exist."""
+
+    def test_a_missing_iss_is_allowed_when_the_provider_advertises_nothing(self):
+        validate_response_issuer(None, HONEST, iss_parameter_supported=False)
+
+    def test_a_matching_iss_is_allowed(self):
+        validate_response_issuer(HONEST, HONEST, iss_parameter_supported=True)
+        validate_response_issuer(HONEST, HONEST, iss_parameter_supported=False)
+
+
+class TestNothingToCompareAgainst:
+    """Before #316 gives a transaction a home, there is no recorded issuer.
+
+    The check has to be inert in that case rather than guess — and a deployment with one
+    provider is not exposed to mix-up in the first place.
+    """
+
+    def test_no_expected_issuer_means_no_decision(self):
+        validate_response_issuer(ATTACKER, None, iss_parameter_supported=True)
+        validate_response_issuer(None, None, iss_parameter_supported=True)
+
+
+class TestTheDecisionIsTotal:
+    """Whatever an attacker puts in the query string, the function decides — it never raises
+    something the caller has not planned for, and never returns for a mismatch."""
+
+    @pytest.mark.parametrize(
+        "returned",
+        [None, "", " ", HONEST, ATTACKER, "not-a-url", "https://honest.idp.invalid#fragment", "https://honest.idp.invalid?a=b"],
+    )
+    @pytest.mark.parametrize("supported", [True, False])
+    def test_every_shape_of_response_is_either_accepted_or_refused(self, returned, supported):
+        try:
+            validate_response_issuer(returned, HONEST, iss_parameter_supported=supported)
+            accepted = True
+        except IssuerMismatchError:
+            accepted = False
+
+        # The rule, stated independently of the implementation: a response is accepted only if it
+        # names the expected issuer exactly, or names no issuer at all against a provider that
+        # never sends one. "No issuer at all" covers absent, empty and whitespace alike.
+        identifies_an_issuer = bool(returned and returned.strip())
+        expected_to_be_accepted = (identifies_an_issuer and returned == HONEST) or (not identifies_an_issuer and not supported)
+
+        assert accepted is expected_to_be_accepted

--- a/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
@@ -24,7 +24,7 @@ import mlflow_oidc_auth.auth as auth_module
 import mlflow_oidc_auth.store as store_module
 from mlflow_oidc_auth.middleware import AuthMiddleware
 
-from .suite import Issuer, TokenAdversarySuite, tamper, unsigned_token
+from .suite import Issuer, TokenAdversarySuite, rejects, unsigned_token
 
 PROTECTED = "/oidc/api/whoami"
 USERNAME = "adversary-suite@example.com"
@@ -68,14 +68,14 @@ class TestAudienceConfusion:
     """
 
     def test_a_token_for_another_audience_is_rejected(self, verify, trusted):
-        with pytest.raises(Exception):
+        with rejects():
             verify(trusted.mint(aud="a-different-application"))
 
     def test_a_token_with_no_audience_is_rejected(self, verify, trusted):
         claims = trusted.claims()
         claims.pop("aud")
 
-        with pytest.raises(Exception):
+        with rejects():
             verify(trusted.mint(claims))
 
     def test_the_expected_audience_among_several_is_accepted(self, verify, trusted):
@@ -83,7 +83,7 @@ class TestAudienceConfusion:
         assert verify(trusted.mint(aud=[trusted.audience, "another-app"])) is not None
 
     def test_an_audience_list_without_ours_is_rejected(self, verify, trusted):
-        with pytest.raises(Exception):
+        with rejects():
             verify(trusted.mint(aud=["another-app", "a-third-app"]))
 
 
@@ -91,14 +91,14 @@ class TestIssuerConfusion:
     def test_a_token_from_another_issuer_is_rejected(self, verify, foreign, trusted):
         """Even when it names the right audience — the case that matters once two providers can
         both mint tokens for this deployment's audience."""
-        with pytest.raises(Exception):
+        with rejects():
             verify(foreign.mint(aud=trusted.audience))
 
     def test_a_token_with_no_issuer_is_rejected(self, verify, trusted):
         claims = trusted.claims()
         claims.pop("iss")
 
-        with pytest.raises(Exception):
+        with rejects():
             verify(trusted.mint(claims))
 
     def test_a_lookalike_issuer_is_rejected(self, verify, trusted):
@@ -110,7 +110,7 @@ class TestIssuerConfusion:
             trusted.iss.replace("https", "http"),
             trusted.iss.upper(),
         ):
-            with pytest.raises(Exception):
+            with rejects():
                 verify(trusted.mint(iss=lookalike))
 
 
@@ -132,17 +132,17 @@ class TestTheUnpinnedDefault:
     def test_the_signature_is_still_the_floor(self, verify_unpinned, foreign):
         """Unpinned does not mean unverified: a token this deployment's keys did not sign is
         still refused, whatever it claims."""
-        with pytest.raises(Exception):
+        with rejects():
             verify_unpinned(foreign.mint())
 
     def test_an_unsigned_token_is_still_refused(self, verify_unpinned, trusted):
-        with pytest.raises(Exception):
+        with rejects():
             verify_unpinned(unsigned_token(trusted.claims()))
 
     def test_an_expired_token_is_still_refused(self, verify_unpinned, trusted):
         now = int(time.time())
 
-        with pytest.raises(Exception):
+        with rejects():
             verify_unpinned(trusted.mint(iat=now - 7200, exp=now - 3600))
 
     def test_but_any_issuer_and_audience_are_accepted(self, verify_unpinned, trusted):
@@ -209,7 +209,9 @@ class TestEndToEndThroughTheMiddleware:
         assert response.json().get("username") is None
 
     def test_a_kid_swapped_token_does_not(self, client, trusted, foreign):
-        response = self._get(client, tamper(foreign.mint(email=USERNAME), kid=trusted.kid))
+        """Minted with the attacker's key and the trusted ``kid`` in the signed header, so the
+        signature is genuine under that key — the header is the only thing vouching for it."""
+        response = self._get(client, foreign.mint(email=USERNAME, kid=trusted.kid))
 
         assert response.status_code == 401
 

--- a/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
@@ -1,0 +1,224 @@
+"""The adversarial suite applied to the OIDC bearer-token path (issue #307).
+
+This is the only provider that exists today, so it is the only instantiation of
+``TokenAdversarySuite``. #313 adds a second issuer and #314 the Kubernetes service-account
+provider; each inherits the class rather than restating the cases.
+
+Two configurations are exercised deliberately, because they reject different things:
+
+* **Issuer and audience pinned** — what a multi-provider deployment will always be. The suite
+  runs here, and cross-issuer replay is rejected by the ``iss`` check.
+* **Neither pinned** — today's default. ``TestTheUnpinnedDefault`` records exactly what that
+  configuration does and does not refuse. Those are not cases the suite should pass; they are the
+  boundary #313 exists to move, written down so the move is visible when it happens.
+"""
+
+import time
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+import mlflow_oidc_auth.auth as auth_module
+import mlflow_oidc_auth.store as store_module
+from mlflow_oidc_auth.middleware import AuthMiddleware
+
+from .suite import Issuer, TokenAdversarySuite, tamper, unsigned_token
+
+PROTECTED = "/oidc/api/whoami"
+USERNAME = "adversary-suite@example.com"
+
+
+@pytest.fixture
+def trusted():
+    return Issuer(name="trusted", iss="https://trusted.idp.invalid", audience="mlflow-tracking")
+
+
+@pytest.fixture
+def foreign():
+    """A second, entirely legitimate provider that this deployment does not trust.
+
+    Realistic: one company's Entra tenant and another's, or the Kubernetes API server's service
+    account issuer next to a human-login IdP. Its tokens are genuine — they are simply not for
+    this deployment.
+    """
+    return Issuer(name="foreign", iss="https://foreign.idp.invalid", audience="some-other-app")
+
+
+@pytest.fixture
+def verify(trusted, monkeypatch):
+    """``validate_token`` with the trusted issuer's keys, issuer and audience pinned."""
+    monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", trusted.iss)
+    monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", trusted.audience)
+    monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
+    return auth_module.validate_token
+
+
+class TestOIDCBearerTokens(TokenAdversarySuite):
+    """Every case in the base class, against the configured OIDC provider."""
+
+
+class TestAudienceConfusion:
+    """A token minted for another application by the *same* identity provider.
+
+    The signature is valid, the issuer is the expected one, the user is real. Only ``aud`` says
+    it was never meant for this deployment — which is the only thing standing between a shared
+    corporate IdP and every application on it accepting each other's tokens.
+    """
+
+    def test_a_token_for_another_audience_is_rejected(self, verify, trusted):
+        with pytest.raises(Exception):
+            verify(trusted.mint(aud="a-different-application"))
+
+    def test_a_token_with_no_audience_is_rejected(self, verify, trusted):
+        claims = trusted.claims()
+        claims.pop("aud")
+
+        with pytest.raises(Exception):
+            verify(trusted.mint(claims))
+
+    def test_the_expected_audience_among_several_is_accepted(self, verify, trusted):
+        """Providers routinely mint multi-audience tokens; rejecting them would be wrong."""
+        assert verify(trusted.mint(aud=[trusted.audience, "another-app"])) is not None
+
+    def test_an_audience_list_without_ours_is_rejected(self, verify, trusted):
+        with pytest.raises(Exception):
+            verify(trusted.mint(aud=["another-app", "a-third-app"]))
+
+
+class TestIssuerConfusion:
+    def test_a_token_from_another_issuer_is_rejected(self, verify, foreign, trusted):
+        """Even when it names the right audience — the case that matters once two providers can
+        both mint tokens for this deployment's audience."""
+        with pytest.raises(Exception):
+            verify(foreign.mint(aud=trusted.audience))
+
+    def test_a_token_with_no_issuer_is_rejected(self, verify, trusted):
+        claims = trusted.claims()
+        claims.pop("iss")
+
+        with pytest.raises(Exception):
+            verify(trusted.mint(claims))
+
+    def test_a_lookalike_issuer_is_rejected(self, verify, trusted):
+        """Issuer comparison is exact. A prefix or suffix match would accept
+        ``https://trusted.idp.invalid.attacker.example``."""
+        for lookalike in (
+            trusted.iss + ".attacker.invalid",
+            trusted.iss + "/",
+            trusted.iss.replace("https", "http"),
+            trusted.iss.upper(),
+        ):
+            with pytest.raises(Exception):
+                verify(trusted.mint(iss=lookalike))
+
+
+class TestTheUnpinnedDefault:
+    """What today's default configuration — no ``OIDC_ISSUER``, no ``OIDC_AUDIENCE`` — refuses.
+
+    These are not suite cases. They record the boundary as it stands, so that when #313 makes
+    issuer and audience validation per-provider and mandatory, the change shows up here as a
+    test that has to be rewritten rather than as silence.
+    """
+
+    @pytest.fixture
+    def verify_unpinned(self, trusted, monkeypatch):
+        monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", None)
+        monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", None)
+        monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
+        return auth_module.validate_token
+
+    def test_the_signature_is_still_the_floor(self, verify_unpinned, foreign):
+        """Unpinned does not mean unverified: a token this deployment's keys did not sign is
+        still refused, whatever it claims."""
+        with pytest.raises(Exception):
+            verify_unpinned(foreign.mint())
+
+    def test_an_unsigned_token_is_still_refused(self, verify_unpinned, trusted):
+        with pytest.raises(Exception):
+            verify_unpinned(unsigned_token(trusted.claims()))
+
+    def test_an_expired_token_is_still_refused(self, verify_unpinned, trusted):
+        now = int(time.time())
+
+        with pytest.raises(Exception):
+            verify_unpinned(trusted.mint(iat=now - 7200, exp=now - 3600))
+
+    def test_but_any_issuer_and_audience_are_accepted(self, verify_unpinned, trusted):
+        """**The gap.** With nothing pinned, a token signed by the configured keys is accepted
+        whatever it says about who it was for.
+
+        For a dedicated IdP that is nearly harmless: only that IdP holds the signing key. On a
+        shared corporate IdP that signs for every application with the same key, it means a token
+        minted for a *different* application authenticates here — the user is genuine, the
+        consent was for something else. Pinning ``OIDC_AUDIENCE`` closes it today; #313 makes it
+        per-provider so it cannot be left unset.
+        """
+        accepted = verify_unpinned(trusted.mint(iss="https://anyone.invalid", aud="a-different-application"))
+
+        assert accepted is not None
+
+
+class TestEndToEndThroughTheMiddleware:
+    """A helper that rejects a token is only useful if the request it arrived on is refused too."""
+
+    @pytest.fixture
+    def client(self, trusted, monkeypatch, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        store = SqlAlchemyStore()
+        store.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        store.create_user(USERNAME, "token", "Adversary Suite", is_admin=True)
+        previous = object.__getattribute__(store_module.store, "_instance")
+        object.__setattr__(store_module.store, "_instance", store)
+
+        monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", trusted.iss)
+        monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", trusted.audience)
+        monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
+
+        app = FastAPI()
+
+        @app.get(PROTECTED)
+        async def whoami(request: Request):
+            return {"username": getattr(request.state, "username", None), "is_admin": getattr(request.state, "is_admin", None)}
+
+        app.add_middleware(AuthMiddleware)
+        app.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+
+        with TestClient(app) as test_client:
+            yield test_client
+
+        object.__setattr__(store_module.store, "_instance", previous)
+        store.engine.dispose()
+
+    def _get(self, client, token):
+        return client.get(PROTECTED, headers={"Authorization": f"Bearer {token}"})
+
+    def test_a_genuine_token_authenticates(self, client, trusted):
+        response = self._get(client, trusted.mint(email=USERNAME))
+
+        assert response.status_code == 200
+        assert response.json()["username"] == USERNAME
+
+    def test_a_foreign_token_naming_the_admin_does_not(self, client, foreign):
+        """The forgery that matters: a real user's address, a real signature, the wrong issuer."""
+        response = self._get(client, foreign.mint(email=USERNAME, aud="mlflow-tracking"))
+
+        assert response.status_code == 401
+        assert response.json().get("username") is None
+
+    def test_a_kid_swapped_token_does_not(self, client, trusted, foreign):
+        response = self._get(client, tamper(foreign.mint(email=USERNAME), kid=trusted.kid))
+
+        assert response.status_code == 401
+
+    def test_a_token_for_another_audience_does_not(self, client, trusted):
+        response = self._get(client, trusted.mint(email=USERNAME, aud="a-different-application"))
+
+        assert response.status_code == 401
+
+    def test_an_unsigned_token_does_not(self, client, trusted):
+        response = self._get(client, unsigned_token(trusted.claims(email=USERNAME)))
+
+        assert response.status_code == 401

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,16 @@ commands =
     coverage run -m pytest -s -m "not integration" mlflow_oidc_auth/tests
     coverage xml
 
+[testenv:adversarial]
+description = Run only the adversarial token / authorization-response suite (#307).
+deps = {[testenv]deps}
+commands =
+    pip install -e '.[full,test]'
+    # Also runs as part of the default env, since it lives under mlflow_oidc_auth/tests. This
+    # env exists so the suite can be run on its own — when reviewing an auth change, or from a
+    # workflow that gates on it specifically.
+    pytest -q mlflow_oidc_auth/tests/adversarial mlflow_oidc_auth/tests/test_token_algorithm_pinning.py
+
 [testenv:integration]
 description = Run browser-based integration tests against a running mlflow-oidc-auth instance.
 deps =


### PR DESCRIPTION
Closes #307. The spike the epic requires **before** multi-issuer validation (#313) ships.

## Why now

With one provider, "which issuer minted this token?" has exactly one answer and every mix-up question is vacuous. #313 and #316 change that. This suite writes the properties down while they are still easy to state, so the providers that come next are held to them instead of each re-deriving them.

## Structure

`mlflow_oidc_auth/tests/adversarial/`

- **`suite.py`** — `Issuer` (a stand-in IdP: own key, own `iss`, own audience, `mint()`), the forgery helpers (`unsigned_token`, `hmac_token`, `tamper`), and **`TokenAdversarySuite`**: the cases as a base class.
- **`test_oidc_bearer_tokens.py`** — today's only provider, inheriting the suite.
- **`test_authorization_response.py`** — the RFC 9207 mix-up cases.

A new provider type supplies a `verify`/`trusted`/`foreign` fixture and inherits every case. That is the "structured so a new provider inherits the suite" criterion: #313's second issuer and #314's Kubernetes provider cannot quietly skip one.

## Cases

| Issue case | Where |
|---|---|
| Algorithm confusion (public key as HMAC secret) | suite + existing `test_token_algorithm_pinning.py` |
| `alg: none` | suite, and end to end through `AuthMiddleware` |
| Cross-issuer replay | suite — a wholly genuine token from a provider this deployment does not trust |
| `kid` confusion | suite — both "foreign token wearing the trusted `kid`" and an unknown `kid` |
| Audience confusion | `TestAudienceConfusion` — wrong `aud`, absent `aud`, multi-audience with and without ours |
| `jku` / `x5u` injection | suite — asserted rejected, and the URL never fetched |
| Callback missing / stripped / mismatched `iss` | `test_authorization_response.py` |

## The RFC 9207 half needs a decision to test

The mix-up cases have no meaning without something that decides them, so the decision is here — `mlflow_oidc_auth/authorization_response.py`, a pure function — and **nothing calls it yet**. Wiring it into the callback needs the per-provider routes and the `auth_state` row that #316 introduces, and #316's own acceptance criteria already say "mix-up cases from #307 all rejected". So it inherits a decision that is already pinned, rather than writing decision and wiring at once. No deployment's behaviour changes in this PR.

The rule it encodes: a mismatch is fatal regardless of metadata; a missing `iss` is fatal when the provider advertises `authorization_response_iss_parameter_supported` (otherwise stripping the parameter opts out of the check); a missing `iss` is allowed when the provider advertises nothing, because RFC 9207 is recent and refusing would break working logins to defend against an attack that needs a second authorization server to exist.

## Two things the suite found about itself

Recorded in place rather than papered over:

1. **The public-key-as-HMAC-secret case cannot fail here.** I mutated the accepted-algorithm set to include `HS256` and it still passed — authlib refuses to use a key it resolved as RSA for HMAC verification, independently of the pin. So passing it is *not* evidence the pin exists. The docstring says so and points at the falsifiable structural assertion. Kept because a future provider could resolve keys differently and lose that second defence.
2. **The property test caught a bug in my own decision function** — `?iss=` (empty) was a mismatch in one branch and missing in another, so a provider emitting an empty parameter would be refused while one omitting it entirely was allowed. Fixed; blank and absent are now the same case.

## Validating that the tests can fail

Adversarial tests that pass on the first run are the least trustworthy kind, so I mutated the source and confirmed they catch it:

- Disabled `iss`/`aud` pinning in `_get_claims_options` → **6 failures**, all the claim-confusion cases.
- Widened `_ACCEPTED_ALGORITHMS` with `none` and `HS256` → **3 failures**, the unsigned-token cases at helper, suite and middleware level.

Both mutations reverted; `git diff` on `mlflow_oidc_auth/auth.py` is empty.

## Validation

```
pre-commit run --all-files                 # passed
pytest -m 'not integration' .../tests      # 3652 passed, 14 skipped
```

55 new tests. The suite runs in CI automatically (it lives under `mlflow_oidc_auth/tests`); `tox -e adversarial` runs it and the algorithm-pinning file alone, for reviewing an auth change.

No migrations, no frontend, no change to the per-request auth path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)