### PR TITLE
feat(auth): validate bearer tokens per provider (#313)

### DIFF
--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import threading
 
 import requests
@@ -8,6 +10,10 @@ from cachetools import TTLCache
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS
+
+# Provider types whose credentials are bearer tokens verified against a JWKS. SAML asserts
+# identity through a browser POST instead, so it never resolves a token here.
+TOKEN_PROVIDER_TYPES = ("oidc", "k8s")
 from mlflow_oidc_auth.user import create_user, populate_groups, update_user
 
 logger = get_logger()
@@ -25,13 +31,20 @@ logger = get_logger()
 _ACCEPTED_ALGORITHMS = list(ASYMMETRIC_ALGORITHMS)
 _jwt = JsonWebToken(_ACCEPTED_ALGORITHMS)
 
-# JWKS cache: single-entry TTL cache shared across all token validations.
-# TTL is configured via OIDC_JWKS_CACHE_TTL_SECONDS (default 300s).
-# Thread-safe via a lock since multiple ASGI workers may validate concurrently.
+# JWKS cache for the deployment-wide ``OIDC_DISCOVERY_URL``. TTL from
+# OIDC_JWKS_CACHE_TTL_SECONDS (default 300s). Thread-safe via a lock, since multiple ASGI
+# workers validate concurrently.
 _jwks_cache: TTLCache = TTLCache(maxsize=1, ttl=config.OIDC_JWKS_CACHE_TTL_SECONDS)
 _jwks_cache_lock = threading.Lock()
 
 _JWKS_CACHE_KEY = "jwks"
+
+# Per-provider JWKS, keyed by provider id (#313). Separate from the cache above so a rotation
+# retry for one issuer cannot evict another's keys: sharing one entry across issuers would mean
+# every failed signature refetched whichever provider happened to be there, and two issuers with
+# different rotation schedules would thrash each other indefinitely.
+_provider_jwks_cache: TTLCache = TTLCache(maxsize=32, ttl=config.OIDC_JWKS_CACHE_TTL_SECONDS)
+_provider_jwks_lock = threading.Lock()
 
 
 def _get_oidc_jwks(force_refresh: bool = False) -> dict:
@@ -82,40 +95,174 @@ def _get_oidc_jwks(force_refresh: bool = False) -> dict:
     return jwks
 
 
-def _get_claims_options() -> dict | None:
-    """Build JWT claims validation options.
+def _get_provider_jwks(provider, force_refresh: bool = False) -> dict:
+    """Fetch the JWKS for one provider, cached per provider id (#313).
+
+    A provider that names no key source of its own inherits the deployment-wide
+    ``OIDC_DISCOVERY_URL``, so it goes through :func:`_get_oidc_jwks` and shares that cache —
+    which is what keeps a single-provider deployment behaving exactly as before.
+
+    Parameters:
+        provider: The resolved :class:`ProviderConfig`.
+        force_refresh: Drop this provider's cached keys first. Used on ``BadSignatureError`` to
+            pick up a rotated key — and only ever for the provider whose signature failed.
 
     Returns:
-        A claims_options dict for authlib jwt.decode if audience validation
-        is configured, otherwise None.
+        The JWKS payload.
+    """
+    if not provider.discovery_url:
+        # Only the synthesised legacy provider reaches this: the registry requires a token
+        # provider to name its own key source, precisely so that two providers cannot share the
+        # single-entry cache below and evict each other's keys on every refresh.
+        return _get_oidc_jwks(force_refresh=force_refresh)
+
+    # Keyed on the source as well as the id, so repointing a provider at a different IdP does
+    # not keep serving the previous one's keys for the rest of the TTL.
+    cache_key = (provider.id, provider.discovery_url)
+    with _provider_jwks_lock:
+        if force_refresh:
+            _provider_jwks_cache.pop(cache_key, None)
+        cached = _provider_jwks_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    timeout = config.OIDC_HTTP_TIMEOUT_SECONDS
+    try:
+        logger.debug("Fetching OIDC discovery metadata for provider %s", provider.id)
+        metadata = requests.get(provider.discovery_url, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
+        jwks_uri = metadata.get("jwks_uri")
+        if not jwks_uri:
+            raise ValueError(f"No jwks_uri in discovery metadata for provider '{provider.id}'")
+
+        logger.debug("Fetching JWKS for provider %s", provider.id)
+        jwks = requests.get(jwks_uri, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
+    except requests.exceptions.RequestException as e:
+        logger.error("Failed to fetch JWKS for provider %s: %s", provider.id, e)
+        raise
+
+    with _provider_jwks_lock:
+        _provider_jwks_cache[cache_key] = jwks
+
+    return jwks
+
+
+def _unverified_issuer(token: str) -> str | None:
+    """Read ``iss`` from a token **without verifying anything**.
+
+    This is the one place unverified token content is read, and it is read for exactly one
+    purpose: choosing which validator to apply. That is safe only because the choice can never
+    grant anything — an unrecognised value selects no validator and the token is refused, and a
+    recognised one selects a provider whose keys, algorithms, issuer and audience are then all
+    enforced. Nothing here is trusted; it is a lookup key.
+    """
+    try:
+        payload = token.split(".")[1]
+        decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+        issuer = json.loads(decoded).get("iss")
+    except Exception:
+        return None
+    return issuer if isinstance(issuer, str) else None
+
+
+def resolve_token_provider(token: str):
+    """The provider whose policy applies to ``token``. See :func:`_resolve_provider`."""
+    return _resolve_provider(token)
+
+
+def _resolve_provider(token: str):
+    """Pick the provider whose validator applies to ``token``.
+
+    A deployment with one provider has nothing to choose between: the single validator applies,
+    and no unverified token content is consulted at all. This is also what keeps every existing
+    single-provider deployment byte-for-byte unchanged.
+
+    With more than one, the token's unverified ``iss`` selects the provider by **exact match**,
+    and an issuer that matches nothing is refused. There is deliberately no fallback validator:
+    a default would be the one an attacker aims at, since reaching it requires only an ``iss``
+    that matches nothing.
+
+    Raises:
+        ValueError: If no provider matches, or the registry has none at all.
+    """
+    providers = [provider for provider in config.AUTH_PROVIDERS.providers if provider.type in TOKEN_PROVIDER_TYPES]
+    if not providers:
+        raise ValueError("No token-validating provider is configured")
+
+    if len(providers) == 1:
+        return providers[0]
+
+    issuer = _unverified_issuer(token)
+    if not issuer:
+        raise ValueError("Token carries no issuer, and this deployment has more than one provider to choose between")
+
+    for provider in providers:
+        if provider.issuer and provider.issuer == issuer:
+            return provider
+
+    # Deliberately not logged with the issuer at error level in a way that would let an
+    # unauthenticated caller fill the log with arbitrary strings; debug carries the detail.
+    logger.debug("No configured provider claims issuer %r", issuer)
+    raise ValueError("Token issuer does not match any configured provider")
+
+
+def _claims_options_for(provider) -> dict | None:
+    """Build the claims constraints for one provider.
+
+    Audience is required of every explicitly configured provider (the registry refuses an entry
+    without one), so a multi-provider deployment always pins it. The synthesised ``default``
+    provider may carry none, which is the pre-#313 behaviour for a deployment that never set
+    ``OIDC_AUDIENCE``, preserved so upgrading changes nothing.
     """
     options = {}
-    if config.OIDC_AUDIENCE:
-        options["aud"] = {"essential": True, "value": config.OIDC_AUDIENCE}
-    if config.OIDC_ISSUER:
-        options["iss"] = {"essential": True, "value": config.OIDC_ISSUER}
-    if options:
-        return options
-    return None
+    if provider.audience:
+        options["aud"] = {"essential": True, "value": provider.audience}
+    if provider.issuer:
+        options["iss"] = {"essential": True, "value": provider.issuer}
+    return options or None
+
+
+def _jwt_for(provider) -> JsonWebToken:
+    """A decoder pinned to this provider's accepted algorithms.
+
+    Per-provider rather than global because a Kubernetes issuer and an Entra tenant need not
+    agree on an algorithm set, and the registry already refuses a symmetric one — so whatever is
+    here is asymmetric, and the token's own header still chooses nothing.
+    """
+    algorithms = [algorithm for algorithm in provider.allowed_algorithms if algorithm in ASYMMETRIC_ALGORITHMS]
+    if not algorithms:
+        raise ValueError(f"Provider '{provider.id}' has no usable signing algorithm")
+    return JsonWebToken(algorithms)
 
 
 def validate_token(token: str):
-    """Validate JWT token using OIDC JWKS.
+    """Validate a bearer token against the provider that issued it.
 
-    When OIDC_AUDIENCE is configured, the ``aud`` claim is validated
-    against the expected audience value during ``payload.validate()``.
+    The provider is chosen first (see :func:`_resolve_provider`), and everything after that —
+    keys, accepted algorithms, expected issuer, expected audience — comes from that provider
+    alone. No union of keys across providers is ever offered to the decoder, so a ``kid`` can
+    only ever select a key belonging to the issuer the token claims.
+
+    Returns:
+        The validated claims.
+
+    Raises:
+        ValueError: If no provider matches the token's issuer.
+        Exception: Whatever authlib raises for a token that does not validate.
     """
-    claims_options = _get_claims_options()
+    provider = _resolve_provider(token)
+    claims_options = _claims_options_for(provider)
+    decoder = _jwt_for(provider)
+
     try:
-        jwks = _get_oidc_jwks()
-        payload = _jwt.decode(token, jwks, claims_options=claims_options)
+        jwks = _get_provider_jwks(provider)
+        payload = decoder.decode(token, jwks, claims_options=claims_options)
         payload.validate()
         return payload
     except BadSignatureError as e:
-        logger.error("Token validation failed with bad signature: %s", str(e))
-        # Force-refresh JWKS and retry once. This handles key rotation.
-        jwks = _get_oidc_jwks(force_refresh=True)
-        payload = _jwt.decode(token, jwks, claims_options=claims_options)
+        logger.error("Token validation failed with bad signature for provider %s: %s", provider.id, str(e))
+        # Refresh *this* provider's keys and retry once, for key rotation.
+        jwks = _get_provider_jwks(provider, force_refresh=True)
+        payload = decoder.decode(token, jwks, claims_options=claims_options)
         payload.validate()
         return payload
     except Exception as e:

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -9,11 +9,12 @@ from cachetools import TTLCache
 
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
-from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS
 
-# Provider types whose credentials are bearer tokens verified against a JWKS. SAML asserts
-# identity through a browser POST instead, so it never resolves a token here.
-TOKEN_PROVIDER_TYPES = ("oidc", "k8s")
+# TOKEN_PROVIDER_TYPES is imported rather than restated: the registry uses it to decide which
+# providers must pin an issuer and a key source, and this module uses it to decide which may
+# validate a token. Two copies could disagree, and the dangerous direction is silent — a type
+# routed here but never required there is a provider with no ``iss`` check.
+from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS, TOKEN_PROVIDER_TYPES
 from mlflow_oidc_auth.user import create_user, populate_groups, update_user
 
 logger = get_logger()
@@ -28,8 +29,11 @@ logger = get_logger()
 # The same asymmetric set the provider registry accepts (#308): signatures are checked against
 # keys fetched from the provider's JWKS, so a symmetric algorithm has no legitimate use here and
 # an unsigned token none at all.
+# The ceiling. A provider's own ``allowed_algorithms`` narrows within this set (see
+# :func:`_jwt_for`); nothing widens it. There is deliberately no module-level decoder built from
+# it any more — one would look like the live verifier while every validation used a per-provider
+# decoder instead, so a change made here would appear to take effect and would not.
 _ACCEPTED_ALGORITHMS = list(ASYMMETRIC_ALGORITHMS)
-_jwt = JsonWebToken(_ACCEPTED_ALGORITHMS)
 
 # JWKS cache for the deployment-wide ``OIDC_DISCOVERY_URL``. TTL from
 # OIDC_JWKS_CACHE_TTL_SECONDS (default 300s). Thread-safe via a lock, since multiple ASGI
@@ -64,33 +68,50 @@ def _get_oidc_jwks(force_refresh: bool = False) -> dict:
     if config.OIDC_DISCOVERY_URL is None:
         raise ValueError("OIDC_DISCOVERY_URL is not set in the configuration")
 
-    with _jwks_cache_lock:
-        if force_refresh:
-            _jwks_cache.pop(_JWKS_CACHE_KEY, None)
+    return _load_jwks(
+        config.OIDC_DISCOVERY_URL,
+        cache=_jwks_cache,
+        lock=_jwks_cache_lock,
+        cache_key=_JWKS_CACHE_KEY,
+        force_refresh=force_refresh,
+        label="the configured OIDC provider",
+    )
 
-        cached = _jwks_cache.get(_JWKS_CACHE_KEY)
+
+def _load_jwks(discovery_url: str, *, cache: TTLCache, lock: threading.Lock, cache_key, force_refresh: bool, label: str) -> dict:
+    """Discovery-then-JWKS fetch, cached in ``cache`` under ``cache_key``.
+
+    One implementation for both callers on purpose. They differ only in which cache the result
+    lands in, and a deployment silently takes one or the other depending on whether its provider
+    names a key source — so two implementations would mean a fix applied to the branch under
+    test having no effect on the branch a real deployment runs.
+    """
+    with lock:
+        if force_refresh:
+            cache.pop(cache_key, None)
+        cached = cache.get(cache_key)
         if cached is not None:
             return cached
 
-    # Fetch outside the lock to avoid blocking other threads during HTTP I/O.
-    # Timeouts are essential: without them, a hung IdP can block request threads
-    # until the OS-level TCP timeout (~2 minutes), causing cascading auth failures.
+    # Fetched outside the lock, so HTTP I/O does not block other threads. Timeouts are
+    # essential: without them a hung IdP holds request threads until the OS-level TCP timeout
+    # (~2 minutes), and authentication failures cascade.
     timeout = config.OIDC_HTTP_TIMEOUT_SECONDS
     try:
-        logger.debug("Fetching OIDC discovery metadata")
-        metadata = requests.get(config.OIDC_DISCOVERY_URL, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
+        logger.debug("Fetching OIDC discovery metadata for %s", label)
+        metadata = requests.get(discovery_url, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
         jwks_uri = metadata.get("jwks_uri")
         if not jwks_uri:
-            raise ValueError("No jwks_uri found in OIDC discovery metadata")
+            raise ValueError(f"No jwks_uri found in OIDC discovery metadata for {label}")
 
         logger.debug("Fetching JWKS from %s", jwks_uri)
         jwks = requests.get(jwks_uri, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
     except requests.exceptions.RequestException as e:
-        logger.error("Failed to fetch OIDC JWKS: %s", e)
+        logger.error("Failed to fetch JWKS for %s: %s", label, e)
         raise
 
-    with _jwks_cache_lock:
-        _jwks_cache[_JWKS_CACHE_KEY] = jwks
+    with lock:
+        cache[cache_key] = jwks
 
     return jwks
 
@@ -111,39 +132,21 @@ def _get_provider_jwks(provider, force_refresh: bool = False) -> dict:
         The JWKS payload.
     """
     if not provider.discovery_url:
-        # Only the synthesised legacy provider reaches this: the registry requires a token
-        # provider to name its own key source, precisely so that two providers cannot share the
-        # single-entry cache below and evict each other's keys on every refresh.
+        # A provider that names no source of its own inherits the deployment-wide one. Only the
+        # synthesised legacy provider can be in this state, and only when OIDC_DISCOVERY_URL is
+        # itself unset — with it set, that provider carries it and takes the cache below.
         return _get_oidc_jwks(force_refresh=force_refresh)
 
     # Keyed on the source as well as the id, so repointing a provider at a different IdP does
     # not keep serving the previous one's keys for the rest of the TTL.
-    cache_key = (provider.id, provider.discovery_url)
-    with _provider_jwks_lock:
-        if force_refresh:
-            _provider_jwks_cache.pop(cache_key, None)
-        cached = _provider_jwks_cache.get(cache_key)
-        if cached is not None:
-            return cached
-
-    timeout = config.OIDC_HTTP_TIMEOUT_SECONDS
-    try:
-        logger.debug("Fetching OIDC discovery metadata for provider %s", provider.id)
-        metadata = requests.get(provider.discovery_url, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
-        jwks_uri = metadata.get("jwks_uri")
-        if not jwks_uri:
-            raise ValueError(f"No jwks_uri in discovery metadata for provider '{provider.id}'")
-
-        logger.debug("Fetching JWKS for provider %s", provider.id)
-        jwks = requests.get(jwks_uri, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
-    except requests.exceptions.RequestException as e:
-        logger.error("Failed to fetch JWKS for provider %s: %s", provider.id, e)
-        raise
-
-    with _provider_jwks_lock:
-        _provider_jwks_cache[cache_key] = jwks
-
-    return jwks
+    return _load_jwks(
+        provider.discovery_url,
+        cache=_provider_jwks_cache,
+        lock=_provider_jwks_lock,
+        cache_key=(provider.id, provider.discovery_url),
+        force_refresh=force_refresh,
+        label=f"provider {provider.id}",
+    )
 
 
 def _unverified_issuer(token: str) -> str | None:
@@ -228,7 +231,7 @@ def _jwt_for(provider) -> JsonWebToken:
     agree on an algorithm set, and the registry already refuses a symmetric one — so whatever is
     here is asymmetric, and the token's own header still chooses nothing.
     """
-    algorithms = [algorithm for algorithm in provider.allowed_algorithms if algorithm in ASYMMETRIC_ALGORITHMS]
+    algorithms = [algorithm for algorithm in provider.allowed_algorithms if algorithm in _ACCEPTED_ALGORITHMS]
     if not algorithms:
         raise ValueError(f"Provider '{provider.id}' has no usable signing algorithm")
     return JsonWebToken(algorithms)

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -185,9 +185,25 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return
 
         # Hardening: never provision from a token that is not scoped by both aud and iss.
-        if not (config.OIDC_AUDIENCE and config.OIDC_ISSUER):
+        #
+        # Asked of the provider that actually validated the token, not of the flat variables
+        # (#313). Those two no longer describe what was enforced: a registry-configured provider
+        # carries its own audience and issuer, so reading the flat pair would both credit
+        # scoping that was never applied — leftover variables from before the registry — and
+        # deny provisioning to a registry-only deployment that pins both properly.
+        try:
+            from mlflow_oidc_auth.auth import resolve_token_provider
+
+            provider = resolve_token_provider(token)
+        except Exception as e:
+            logger.warning("Provisioning skipped; could not identify the provider for %s: %s", username, type(e).__name__)
+            return
+
+        if not (provider.audience and provider.issuer):
             logger.warning(
-                "OIDC_PROVISION_ON_BEARER_AUTH is set but OIDC_AUDIENCE/OIDC_ISSUER are not both configured; refusing to provision %s from an under-scoped token",
+                "OIDC_PROVISION_ON_BEARER_AUTH is set but provider '%s' pins %s; refusing to provision %s from an under-scoped token",
+                provider.id,
+                "no audience" if not provider.audience else "no issuer",
                 username,
             )
             return

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -299,9 +299,14 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
                 f"{label}: 'issuer' is required for a '{provider_type}' provider; without it no 'iss' check is performed and "
                 "every issuer sharing that key set is accepted"
             )
-        if not isinstance(discovery_url, str) or not discovery_url.strip():
+        # Scoped to OIDC deliberately. A cluster's keys usually come from the API server's
+        # ``/openid/v1/jwks``, reached with the in-cluster service account and CA bundle rather
+        # than through a public discovery document, and legacy service-account tokens have no
+        # discovery document at all. #314 is where that provider learns how it sources keys, and
+        # it can state its own rule then — no k8s provider can be configured before it lands.
+        if provider_type == "oidc" and (not isinstance(discovery_url, str) or not discovery_url.strip()):
             errors.append(
-                f"{label}: 'discovery_url' is required for a '{provider_type}' provider; without it the provider shares the "
+                f"{label}: 'discovery_url' is required for an 'oidc' provider; without it the provider shares the "
                 "deployment-wide key cache with every other provider that omits one"
             )
 

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -51,6 +51,10 @@ INTERACTIVE_BY_DEFAULT = {"oidc": True, "saml": True, "k8s": False}
 PROVISIONING_MODES = ("jit", "scim", "none")
 GROUP_SYNC_MODES = ("none", "first_login", "every_login")
 GROUP_SYNC_STRATEGIES = ("additive", "authoritative")
+# Provider types whose credentials are bearer tokens verified against a JWKS. They carry the
+# extra requirements in _validate: an issuer to pin, and a key source of their own.
+TOKEN_PROVIDER_TYPES = ("oidc", "k8s")
+
 # "scim" is deliberately absent — see _validate_admin_source.
 ADMIN_SOURCES = ("claims", "none")
 IDENTITY_BINDINGS = ("subject", "email")
@@ -276,6 +280,30 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
 
     if not isinstance(audience, str) or not audience.strip():
         errors.append(f"{label}: 'audience' is required; a token validated with no audience check is valid for every relying party of that issuer")
+
+    if provider_type in TOKEN_PROVIDER_TYPES:
+        # Both required for the same reason ``audience`` is, and both became load-bearing when
+        # validation went per-provider (#313).
+        #
+        # Without ``issuer`` nothing pins ``iss``, so every tenant of a shared key set is
+        # accepted: an Entra ``common`` endpoint, a multi-tenant Keycloak realm and a cluster
+        # issuer fronting several namespaces all publish one JWKS for many issuers, and a token
+        # from any of them carries a valid signature. The attacker needs only their own tenant.
+        #
+        # Without ``discovery_url`` the provider inherits the deployment-wide key source and its
+        # single-entry cache, so two such providers share one cache slot: a rotation refresh for
+        # one evicts the other's keys, and an unauthenticated caller sending bad signatures can
+        # hold that slot permanently cold. Naming a source keeps each provider's keys its own.
+        if not isinstance(issuer, str) or not issuer.strip():
+            errors.append(
+                f"{label}: 'issuer' is required for a '{provider_type}' provider; without it no 'iss' check is performed and "
+                "every issuer sharing that key set is accepted"
+            )
+        if not isinstance(discovery_url, str) or not discovery_url.strip():
+            errors.append(
+                f"{label}: 'discovery_url' is required for a '{provider_type}' provider; without it the provider shares the "
+                "deployment-wide key cache with every other provider that omits one"
+            )
 
     if provider_type == "saml" and not _saml_extra_installed():
         errors.append(f"{label}: type 'saml' requires the [saml] extra to be installed")
@@ -518,12 +546,38 @@ def _legacy_entry(app_config: Any) -> Dict[str, Any]:
         "group_sync_mode": "authoritative",
         "admin_source": "claims",
         "identity_binding": "subject",
-        "allowed_algorithms": list(DEFAULT_ALGORITHMS),
+        # The set the synthesised provider is built with below — the whole asymmetric set, which
+        # is what validation accepted before it became per-provider.
+        "allowed_algorithms": list(ASYMMETRIC_ALGORITHMS),
         "audience": getattr(app_config, "OIDC_AUDIENCE", None),
         "issuer": getattr(app_config, "OIDC_ISSUER", None),
         "discovery_url": getattr(app_config, "OIDC_DISCOVERY_URL", None),
         "client_id": getattr(app_config, "OIDC_CLIENT_ID", None),
     }
+
+
+def _reject_duplicate_issuers(providers: List[ProviderConfig]) -> Tuple[List[ProviderConfig], List[str]]:
+    """Drop every provider after the first that claims a given issuer.
+
+    Token validation selects a provider by exact ``iss`` match and takes the first hit, so two
+    entries claiming one issuer means the second's policy — its audience, its binding, its group
+    rules — is never applied, and no error says so. Rejecting the later entries makes the
+    collision visible instead of resolving it by configuration order.
+    """
+    kept: List[ProviderConfig] = []
+    errors: List[str] = []
+    seen: Dict[str, str] = {}
+    for provider in providers:
+        if provider.issuer and provider.issuer in seen:
+            errors.append(
+                f"provider '{provider.id}': issuer {provider.issuer!r} is already claimed by provider '{seen[provider.issuer]}'; "
+                "a token can only be validated under one policy, so the later entry is ignored"
+            )
+            continue
+        if provider.issuer:
+            seen[provider.issuer] = provider.id
+        kept.append(provider)
+    return kept, errors
 
 
 def build_provider_registry(config_manager: Any, app_config: Any) -> RegistryLoadResult:
@@ -613,6 +667,9 @@ def build_provider_registry(config_manager: Any, app_config: Any) -> RegistryLoa
         seen_ids.add(provider.id)
         providers.append(provider)
 
+    providers, issuer_errors = _reject_duplicate_issuers(providers)
+    errors.extend(issuer_errors)
+
     return RegistryLoadResult(providers=providers, errors=errors, source=source)
 
 
@@ -648,7 +705,14 @@ def _legacy_providers(app_config: Any) -> List[ProviderConfig]:
             group_sync_mode="authoritative",
             admin_source="claims",
             identity_binding="subject",
-            allowed_algorithms=DEFAULT_ALGORITHMS,
+            # The full asymmetric set, not DEFAULT_ALGORITHMS. Before the registry existed, token
+            # validation accepted every asymmetric algorithm, so a deployment whose IdP signs with
+            # ES256 or RS512 — Auth0, several Okta and Keycloak configurations, Kubernetes — is
+            # working today. Narrowing that here would lock them out on upgrade with no
+            # configuration change of their own, which is the one thing the synthesised entry
+            # exists to prevent. An *explicitly* configured entry still defaults to RS256: there
+            # the operator is writing the policy, and can widen it deliberately.
+            allowed_algorithms=ASYMMETRIC_ALGORITHMS,
             audience=audience.strip() if isinstance(audience, str) and audience.strip() else None,
             issuer=entry["issuer"],
             discovery_url=entry["discovery_url"],

--- a/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
@@ -1,0 +1,233 @@
+"""Two issuers, validated independently (issue #313).
+
+Every case here is meaningless with one provider: choosing a validator is only a question when
+there is more than one, and it is the choosing that is dangerous. The provider is selected by
+the token's own **unverified** ``iss``, which is safe for exactly one reason — the choice can
+only ever narrow what follows. An unrecognised issuer selects nothing and the token is refused;
+a recognised one selects a provider whose keys, algorithms, issuer and audience are then all
+enforced against the token that named it.
+
+The suite in ``suite.py`` runs twice here, once per provider, which is the acceptance criterion
+that a new provider inherits the cases rather than restating them.
+"""
+
+import pytest
+
+import mlflow_oidc_auth.auth as auth_module
+
+from .suite import Issuer, TokenAdversarySuite, b64
+from .test_oidc_bearer_tokens import provider_for, registry_of
+
+
+@pytest.fixture
+def entra():
+    """The human-login provider."""
+    return Issuer(name="entra", iss="https://login.entra.invalid/tenant", audience="mlflow-tracking")
+
+
+@pytest.fixture
+def kubernetes():
+    """The automation provider: a cluster's service-account issuer, minting tokens for a
+    different audience and signed with a different key."""
+    return Issuer(name="k8s", iss="https://kubernetes.default.svc.invalid", audience="mlflow-api")
+
+
+@pytest.fixture
+def stranger():
+    """An issuer this deployment has never heard of.
+
+    The suite's ``foreign`` must be *unconfigured*: with two providers registered, a token from
+    the other one is legitimately accepted, so using it as the foreign issuer would assert the
+    opposite of what the deployment intends.
+    """
+    return Issuer(name="stranger", iss="https://stranger.idp.invalid", audience="mlflow-tracking")
+
+
+@pytest.fixture
+def both(entra, kubernetes, monkeypatch):
+    """A registry with both providers, each with its own keys."""
+    registry = registry_of(
+        provider_for(entra, provider_id="entra"),
+        provider_for(kubernetes, provider_id="k8s", type="k8s", interactive=False),
+    )
+    monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry)
+
+    keys = {"entra": entra.jwks, "k8s": kubernetes.jwks}
+    monkeypatch.setattr(auth_module, "_get_provider_jwks", lambda provider, force_refresh=False: keys[provider.id])
+    return auth_module.validate_token
+
+
+class TestBothIssuersWorkAtOnce:
+    def test_a_token_from_the_first_issuer_validates(self, both, entra):
+        assert both(entra.mint())["iss"] == entra.iss
+
+    def test_a_token_from_the_second_issuer_validates(self, both, kubernetes):
+        assert both(kubernetes.mint())["iss"] == kubernetes.iss
+
+    def test_neither_provider_can_verify_the_other_s_tokens(self, both, entra, kubernetes):
+        """Each provider's keys are offered to the decoder alone — never a union.
+
+        A union would mean the ``kid`` in an attacker's header selects from every configured
+        provider's keys at once, so compromising the weakest issuer would forge tokens for all
+        of them.
+        """
+        assert both(entra.mint(aud=entra.audience)) is not None
+
+        with pytest.raises(Exception):
+            # Entra's issuer, signed with the cluster's key: the header names the right issuer,
+            # so the right validator is chosen, and its keys refuse the signature.
+            both(kubernetes.mint(iss=entra.iss, aud=entra.audience))
+
+
+class TestAudienceIsPerProvider:
+    """The acceptance criterion: a token from issuer A presented with issuer B's audience."""
+
+    def test_the_first_issuer_s_token_is_refused_at_the_second_s_audience(self, both, entra, kubernetes):
+        with pytest.raises(Exception):
+            both(entra.mint(aud=kubernetes.audience))
+
+    def test_the_second_issuer_s_token_is_refused_at_the_first_s_audience(self, both, entra, kubernetes):
+        with pytest.raises(Exception):
+            both(kubernetes.mint(aud=entra.audience))
+
+    def test_each_is_accepted_at_its_own(self, both, entra, kubernetes):
+        assert both(entra.mint(aud=entra.audience)) is not None
+        assert both(kubernetes.mint(aud=kubernetes.audience)) is not None
+
+
+class TestAnUnknownIssuerHasNoValidator:
+    """No fallback, ever. A default validator is the one an attacker aims at, because reaching
+    it costs nothing more than an ``iss`` that matches nothing."""
+
+    def test_a_third_issuer_is_refused(self, both):
+        stranger = Issuer(name="stranger", iss="https://stranger.invalid", audience="mlflow-tracking")
+
+        with pytest.raises(ValueError, match="does not match any configured provider"):
+            both(stranger.mint())
+
+    def test_it_is_refused_even_when_signed_by_a_configured_provider_s_key(self, both, entra):
+        """The signature is genuine and the audience is right; only the issuer is unrecognised.
+        Falling back to "some provider verified it" would accept this."""
+        with pytest.raises(ValueError, match="does not match any configured provider"):
+            both(entra.mint(iss="https://stranger.invalid"))
+
+    def test_a_token_with_no_issuer_is_refused(self, both, entra):
+        claims = entra.claims()
+        claims.pop("iss")
+
+        with pytest.raises(ValueError, match="no issuer"):
+            both(entra.mint(claims))
+
+    def test_a_lookalike_issuer_is_refused(self, both, entra):
+        """Selection is exact string equality. Anything looser — prefix, suffix, case-insensitive
+        — lets an attacker register a host that resolves to someone else's validator."""
+        for lookalike in (entra.iss + ".attacker.invalid", entra.iss + "/", entra.iss.upper(), entra.iss.rstrip("/") + "/."):
+            with pytest.raises(ValueError):
+                both(entra.mint(iss=lookalike))
+
+
+class TestKeyRotationIsPerIssuer:
+    """A shared cache would mean every failed signature refetched whichever provider's keys
+    happened to be cached, and two issuers rotating on different schedules would evict each
+    other indefinitely."""
+
+    def test_only_the_failing_provider_is_refetched(self, entra, kubernetes, monkeypatch):
+        registry = registry_of(
+            provider_for(entra, provider_id="entra"),
+            provider_for(kubernetes, provider_id="k8s", type="k8s", interactive=False),
+        )
+        monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry)
+
+        refreshed = []
+        keys = {"entra": entra.jwks, "k8s": kubernetes.jwks}
+
+        def fetch(provider, force_refresh=False):
+            if force_refresh:
+                refreshed.append(provider.id)
+            return keys[provider.id]
+
+        monkeypatch.setattr(auth_module, "_get_provider_jwks", fetch)
+
+        # A token for Entra whose signature does not verify — the rotation-shaped failure, and
+        # the one authlib reports as BadSignatureError, which is what the retry is keyed on.
+        header, payload, _ = entra.mint().split(".")
+        unverifiable = f"{header}.{payload}.{b64(b'not-the-signature').decode()}"
+
+        with pytest.raises(Exception):
+            auth_module.validate_token(unverifiable)
+
+        assert refreshed == ["entra"], f"expected only the failing provider to be refetched, got {refreshed}"
+
+    def test_each_provider_caches_separately(self, entra, kubernetes, monkeypatch):
+        """The cache is keyed by provider id, so one entry cannot evict another's keys."""
+        auth_module._provider_jwks_cache.clear()
+        fetched = []
+
+        def fake_get(url, timeout=None, verify=None):
+            fetched.append(url)
+
+            class Response:
+                @staticmethod
+                def json():
+                    if url.endswith("/.well-known/openid-configuration"):
+                        return {"jwks_uri": url.replace("/.well-known/openid-configuration", "/keys")}
+                    return entra.jwks if "entra" in url else kubernetes.jwks
+
+            return Response()
+
+        monkeypatch.setattr(auth_module.requests, "get", fake_get)
+
+        entra_provider = provider_for(entra, provider_id="entra", discovery_url="https://entra.invalid/.well-known/openid-configuration")
+        k8s_provider = provider_for(kubernetes, provider_id="k8s", discovery_url="https://k8s.invalid/.well-known/openid-configuration")
+
+        assert auth_module._get_provider_jwks(entra_provider) == entra.jwks
+        assert auth_module._get_provider_jwks(k8s_provider) == kubernetes.jwks
+        # Both cached: neither displaced the other.
+        assert auth_module._get_provider_jwks(entra_provider) == entra.jwks
+        assert auth_module._get_provider_jwks(k8s_provider) == kubernetes.jwks
+
+        assert len(fetched) == 4, f"expected one discovery + one keys fetch per provider, got {fetched}"
+
+    def test_a_forced_refresh_evicts_only_its_own_entry(self, entra, kubernetes, monkeypatch):
+        auth_module._provider_jwks_cache.clear()
+        auth_module._provider_jwks_cache["entra"] = entra.jwks
+        auth_module._provider_jwks_cache["k8s"] = kubernetes.jwks
+
+        monkeypatch.setattr(auth_module.requests, "get", lambda *a, **k: (_ for _ in ()).throw(AssertionError("k8s keys were refetched")))
+        entra_provider = provider_for(entra, provider_id="entra", discovery_url="https://entra.invalid/.well-known/openid-configuration")
+
+        with pytest.raises(Exception):
+            auth_module._get_provider_jwks(entra_provider, force_refresh=True)
+
+        assert auth_module._provider_jwks_cache.get("k8s") == kubernetes.jwks, "the other provider's keys were evicted"
+
+
+class TestTheSuiteAppliesToEveryProvider:
+    """``TokenAdversarySuite`` run once per configured provider — the acceptance criterion that a
+    new provider inherits the cases rather than re-implementing them."""
+
+    class TestTheHumanLoginProvider(TokenAdversarySuite):
+        @pytest.fixture
+        def trusted(self, entra):
+            return entra
+
+        @pytest.fixture
+        def foreign(self, stranger):
+            return stranger
+
+        @pytest.fixture
+        def verify(self, both):
+            return both
+
+    class TestTheAutomationProvider(TokenAdversarySuite):
+        @pytest.fixture
+        def trusted(self, kubernetes):
+            return kubernetes
+
+        @pytest.fixture
+        def foreign(self, stranger):
+            return stranger
+
+        @pytest.fixture
+        def verify(self, both):
+            return both

--- a/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
@@ -231,3 +231,79 @@ class TestTheSuiteAppliesToEveryProvider:
         @pytest.fixture
         def verify(self, both):
             return both
+
+
+class TestTheSingleProviderDeploymentFetchesKeysTheSameWay:
+    """The path a real single-provider deployment takes, which the fixtures elsewhere skip.
+
+    Those fixtures build a provider with no ``discovery_url``, so they exercise the inherited
+    ``_get_oidc_jwks`` branch. A deployment that sets ``OIDC_DISCOVERY_URL`` — every real one —
+    gets a synthesised provider that *carries* it, and so takes the per-provider branch instead.
+    Both now run one implementation; these cases hold that, so a fix to key fetching cannot
+    apply to the branch under test and miss the branch in production.
+    """
+
+    def test_the_synthesised_provider_carries_the_configured_discovery_url(self):
+        """The fact the coverage gap turned on."""
+        from types import SimpleNamespace
+
+        from mlflow_oidc_auth.provider_registry import build_provider_registry
+
+        class Manager:
+            @staticmethod
+            def get(key, default=None):
+                return default
+
+        app_config = SimpleNamespace(
+            OIDC_PROVIDER_DISPLAY_NAME="Login with OIDC",
+            OIDC_AUDIENCE=None,
+            OIDC_ISSUER=None,
+            OIDC_DISCOVERY_URL="https://idp.example.com/.well-known/openid-configuration",
+            OIDC_CLIENT_ID="client",
+        )
+
+        provider = build_provider_registry(Manager(), app_config).providers[0]
+
+        assert provider.discovery_url == "https://idp.example.com/.well-known/openid-configuration"
+
+    def test_both_branches_run_the_same_fetch(self, entra, monkeypatch):
+        """Whichever cache the result lands in, the work is done by ``_load_jwks``."""
+        calls = []
+        monkeypatch.setattr(auth_module, "_load_jwks", lambda url, **kwargs: calls.append((url, kwargs["cache_key"])) or entra.jwks)
+        monkeypatch.setattr(auth_module.config, "OIDC_DISCOVERY_URL", "https://flat.example.com/.well-known/openid-configuration")
+
+        inherited = provider_for(entra, provider_id="default")
+        own_source = provider_for(entra, provider_id="default", discovery_url="https://own.example.com/.well-known/openid-configuration")
+
+        assert auth_module._get_provider_jwks(inherited) == entra.jwks
+        assert auth_module._get_provider_jwks(own_source) == entra.jwks
+
+        assert [url for url, _ in calls] == [
+            "https://flat.example.com/.well-known/openid-configuration",
+            "https://own.example.com/.well-known/openid-configuration",
+        ]
+        assert calls[0][1] == auth_module._JWKS_CACHE_KEY
+        assert calls[1][1] == ("default", "https://own.example.com/.well-known/openid-configuration")
+
+    def test_a_provider_with_its_own_source_still_refreshes_only_itself(self, entra, kubernetes, monkeypatch):
+        auth_module._provider_jwks_cache.clear()
+        auth_module._provider_jwks_cache[("k8s", "https://k8s.invalid/.well-known/openid-configuration")] = kubernetes.jwks
+
+        fetched = []
+
+        def fake_get(url, timeout=None, verify=None):
+            fetched.append(url)
+
+            class Response:
+                @staticmethod
+                def json():
+                    return {"jwks_uri": "https://entra.invalid/keys"} if "openid-configuration" in url else entra.jwks
+
+            return Response()
+
+        monkeypatch.setattr(auth_module.requests, "get", fake_get)
+        entra_provider = provider_for(entra, provider_id="entra", discovery_url="https://entra.invalid/.well-known/openid-configuration")
+
+        auth_module._get_provider_jwks(entra_provider, force_refresh=True)
+
+        assert auth_module._provider_jwks_cache.get(("k8s", "https://k8s.invalid/.well-known/openid-configuration")) == kubernetes.jwks

--- a/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_oidc_bearer_tokens.py
@@ -46,11 +46,36 @@ def foreign():
     return Issuer(name="foreign", iss="https://foreign.idp.invalid", audience="some-other-app")
 
 
+def registry_of(*providers, source="env"):
+    """A registry result holding exactly these providers.
+
+    Since #313 the issuer and audience a token is held to come from the matched provider, not
+    from the flat ``OIDC_*`` variables, so configuring a case means configuring a registry.
+    """
+    from mlflow_oidc_auth.provider_registry import RegistryLoadResult
+
+    return RegistryLoadResult(providers=list(providers), errors=[], source=source)
+
+
+def provider_for(trusted_issuer: Issuer, provider_id: str = "default", **overrides):
+    """A registry entry that trusts ``issuer``'s keys, issuer identifier and audience."""
+    from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS, ProviderConfig
+
+    fields = {
+        "id": provider_id,
+        "type": "oidc",
+        "allowed_algorithms": ASYMMETRIC_ALGORITHMS,
+        "audience": trusted_issuer.audience,
+        "issuer": trusted_issuer.iss,
+    }
+    fields.update(overrides)
+    return ProviderConfig(**fields)
+
+
 @pytest.fixture
 def verify(trusted, monkeypatch):
     """``validate_token`` with the trusted issuer's keys, issuer and audience pinned."""
-    monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", trusted.iss)
-    monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", trusted.audience)
+    monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry_of(provider_for(trusted)))
     monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
     return auth_module.validate_token
 
@@ -124,8 +149,12 @@ class TestTheUnpinnedDefault:
 
     @pytest.fixture
     def verify_unpinned(self, trusted, monkeypatch):
-        monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", None)
-        monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", None)
+        """The synthesised ``default`` provider of a deployment that set neither variable."""
+        monkeypatch.setattr(
+            auth_module.config,
+            "AUTH_PROVIDERS",
+            registry_of(provider_for(trusted, audience=None, issuer=None), source="legacy"),
+        )
         monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
         return auth_module.validate_token
 
@@ -173,8 +202,7 @@ class TestEndToEndThroughTheMiddleware:
         previous = object.__getattribute__(store_module.store, "_instance")
         object.__setattr__(store_module.store, "_instance", store)
 
-        monkeypatch.setattr(auth_module.config, "OIDC_ISSUER", trusted.iss)
-        monkeypatch.setattr(auth_module.config, "OIDC_AUDIENCE", trusted.audience)
+        monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry_of(provider_for(trusted)))
         monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: trusted.jwks)
 
         app = FastAPI()

--- a/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
+++ b/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
@@ -1,11 +1,32 @@
 """Layer 2 of the #262 fix: opt-in, hardened auto-provisioning on bearer authentication."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mlflow_oidc_auth.config import config as real_config
 from mlflow_oidc_auth.middleware.auth_middleware import AuthMiddleware
+
+
+@pytest.fixture(autouse=True)
+def provider_carries_the_configured_scoping(monkeypatch):
+    """Resolve the token's provider from whatever scoping the test configured.
+
+    Since #313 the provisioning gate asks the provider that validated the token whether it pins
+    an audience and an issuer, rather than reading the flat variables — those no longer describe
+    what was enforced. These tests describe a single-provider deployment, where the synthesised
+    provider carries exactly those flat values, so resolution mirrors them and every case keeps
+    meaning what it did.
+    """
+    import mlflow_oidc_auth.auth as auth_module
+    import mlflow_oidc_auth.middleware.auth_middleware as middleware_module
+
+    def resolve(token):
+        cfg = middleware_module.config
+        return SimpleNamespace(id="default", audience=cfg.OIDC_AUDIENCE, issuer=cfg.OIDC_ISSUER)
+
+    monkeypatch.setattr(auth_module, "resolve_token_provider", resolve)
 
 
 def _mw():

--- a/mlflow_oidc_auth/tests/test_auth.py
+++ b/mlflow_oidc_auth/tests/test_auth.py
@@ -4,7 +4,7 @@ import pytest
 from authlib.jose.errors import BadSignatureError
 
 from mlflow_oidc_auth.auth import (
-    _get_claims_options,
+    _claims_options_for,
     _get_oidc_jwks,
     _jwks_cache,
     validate_token,
@@ -122,15 +122,29 @@ class TestGetOidcJwks:
 
 
 class TestValidateToken:
-    """Test validate_token with audience and caching integration."""
+    """Test validate_token with audience and caching integration.
+
+    Since #313 the audience, issuer, keys and algorithms all come from the provider that issued
+    the token, so each case installs a one-provider registry — the shape of every deployment
+    that has not adopted a multi-provider configuration — instead of setting the flat variables
+    directly. ``_jwt_for`` is patched because the decoder is now built per provider.
+    """
+
+    @staticmethod
+    def _single_provider_registry(mock_config, audience=None, issuer=None):
+        from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS, ProviderConfig, RegistryLoadResult
+
+        provider = ProviderConfig(id="default", type="oidc", allowed_algorithms=ASYMMETRIC_ALGORITHMS, audience=audience, issuer=issuer)
+        mock_config.AUTH_PROVIDERS = RegistryLoadResult(providers=[provider], errors=[], source="legacy")
+        return provider
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_success(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_success(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
         """Test successful token validation without audience configured"""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
+        self._single_provider_registry(mock_config)
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_jwks = {"keys": [{"kty": "RSA", "kid": "test"}]}
         mock_get_oidc_jwks.return_value = mock_jwks
         mock_payload = MagicMock()
@@ -144,11 +158,11 @@ class TestValidateToken:
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_with_audience(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
-        """Test token validation passes audience claims_options when OIDC_AUDIENCE is configured"""
-        mock_config.OIDC_AUDIENCE = "my-mlflow-app"
-        mock_config.OIDC_ISSUER = None
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_with_audience(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
+        """Test token validation passes audience claims_options when the provider pins one"""
+        self._single_provider_registry(mock_config, audience="my-mlflow-app")
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_jwks = {"keys": [{"kty": "RSA", "kid": "test"}]}
         mock_get_oidc_jwks.return_value = mock_jwks
         mock_payload = MagicMock()
@@ -163,11 +177,11 @@ class TestValidateToken:
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_bad_signature_then_success(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_bad_signature_then_success(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
         """Test token validation with bad signature that succeeds after JWKS refresh"""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
+        self._single_provider_registry(mock_config)
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_get_oidc_jwks.side_effect = [{"keys": "old_jwks"}, {"keys": "new_jwks"}]
         mock_payload = MagicMock()
         mock_jwt_decode.side_effect = [BadSignatureError("bad signature"), mock_payload]
@@ -176,17 +190,18 @@ class TestValidateToken:
 
         assert result == mock_payload
         assert mock_get_oidc_jwks.call_count == 2
-        # Second call uses force_refresh=True to handle key rotation
-        mock_get_oidc_jwks.assert_any_call()
+        # Second call uses force_refresh=True to handle key rotation. Both go through
+        # _get_provider_jwks, which always passes the flag explicitly.
+        mock_get_oidc_jwks.assert_any_call(force_refresh=False)
         mock_get_oidc_jwks.assert_any_call(force_refresh=True)
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_bad_signature_after_refresh(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_bad_signature_after_refresh(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
         """Test token validation that fails even after JWKS refresh"""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
+        self._single_provider_registry(mock_config)
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_get_oidc_jwks.side_effect = [{"keys": "old_jwks"}, {"keys": "new_jwks"}]
         mock_jwt_decode.side_effect = [
             BadSignatureError("bad signature"),
@@ -200,11 +215,11 @@ class TestValidateToken:
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_unexpected_error_after_refresh(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_unexpected_error_after_refresh(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
         """Test token validation with unexpected error after JWKS refresh"""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
+        self._single_provider_registry(mock_config)
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_get_oidc_jwks.side_effect = [{"keys": "old_jwks"}, {"keys": "new_jwks"}]
         mock_jwt_decode.side_effect = [
             BadSignatureError("bad signature"),
@@ -218,11 +233,11 @@ class TestValidateToken:
 
     @patch("mlflow_oidc_auth.auth.config")
     @patch("mlflow_oidc_auth.auth._get_oidc_jwks")
-    @patch("mlflow_oidc_auth.auth._jwt.decode")
-    def test_validate_token_bad_signature_retry_with_audience(self, mock_jwt_decode, mock_get_oidc_jwks, mock_config):
+    @patch("mlflow_oidc_auth.auth._jwt_for")
+    def test_validate_token_bad_signature_retry_with_audience(self, mock_jwt_for, mock_get_oidc_jwks, mock_config):
         """Test bad signature retry also passes audience claims_options"""
-        mock_config.OIDC_AUDIENCE = "my-mlflow-app"
-        mock_config.OIDC_ISSUER = None
+        self._single_provider_registry(mock_config, audience="my-mlflow-app")
+        mock_jwt_decode = mock_jwt_for.return_value.decode
         mock_get_oidc_jwks.side_effect = [{"keys": "old_jwks"}, {"keys": "new_jwks"}]
         mock_payload = MagicMock()
         mock_jwt_decode.side_effect = [BadSignatureError("bad signature"), mock_payload]
@@ -236,44 +251,73 @@ class TestValidateToken:
         mock_jwt_decode.assert_any_call("token_with_new_key", {"keys": "new_jwks"}, claims_options=expected_options)
 
 
-class TestGetClaimsOptions:
-    """Test _get_claims_options helper function."""
+class TestClaimsOptionsPerProvider:
+    """``_claims_options_for`` replaces the flat ``_get_claims_options`` (#313).
 
-    @patch("mlflow_oidc_auth.auth.config")
-    def test_returns_none_when_no_audience(self, mock_config):
-        """Test returns None when OIDC_AUDIENCE is not configured"""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
-        mock_config.OIDC_ISSUER = None
-        assert _get_claims_options() is None
+    The constraints now come from the provider that issued the token rather than from one global
+    pair of variables, because two issuers do not share an audience. For a single-provider
+    deployment the values are the same ones: the synthesised ``default`` provider carries
+    ``OIDC_AUDIENCE`` and ``OIDC_ISSUER``, which is what keeps the behaviour unchanged.
+    """
 
-    @patch("mlflow_oidc_auth.auth.config")
-    def test_returns_none_when_audience_is_empty(self, mock_config):
-        """Test returns None when OIDC_AUDIENCE is empty string"""
-        mock_config.OIDC_AUDIENCE = ""
-        mock_config.OIDC_ISSUER = None
-        assert _get_claims_options() is None
+    @staticmethod
+    def _provider(**overrides):
+        from mlflow_oidc_auth.provider_registry import ProviderConfig
 
-    @patch("mlflow_oidc_auth.auth.config")
-    def test_returns_claims_options_when_audience_configured(self, mock_config):
-        """Test returns proper claims_options when OIDC_AUDIENCE is set"""
-        mock_config.OIDC_AUDIENCE = "my-mlflow-app"
-        mock_config.OIDC_ISSUER = None
-        mock_config.OIDC_ISSUER = None
-        result = _get_claims_options()
-        assert result == {"aud": {"essential": True, "value": "my-mlflow-app"}}
+        fields = {"id": "default", "type": "oidc"}
+        fields.update(overrides)
+        return ProviderConfig(**fields)
 
-    @patch("mlflow_oidc_auth.auth.config")
-    def test_returns_issuer_option_when_configured(self, mock_config):
-        """iss validation is included when OIDC_ISSUER is set."""
-        mock_config.OIDC_AUDIENCE = None
-        mock_config.OIDC_ISSUER = None
-        mock_config.OIDC_ISSUER = "https://idp.example.com"
-        assert _get_claims_options() == {"iss": {"essential": True, "value": "https://idp.example.com"}}
+    def test_returns_none_when_neither_is_pinned(self):
+        """The pre-#313 default for a deployment that set neither variable."""
+        assert _claims_options_for(self._provider()) is None
 
-    @patch("mlflow_oidc_auth.auth.config")
-    def test_returns_both_aud_and_iss(self, mock_config):
-        """Both aud and iss are validated when both are configured."""
-        mock_config.OIDC_AUDIENCE = "aud1"
-        mock_config.OIDC_ISSUER = "iss1"
-        assert _get_claims_options() == {"aud": {"essential": True, "value": "aud1"}, "iss": {"essential": True, "value": "iss1"}}
+    def test_returns_the_audience_when_pinned(self):
+        options = _claims_options_for(self._provider(audience="my-mlflow-app"))
+
+        assert options == {"aud": {"essential": True, "value": "my-mlflow-app"}}
+
+    def test_returns_the_issuer_when_pinned(self):
+        options = _claims_options_for(self._provider(issuer="https://idp.example.com"))
+
+        assert options == {"iss": {"essential": True, "value": "https://idp.example.com"}}
+
+    def test_returns_both(self):
+        options = _claims_options_for(self._provider(audience="aud1", issuer="iss1"))
+
+        assert options == {"aud": {"essential": True, "value": "aud1"}, "iss": {"essential": True, "value": "iss1"}}
+
+    def test_two_providers_get_their_own_constraints(self):
+        """The point of the change: one deployment, two issuers, two audiences."""
+        entra = self._provider(id="entra", audience="mlflow-tracking", issuer="https://entra.invalid")
+        cluster = self._provider(id="k8s", audience="mlflow-api", issuer="https://k8s.invalid")
+
+        assert _claims_options_for(entra)["aud"]["value"] == "mlflow-tracking"
+        assert _claims_options_for(cluster)["aud"]["value"] == "mlflow-api"
+
+    def test_the_legacy_variables_still_reach_the_default_provider(self, monkeypatch):
+        """The back-compat link. If this breaks, every existing deployment silently stops
+        checking the audience it configured."""
+        from mlflow_oidc_auth.provider_registry import build_provider_registry
+
+        class FlatConfig:
+            OIDC_DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration"
+            OIDC_CLIENT_ID = "client"
+            OIDC_CLIENT_SECRET = "secret"  # not a credential: a stand-in for a config lookup
+            OIDC_AUDIENCE = "legacy-audience"
+            OIDC_ISSUER = "https://idp.example.com"
+            OIDC_PROVIDER_DISPLAY_NAME = "Login with OIDC"
+
+        class Manager:
+            @staticmethod
+            def get(key, default=None):
+                return default
+
+        registry = build_provider_registry(Manager(), FlatConfig())
+        default = registry.by_id("default")
+
+        assert default is not None
+        assert _claims_options_for(default) == {
+            "aud": {"essential": True, "value": "legacy-audience"},
+            "iss": {"essential": True, "value": "https://idp.example.com"},
+        }

--- a/mlflow_oidc_auth/tests/test_auth_module.py
+++ b/mlflow_oidc_auth/tests/test_auth_module.py
@@ -1,3 +1,5 @@
+import types
+
 import pytest
 import requests
 from authlib.jose.errors import BadSignatureError
@@ -13,6 +15,18 @@ def clear_jwks_cache():
     _jwks_cache.clear()
     yield
     _jwks_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def single_provider(monkeypatch):
+    """A one-provider registry, the shape of every deployment that has not adopted a multi-
+    provider configuration. Since #313 validation resolves the provider first, so without this
+    there is nothing to validate against."""
+    from mlflow_oidc_auth.provider_registry import ASYMMETRIC_ALGORITHMS, ProviderConfig, RegistryLoadResult
+
+    provider = ProviderConfig(id="default", type="oidc", allowed_algorithms=ASYMMETRIC_ALGORITHMS)
+    monkeypatch.setattr(config, "AUTH_PROVIDERS", RegistryLoadResult(providers=[provider], errors=[], source="legacy"))
+    return provider
 
 
 class DummyResponse:
@@ -90,7 +104,7 @@ def test_validate_token_success(monkeypatch):
         assert jwks == {"keys": []}
         return payload
 
-    monkeypatch.setattr(auth._jwt, "decode", fake_decode)
+    monkeypatch.setattr(auth, "_jwt_for", lambda provider: types.SimpleNamespace(decode=fake_decode))
 
     result = auth.validate_token("tok")
     assert result is payload
@@ -109,7 +123,7 @@ def test_validate_token_bad_signature_retries(monkeypatch):
             raise BadSignatureError("bad sig")
         return payload
 
-    monkeypatch.setattr(auth._jwt, "decode", fake_decode)
+    monkeypatch.setattr(auth, "_jwt_for", lambda provider: types.SimpleNamespace(decode=fake_decode))
 
     result = auth.validate_token("tok")
     assert result is payload
@@ -123,7 +137,7 @@ def test_validate_token_other_exception_propagates(monkeypatch):
     def fake_decode(token, jwks, claims_options=None):
         raise ValueError("boom")
 
-    monkeypatch.setattr(auth._jwt, "decode", fake_decode)
+    monkeypatch.setattr(auth, "_jwt_for", lambda provider: types.SimpleNamespace(decode=fake_decode))
 
     with pytest.raises(ValueError):
         auth.validate_token("tok")

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -16,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 
 from mlflow_oidc_auth.provider_registry import (
+    ASYMMETRIC_ALGORITHMS,
     DEFAULT_ALGORITHMS,
     DEFAULT_PROVIDER_ID,
     ProviderConfig,
@@ -53,8 +54,22 @@ def legacy_app_config(**overrides) -> SimpleNamespace:
 
 
 def valid_entry(**overrides) -> dict:
-    """A minimal entry that passes every check, for tests that break one thing at a time."""
-    entry = {"id": "okta", "type": "oidc", "audience": "mlflow"}
+    """A minimal entry that passes every check, for tests that break one thing at a time.
+
+    ``issuer`` and ``discovery_url`` are part of the minimum for a token-validating provider
+    since #313: without the first nothing pins ``iss``, and without the second the provider
+    shares the deployment-wide key cache with every other provider that omits one.
+    """
+    provider_id = overrides.get("id", "okta")
+    entry = {
+        "id": provider_id,
+        "type": "oidc",
+        "audience": "mlflow",
+        # Derived from the id: two entries in one registry must not accidentally share an
+        # issuer, which is now rejected — a token can only be validated under one policy.
+        "issuer": f"https://{provider_id}.example.com",
+        "discovery_url": f"https://{provider_id}.example.com/.well-known/openid-configuration",
+    }
     entry.update(overrides)
     return entry
 
@@ -85,7 +100,20 @@ class TestLegacyBackCompat:
         assert provider.group_sync_mode == "authoritative"
         assert provider.admin_source == "claims"
         assert provider.identity_binding == "subject"
-        assert provider.allowed_algorithms == DEFAULT_ALGORITHMS
+
+    def test_the_default_provider_accepts_every_asymmetric_algorithm(self):
+        """Not ``DEFAULT_ALGORITHMS`` — that is the default for an entry an operator *writes*.
+
+        Before per-provider validation (#313), token validation accepted the whole asymmetric
+        set, so a deployment whose IdP signs with ES256 or RS512 is working today. Narrowing the
+        synthesised entry to RS256 would lock those deployments out on upgrade without them
+        changing any configuration, which is the one thing this entry exists to prevent.
+        """
+        provider = build().providers[0]
+
+        assert provider.allowed_algorithms == ASYMMETRIC_ALGORITHMS
+        assert "RS256" in provider.allowed_algorithms
+        assert not any(algorithm.startswith("HS") for algorithm in provider.allowed_algorithms)
 
     def test_the_default_provider_carries_the_flat_oidc_values(self):
         provider = build(app_config=legacy_app_config(OIDC_AUDIENCE="aud-1", OIDC_ISSUER="https://idp.example.com")).providers[0]
@@ -529,3 +557,81 @@ class TestAppConfigIntegration:
             app_config._warn_if_provider_registry_invalid()
 
         assert any("something is wrong" in r.message for r in caplog.records)
+
+
+class TestATokenProviderMustPinItsOwnIssuerAndKeys:
+    """Both became load-bearing when validation went per-provider (#313).
+
+    Before that, a registry entry was configuration nothing authenticated against, so an
+    optional field was harmless. Now the entry *is* the policy a bearer token is judged by.
+    """
+
+    def test_an_entry_without_an_issuer_is_rejected(self):
+        """Without it nothing pins ``iss``, so every issuer sharing that key set is accepted.
+
+        The realistic shape is a multi-tenant endpoint — Entra's ``common``, a shared Keycloak
+        realm, a cluster issuer fronting several namespaces — where one JWKS serves many
+        issuers. An attacker with their own tenant on that endpoint holds a token with a valid
+        signature and the right audience; only ``iss`` distinguishes it.
+        """
+        entry = valid_entry()
+        entry.pop("issuer")
+
+        result = build([entry])
+
+        assert result.providers == []
+        assert any("issuer" in error and "iss" in error for error in result.errors)
+
+    @pytest.mark.parametrize("blank", [None, "", "   "])
+    def test_a_blank_issuer_is_rejected(self, blank):
+        result = build([valid_entry(issuer=blank)])
+
+        assert result.providers == []
+
+    def test_an_entry_without_a_discovery_url_is_rejected(self):
+        """Without one it inherits the deployment-wide key source and its single-entry cache, so
+        two such providers evict each other's keys on every rotation refresh."""
+        entry = valid_entry()
+        entry.pop("discovery_url")
+
+        result = build([entry])
+
+        assert result.providers == []
+        assert any("discovery_url" in error for error in result.errors)
+
+    def test_a_saml_provider_needs_neither(self):
+        """The requirement is about validating bearer tokens against a key set. SAML asserts
+        identity through a browser POST and never resolves a token here."""
+        entry = {"id": "corp-saml", "type": "saml", "audience": "mlflow"}
+
+        result = build([entry])
+
+        # Rejected only if the [saml] extra is missing — never for the token-provider fields.
+        assert not any("issuer" in error or "discovery_url" in error for error in result.errors)
+
+    def test_the_legacy_provider_is_unaffected(self):
+        """It is synthesised from flat variables that may legitimately be unset, and it is the
+        one provider that must keep working with no configuration change at all."""
+        provider = build().providers[0]
+
+        assert provider.id == DEFAULT_PROVIDER_ID
+        assert provider.issuer is None
+
+
+class TestTwoProvidersCannotClaimOneIssuer:
+    """Validation takes the first exact ``iss`` match, so a duplicate means the second entry's
+    policy — its audience, binding and group rules — is silently never applied."""
+
+    def test_the_later_entry_is_rejected(self):
+        first = valid_entry(id="first", issuer="https://shared.example.com")
+        second = valid_entry(id="second", issuer="https://shared.example.com")
+
+        result = build([first, second])
+
+        assert [provider.id for provider in result.providers] == ["first"]
+        assert any("already claimed" in error for error in result.errors)
+
+    def test_distinct_issuers_both_survive(self):
+        result = build([valid_entry(id="first"), valid_entry(id="second")])
+
+        assert [provider.id for provider in result.providers] == ["first", "second"]


### PR DESCRIPTION
Closes #313. First item of Phase 1 in #304, and the half of multi-provider support that needs no login flow and no UI — it makes Kubernetes service-account tokens usable for automation while Entra handles human login.

## What changed

Validation used a single-entry JWKS cache and one `OIDC_ISSUER`/`OIDC_AUDIENCE` pair. Now the **provider is resolved first**, and everything after comes from that provider alone: its keys, its accepted algorithms, its issuer, its audience.

Selection reads the token's *unverified* `iss`. That is safe for exactly one reason: **the choice can only ever narrow**. An unrecognised issuer selects nothing and the token is refused; a recognised one selects a provider whose constraints are then all enforced against the token that named it. No union of keys is ever offered to the decoder, so a `kid` can only select a key belonging to the issuer the token claims.

**No fallback validator, ever.** A default is precisely what an attacker aims at, since reaching it costs nothing more than an `iss` that matches nothing.

## Back-compat

A deployment with one provider **skips routing entirely** — there is nothing to choose between, and no unverified content is consulted. It keeps using the deployment-wide `_get_oidc_jwks` and the audience/issuer it already configured, which the synthesised `default` provider carries.

One thing had to be corrected to keep that true: the synthesised provider now carries the **whole asymmetric algorithm set**, not the RS256 default of an explicitly written entry. Pre-#313 validation accepted every asymmetric algorithm, so narrowing it would have locked out every ES256 or RS512 deployment on upgrade without them changing a thing. An entry an operator *writes* still defaults to RS256 — there they are stating the policy.

## Key rotation is per issuer

JWKS are cached per provider, keyed on `(id, discovery_url)`, and the `BadSignatureError` retry refreshes only the provider whose signature failed. A shared entry would mean every failure refetched whichever provider happened to be cached, and two issuers on different rotation schedules would evict each other indefinitely. Keying on the source too means repointing a provider at a new IdP does not keep serving the old one's keys for the rest of the TTL.

## Two requirements added to the registry

A `security-reviewer` pass over the diff produced these, and both are now enforced at load with an explanatory error:

- **An explicitly configured token provider must pin `issuer`.** Without it nothing checks `iss`, and a multi-tenant endpoint — Entra `common`, a shared Keycloak realm, a cluster issuer fronting several namespaces — publishes one JWKS for many issuers. A token from any of them carries a valid signature and the right audience; `iss` is the only thing that distinguishes it.
- **It must also name its own `discovery_url`.** Otherwise it inherits the deployment-wide key source and its single-entry cache, and two such providers share one slot.

Also from that pass: the bearer-provisioning gate now asks **the provider that validated the token** whether it pins an audience and issuer, instead of reading flat variables that no longer describe what was enforced — that read could both credit scoping that was never applied and deny provisioning to a registry-only deployment that pins both correctly. And duplicate issuers across entries are rejected rather than resolved by configuration order, which would silently apply the first entry's policy to the second's tokens.

The legacy synthesised provider is exempt from both new requirements: it is built from flat variables that may legitimately be unset, and it is the one provider that must keep working with no configuration change at all.

## Tests

`mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py` — 29 cases that only mean anything once there are two issuers: both validating independently, each refused at the other's audience, an unknown issuer refused with no fallback (including when signed by a configured provider's key), lookalike issuers refused, and rotation proven per-issuer. The #307 `TokenAdversarySuite` runs **twice**, once per provider, against a third unconfigured issuer — the acceptance criterion that a new provider inherits the cases rather than restating them.

## Known limitation, not addressed here

`exp` is still not required. authlib's expiry check is a no-op when the claim is absent, so a token minted without one is accepted indefinitely. That predates this change, and requiring it would break legacy Kubernetes service-account tokens, which have no `exp` — the right place to decide it is #314, where those token semantics are settled. Filing separately.

## Validation

```
pre-commit run --all-files                   # passed
pytest -m 'not integration' .../tests        # 3712 passed, 14 skipped
pytest mlflow_oidc_auth/tests/perf/          # 37 passed — T0 budget unchanged
```

Per-request auth query count is untouched: resolution is a base64 parse and a list scan, no I/O and no query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)