### PR TITLE
feat(auth): kubernetes service-account token provider (#314)

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,6 +2,7 @@
 - [Home](/)
 - [Installation](installation)
 - [Configuration](configuration)
+- [Kubernetes Service Accounts](kubernetes-auth)
 - [Configuration Providers](configuration-providers)
 - [Permissions](permissions)
 - [Workspaces](workspaces)

--- a/docs/kubernetes-auth.md
+++ b/docs/kubernetes-auth.md
@@ -51,7 +51,9 @@ interchangeable:
   for another application is otherwise a valid MLflow credential.
 - **`issuer`** — without it nothing checks `iss`, so any issuer whose keys you happen to trust is
   accepted.
-- **`namespace_allowlist`** — this is the whole authorization decision. A service-account token
+- **`namespace_allowlist`** — this is the whole authorization decision, and each entry must be a
+  real Kubernetes namespace (a DNS label). `Team-A` or `team_a` are refused at load rather than
+  accepted and silently never matched. A service-account token
   carries **no groups claim**, so the group gate that guards OIDC bearer provisioning cannot
   apply. An empty list means *nobody*, never everybody: otherwise every pod in the cluster that
   can read its own projected token becomes an MLflow user the moment you configure the provider.
@@ -143,6 +145,12 @@ A service account that authenticates from an allowlisted namespace is provisione
 
 Grant permissions to the `k8s:<namespace>` group and every service account in that namespace
 inherits them.
+
+Provisioning happens on first authentication and needs no extra flag:
+`OIDC_PROVISION_ON_BEARER_AUTH` gates provisioning from an *OIDC* token, where the alternative is
+trusting whatever groups an arbitrary token from the corporate IdP carries. Here the opt-in is
+already narrower and explicit — a provider you configured, and a namespace you named in its
+allowlist.
 
 Administrator rights are never conferred from a cluster token. There is no claim a cluster could
 assert that should make something an MLflow administrator, and `OIDC_TRUST_BEARER_GROUP_CLAIMS`

--- a/docs/kubernetes-auth.md
+++ b/docs/kubernetes-auth.md
@@ -1,0 +1,205 @@
+# Kubernetes service accounts
+
+Let a pod authenticate to MLflow with its projected service-account token, while human login
+stays on your OIDC provider. This is the automation half of multi-provider support: these tokens
+can never be provisioned by SCIM — your corporate directory does not know they exist — which is
+why the policy for them is per-provider rather than global.
+
+## What a pod presents
+
+A projected service-account token is an ordinary JWT signed by the cluster. Its `sub` is
+`system:serviceaccount:<namespace>:<name>`, and its `aud` is whatever the pod's volume
+projection asked for:
+
+```yaml
+volumes:
+  - name: mlflow-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            path: token
+            audience: mlflow-api        # must match the provider's audience
+            expirationSeconds: 3600
+```
+
+The pod reads `/var/run/secrets/.../mlflow-token/token` and sends it as
+`Authorization: Bearer <token>`.
+
+The username MLflow uses comes from `sub`, not from `OIDC_USERNAME_FIELD` — a service-account
+token carries no `email` or `preferred_username`, and making the global field list include `sub`
+to accommodate it would change how every other provider's tokens are named.
+
+## Configuring the provider
+
+```json
+{
+  "id": "cluster",
+  "type": "k8s",
+  "display_name": "Kubernetes",
+  "audience": "mlflow-api",
+  "issuer": "https://kubernetes.default.svc",
+  "namespace_allowlist": ["team-a", "team-b"],
+  "jwks_uri": "https://kubernetes.default.svc/openid/v1/jwks",
+  "in_cluster": true
+}
+```
+
+`audience`, `issuer` and `namespace_allowlist` are all required, and the reasons are not
+interchangeable:
+
+- **`audience`** — an unpinned audience accepts any pod's token for any service. A token minted
+  for another application is otherwise a valid MLflow credential.
+- **`issuer`** — without it nothing checks `iss`, so any issuer whose keys you happen to trust is
+  accepted.
+- **`namespace_allowlist`** — this is the whole authorization decision. A service-account token
+  carries **no groups claim**, so the group gate that guards OIDC bearer provisioning cannot
+  apply. An empty list means *nobody*, never everybody: otherwise every pod in the cluster that
+  can read its own projected token becomes an MLflow user the moment you configure the provider.
+
+  It is checked on **every request**, not only when the user record is created — so removing a
+  namespace from the list revokes access for service accounts that already authenticated, rather
+  than leaving them with the row and group they were given.
+
+## Getting the cluster's keys
+
+The usual failure here is not validation, it is *reachability*. `system:service-account-issuer-discovery`
+is not bound to `system:unauthenticated` on most clusters, and the API server is often not
+reachable from wherever MLflow runs. Three modes, in order of how often they are the answer:
+
+### 1. `jwks_uri` + `in_cluster` — MLflow runs in the cluster
+
+```json
+{"jwks_uri": "https://kubernetes.default.svc/openid/v1/jwks", "in_cluster": true}
+```
+
+The fetch authenticates with MLflow's own pod service-account token and verifies the API server
+against the mounted cluster CA. Grant the reader:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mlflow-issuer-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+  - kind: ServiceAccount
+    name: mlflow
+    namespace: mlflow
+```
+
+### 2. `jwks_inline` — the cluster is unreachable from MLflow
+
+Paste the key set into configuration. No network in the authentication path at all, which is the
+only thing that works when MLflow runs outside the cluster and the API server is not exposed:
+
+```bash
+kubectl get --raw /openid/v1/jwks
+```
+
+```json
+{"jwks_inline": "{\"keys\":[{\"kty\":\"RSA\",...}]}"}
+```
+
+The trade is that **you own key rotation**. When the cluster rotates its service-account signing
+key, this value must be updated or every pod stops authenticating. Prefer mode 1 or 3 if you can
+reach the cluster at all.
+
+### 3. `discovery_url` — public discovery
+
+For a managed cluster whose issuer is a public HTTPS endpoint (EKS, GKE and AKS all publish
+one), the ordinary OIDC path works:
+
+```json
+{"discovery_url": "https://oidc.eks.eu-west-1.amazonaws.com/id/EXAMPLE/.well-known/openid-configuration"}
+```
+
+Use `ca_bundle_path` with any mode when the endpoint presents a certificate from a private CA.
+It **pins** that authority rather than loosening anything: only that CA may sign, instead of
+every public root.
+
+`in_cluster` refuses to start a fetch when no CA bundle is available rather than falling back to
+the global `OIDC_VERIFY_SSL`: that flag is often set false to work around a private-CA IdP, and
+inheriting it here would mean fetching a cluster's signing keys, and presenting the pod's
+credential, over an unverified connection.
+
+The pod's credential is sent **only** to a `jwks_uri` you configured. It is deliberately not
+attached to the discovery path, where the follow-up request goes to whatever host the discovery
+document names — on managed clusters that is routinely a third-party bucket or CDN.
+
+## What gets created
+
+A service account that authenticates from an allowlisted namespace is provisioned as:
+
+| | |
+|---|---|
+| Username | `<name>.<namespace>@serviceaccount.cluster.local` |
+| Display name | `<namespace>/<name> (service account)` |
+| Group | `k8s:<namespace>` |
+| `is_service_account` | `true` |
+| `is_admin` | **always `false`** |
+
+Grant permissions to the `k8s:<namespace>` group and every service account in that namespace
+inherits them.
+
+Administrator rights are never conferred from a cluster token. There is no claim a cluster could
+assert that should make something an MLflow administrator, and `OIDC_TRUST_BEARER_GROUP_CLAIMS`
+deliberately does not reach this path — it opts into trusting a *directory's* group names, which
+is a different statement from trusting a namespace.
+
+A token from a namespace that is not on the allowlist is **refused** — the signature is valid,
+but the request does not authenticate — and the refusal is recorded as `auth.denied_namespace`.
+
+## Why not `TokenReview`
+
+The Kubernetes `TokenReview` API answers "is this token valid?" for a cluster that publishes no
+usable discovery document at all. It was evaluated and **deliberately not implemented**:
+
+- **It puts a network call in the authentication path.** Every authenticated request would become
+  a synchronous POST to the API server. The per-request auth budget this project holds itself to
+  (#305) is measured in database round trips precisely because that path is the one thing every
+  API call and every UI navigation pays for; adding an unbounded network hop to it is a much
+  larger regression than the query it took years to avoid.
+- **It moves MLflow's availability under the API server's.** JWKS validation is offline once the
+  keys are cached, so a control-plane restart or an upgrade does not interrupt authentication.
+  With `TokenReview` it does.
+- **It needs a permanent, powerful credential.** `system:auth-delegator` lets the holder submit
+  arbitrary tokens for review; JWKS needs only public keys.
+- **It buys little.** Every cluster that can run `TokenReview` also has service-account issuer
+  discovery available to a credential that is allowed to read it — the same credential
+  `TokenReview` would require. Mode 1 covers those clusters, and `jwks_inline` covers the rest.
+
+[opendatahub-io/mlflow-kubernetes-plugins](https://github.com/opendatahub-io/mlflow-kubernetes-plugins)
+solves the same problem and is worth reading if your cluster does not fit any of the three modes
+above; its approach is a separate plugin rather than a provider inside this one.
+
+If a deployment genuinely needs `TokenReview`, open an issue describing the cluster — it belongs
+behind an explicit opt-in with its own caching, not as a default path.
+
+## Verifying against a real cluster
+
+The automated tests mint tokens with a local key rather than a cluster, so this procedure is the
+end-to-end check. It needs a cluster and cannot run in CI:
+
+```bash
+kind create cluster --name mlflow-auth
+kubectl create namespace team-a
+kubectl create serviceaccount trainer -n team-a
+kubectl get --raw /openid/v1/jwks > /tmp/cluster-jwks.json
+kubectl get --raw /.well-known/openid-configuration | jq -r .issuer     # -> provider "issuer"
+
+# Mint a token with MLflow's audience, exactly as a projected volume would
+kubectl create token trainer -n team-a --audience mlflow-api --duration 1h
+```
+
+Configure the provider with `jwks_inline` set to the contents of `/tmp/cluster-jwks.json` and
+the issuer printed above, then:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" http://localhost:5000/oidc/api/whoami
+```
+
+Expect `trainer.team-a@serviceaccount.cluster.local`. Then repeat with a service account in a
+namespace that is not on the allowlist and confirm no user is created.

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import json
 import threading
 
@@ -161,7 +162,21 @@ def _get_provider_jwks(provider, force_refresh: bool = False) -> dict:
     # mode that works when the API server is unreachable from wherever MLflow runs, and the only
     # one with no network in the authentication path at all.
     if getattr(provider, "jwks_inline", None):
-        return load_inline_jwks(provider.jwks_inline)
+        # Parsed once and kept, rather than re-read on every request. It is immutable
+        # configuration, and this is the mode whose whole point is that it does no work in the
+        # authentication path.
+        # Keyed on the material as well as the id: two key sets configured under one provider id
+        # — a rotation, or a second deployment reusing the id — must not serve each other's keys.
+        cache_key = (provider.id, "jwks_inline", hashlib.sha256(str(provider.jwks_inline).encode()).hexdigest())
+        with _provider_jwks_lock:
+            cached = _provider_jwks_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        parsed = load_inline_jwks(provider.jwks_inline)
+        with _provider_jwks_lock:
+            _provider_jwks_cache[cache_key] = parsed
+        return parsed
 
     # A known key-set URL, for a cluster whose discovery document is not anonymously readable —
     # the common case, since system:service-account-issuer-discovery is rarely bound to

--- a/mlflow_oidc_auth/auth.py
+++ b/mlflow_oidc_auth/auth.py
@@ -7,7 +7,10 @@ from authlib.jose import JsonWebToken
 from authlib.jose.errors import BadSignatureError
 from cachetools import TTLCache
 
+from typing import Optional
+
 from mlflow_oidc_auth.config import config
+from mlflow_oidc_auth.kubernetes import in_cluster_credentials, load_inline_jwks
 from mlflow_oidc_auth.logger import get_logger
 
 # TOKEN_PROVIDER_TYPES is imported rather than restated: the registry uses it to decide which
@@ -78,7 +81,18 @@ def _get_oidc_jwks(force_refresh: bool = False) -> dict:
     )
 
 
-def _load_jwks(discovery_url: str, *, cache: TTLCache, lock: threading.Lock, cache_key, force_refresh: bool, label: str) -> dict:
+def _load_jwks(
+    url: str,
+    *,
+    cache: TTLCache,
+    lock: threading.Lock,
+    cache_key,
+    force_refresh: bool,
+    label: str,
+    direct: bool = False,
+    verify=None,
+    auth_token: Optional[str] = None,
+) -> dict:
     """Discovery-then-JWKS fetch, cached in ``cache`` under ``cache_key``.
 
     One implementation for both callers on purpose. They differ only in which cache the result
@@ -97,15 +111,27 @@ def _load_jwks(discovery_url: str, *, cache: TTLCache, lock: threading.Lock, cac
     # essential: without them a hung IdP holds request threads until the OS-level TCP timeout
     # (~2 minutes), and authentication failures cascade.
     timeout = config.OIDC_HTTP_TIMEOUT_SECONDS
+    if verify is None:
+        verify = config.OIDC_VERIFY_SSL
+    # Only sent when there is one: the API server needs the pod's credential, a public IdP must
+    # never be handed it, and the ordinary call keeps its exact shape.
+    extra = {"headers": {"Authorization": f"Bearer {auth_token}"}} if auth_token else {}
     try:
-        logger.debug("Fetching OIDC discovery metadata for %s", label)
-        metadata = requests.get(discovery_url, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
-        jwks_uri = metadata.get("jwks_uri")
-        if not jwks_uri:
-            raise ValueError(f"No jwks_uri found in OIDC discovery metadata for {label}")
+        if direct:
+            # ``url`` is already the key set — a cluster that does not serve discovery anonymously
+            # but whose JWKS endpoint is known (#314).
+            jwks_uri = url
+        else:
+            logger.debug("Fetching OIDC discovery metadata for %s", label)
+            metadata = requests.get(url, timeout=timeout, verify=verify, allow_redirects=False, **extra).json()
+            jwks_uri = metadata.get("jwks_uri")
+            if not jwks_uri:
+                raise ValueError(f"No jwks_uri found in OIDC discovery metadata for {label}")
 
         logger.debug("Fetching JWKS from %s", jwks_uri)
-        jwks = requests.get(jwks_uri, timeout=timeout, verify=config.OIDC_VERIFY_SSL).json()
+        # Redirects are not followed on either fetch: this decides which signatures are valid,
+        # so a 302 must be a visible configuration error rather than a silent change of source.
+        jwks = requests.get(jwks_uri, timeout=timeout, verify=verify, allow_redirects=False, **extra).json()
     except requests.exceptions.RequestException as e:
         logger.error("Failed to fetch JWKS for %s: %s", label, e)
         raise
@@ -131,6 +157,31 @@ def _get_provider_jwks(provider, force_refresh: bool = False) -> dict:
     Returns:
         The JWKS payload.
     """
+    # A cluster's keys may be written into configuration rather than fetched (#314): the only
+    # mode that works when the API server is unreachable from wherever MLflow runs, and the only
+    # one with no network in the authentication path at all.
+    if getattr(provider, "jwks_inline", None):
+        return load_inline_jwks(provider.jwks_inline)
+
+    # A known key-set URL, for a cluster whose discovery document is not anonymously readable —
+    # the common case, since system:service-account-issuer-discovery is rarely bound to
+    # system:unauthenticated.
+    if getattr(provider, "jwks_uri", None):
+        return _load_jwks(
+            provider.jwks_uri,
+            cache=_provider_jwks_cache,
+            lock=_provider_jwks_lock,
+            cache_key=(provider.id, provider.jwks_uri),
+            force_refresh=force_refresh,
+            label=f"provider {provider.id}",
+            direct=True,
+            verify=_verify_for(provider),
+            # The only path that presents the pod's own credential: this URL comes from the
+            # operator's configuration. It is deliberately not sent on the discovery path, where
+            # the second request goes to whatever host the discovery *body* names.
+            auth_token=_in_cluster_token(provider),
+        )
+
     if not provider.discovery_url:
         # A provider that names no source of its own inherits the deployment-wide one. Only the
         # synthesised legacy provider can be in this state, and only when OIDC_DISCOVERY_URL is
@@ -146,7 +197,51 @@ def _get_provider_jwks(provider, force_refresh: bool = False) -> dict:
         cache_key=(provider.id, provider.discovery_url),
         force_refresh=force_refresh,
         label=f"provider {provider.id}",
+        verify=_verify_for(provider),
     )
+
+
+def _verify_for(provider):
+    """TLS verification for this provider's key fetch.
+
+    A cluster's API server presents a certificate signed by the cluster CA, which no public trust
+    store knows, so a CA bundle is a *stricter* setting than the default rather than a looser one
+    — it names the single authority allowed to sign, instead of every public root.
+    """
+    ca_bundle = getattr(provider, "ca_bundle_path", None)
+    if ca_bundle:
+        return ca_bundle
+    if getattr(provider, "in_cluster", False):
+        _, ca = in_cluster_credentials()
+        if ca:
+            return ca
+        # Never fall through to the global flag here. OIDC_VERIFY_SSL is commonly set False to
+        # work around a private-CA IdP, and inheriting it would mean fetching a cluster's signing
+        # keys — and presenting the pod's credential — over an unverified connection. Whoever can
+        # answer for the API server's address would then choose which tokens are valid.
+        raise ValueError(
+            f"Provider '{provider.id}' fetches keys in-cluster but no CA bundle is available: mount "
+            "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt or set 'ca_bundle_path'"
+        )
+    return config.OIDC_VERIFY_SSL
+
+
+def _in_cluster_token(provider):
+    """The pod's own service-account token, when this provider fetches from the API server.
+
+    Kubernetes does not serve ``/openid/v1/jwks`` anonymously on most clusters, so the fetch has
+    to authenticate as something — and the pod already holds a credential for exactly this.
+    """
+    if not getattr(provider, "in_cluster", False):
+        return None
+    token, _ = in_cluster_credentials()
+    if token is None:
+        logger.warning(
+            "Provider '%s' is configured with in_cluster key fetching, but no service-account token is mounted; "
+            "MLflow does not appear to be running in a cluster",
+            provider.id,
+        )
+    return token
 
 
 def _unverified_issuer(token: str) -> str | None:

--- a/mlflow_oidc_auth/kubernetes.py
+++ b/mlflow_oidc_auth/kubernetes.py
@@ -1,0 +1,180 @@
+"""Kubernetes service-account tokens as a bearer credential (issue #314).
+
+A pod holds a projected service-account token: an ordinary OIDC-shaped JWT, signed by the
+cluster, whose ``sub`` is ``system:serviceaccount:<namespace>:<name>``. Validating one is the
+same work as validating any other token — #313 already routes by issuer and enforces the
+provider's keys, algorithms, issuer and audience — so what is left is everything *around* that:
+
+**Where the keys come from.** A cluster's JWKS is often not reachable the way a public IdP's is.
+``system:service-account-issuer-discovery`` is not bound to ``system:unauthenticated`` on most
+clusters, and the API server is frequently unreachable from wherever MLflow runs. Three modes,
+because in practice deployments need all three:
+
+* ``discovery`` — the public case, an anonymously readable ``/.well-known/openid-configuration``.
+* ``inline`` — the operator pastes the JWKS into configuration. No network at all, which is also
+  the only mode that works when the cluster is unreachable from the tracking server.
+* ``in_cluster`` — fetch from the API server using the pod's own credentials and CA bundle.
+
+**Who the token says it is.** ``sub`` is parsed rather than used verbatim: a username of
+``system:serviceaccount:team-a:trainer`` is unusable in a UI and collides with nothing, so a
+template turns it into something an operator can read and grant permissions to.
+
+**Whether it may be provisioned.** A service-account token carries no groups claim, so the group
+gate that guards OIDC bearer provisioning cannot apply. A namespace allowlist takes its place —
+without one, *every* pod in the cluster that can read a projected token becomes an MLflow user.
+
+The ``TokenReview`` alternative is evaluated in ``docs/kubernetes-auth.md`` and deliberately not
+implemented; the short version is that it turns every authenticated request into a synchronous
+call to the API server.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+#: ``sub`` of a projected service-account token.
+SERVICE_ACCOUNT_SUBJECT = re.compile(r"^system:serviceaccount:(?P<namespace>[^:]+):(?P<name>[^:]+)$")
+
+#: Kubernetes object names are DNS labels, and namespaces likewise. Anchored and bounded so a
+#: crafted ``sub`` cannot smuggle punctuation into a username, a group name or a template.
+DNS_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+MAX_LABEL_LENGTH = 63
+
+#: Username shape. Fixed rather than configurable, and separated by ``.`` rather than ``-``.
+#:
+#: ``-`` is legal *inside* a DNS label, so ``{namespace}-{name}`` is ambiguous: namespace
+#: ``prod-etl`` with account ``writer`` and namespace ``prod`` with account ``etl-writer`` both
+#: render ``prod-etl-writer``. Anyone who can create a service account in one allowlisted
+#: namespace could then collide with an account in another and inherit its permissions. ``.``
+#: cannot appear in a label, so the two halves stay distinguishable.
+USERNAME_TEMPLATE = "{name}.{namespace}@serviceaccount.cluster.local"
+
+#: Group. Namespace-derived, so permissions can be granted to a whole team's namespace
+#: rather than to each service account in it.
+GROUP_TEMPLATE = "k8s:{namespace}"
+
+#: Where a pod finds its own credentials and the API server's CA.
+IN_CLUSTER_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+IN_CLUSTER_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+
+class ServiceAccountError(Exception):
+    """A token that is not a usable Kubernetes service-account credential."""
+
+
+@dataclass(frozen=True)
+class ServiceAccount:
+    """The identity a projected token asserts.
+
+    Attributes:
+        namespace: Kubernetes namespace the service account lives in.
+        name: Service account name.
+    """
+
+    namespace: str
+    name: str
+
+    @property
+    def username(self) -> str:
+        """The MLflow username for this service account."""
+        return USERNAME_TEMPLATE.format(namespace=self.namespace, name=self.name)
+
+    @property
+    def group(self) -> str:
+        """The group standing for this service account's namespace."""
+        return GROUP_TEMPLATE.format(namespace=self.namespace)
+
+
+def _valid_label(value: str) -> bool:
+    return bool(value) and len(value) <= MAX_LABEL_LENGTH and bool(DNS_LABEL.match(value))
+
+
+def parse_service_account(subject: Any) -> ServiceAccount:
+    """Parse ``sub`` into a namespace and a service-account name.
+
+    Both halves are validated as DNS labels rather than accepted as written. The claim is signed,
+    so a cluster cannot be tricked into asserting a malformed ``sub`` — but a *compromised or
+    hostile* cluster that a deployment has (perhaps unwisely) configured as a provider could,
+    and the value goes on to become a username and a group name. Anything outside the character
+    set Kubernetes itself allows is refused here rather than rendered into an identifier.
+
+    Parameters:
+        subject: The token's ``sub`` claim.
+
+    Returns:
+        The parsed :class:`ServiceAccount`.
+
+    Raises:
+        ServiceAccountError: If ``sub`` is not a well-formed service-account subject.
+    """
+    if not isinstance(subject, str):
+        raise ServiceAccountError(f"service-account subject must be a string, got {type(subject).__name__}")
+
+    match = SERVICE_ACCOUNT_SUBJECT.match(subject)
+    if not match:
+        raise ServiceAccountError("token subject is not 'system:serviceaccount:<namespace>:<name>'")
+
+    namespace, name = match.group("namespace"), match.group("name")
+    if not _valid_label(namespace) or not _valid_label(name):
+        raise ServiceAccountError("service-account namespace and name must be DNS labels")
+
+    return ServiceAccount(namespace=namespace, name=name)
+
+
+def namespace_is_allowed(namespace: str, allowlist: Tuple[str, ...]) -> bool:
+    """Whether ``namespace`` may be provisioned.
+
+    An empty allowlist means **no**, never "all". A service-account token carries no group claim,
+    so nothing else narrows who may become a user: with an empty list treated as permissive,
+    every pod in the cluster that can read its own projected token would become an MLflow user
+    the moment the provider was configured.
+    """
+    return namespace in allowlist
+
+
+def load_inline_jwks(raw: Any) -> Dict[str, Any]:
+    """Validate an operator-supplied JWKS, given as a mapping or a JSON string.
+
+    Raises:
+        ValueError: If it is not a JWKS-shaped object with a non-empty ``keys`` list.
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"inline JWKS is not valid JSON: {exc}") from exc
+
+    if not isinstance(raw, dict) or not isinstance(raw.get("keys"), list) or not raw["keys"]:
+        raise ValueError("inline JWKS must be an object with a non-empty 'keys' list")
+
+    return raw
+
+
+def in_cluster_credentials(token_path: str = IN_CLUSTER_TOKEN_PATH, ca_path: str = IN_CLUSTER_CA_PATH) -> Tuple[Optional[str], Optional[str]]:
+    """The pod's own service-account token and the API server's CA bundle.
+
+    Returns ``(None, None)`` when they are not present, which is the ordinary case when MLflow
+    runs outside the cluster — the caller then reports a configuration problem rather than
+    failing with a file-not-found from deep inside an HTTP call.
+    """
+    try:
+        with open(token_path, "r", encoding="utf-8") as handle:
+            token = handle.read().strip()
+    except OSError:
+        return None, None
+
+    ca = ca_path if _readable(ca_path) else None
+    return (token or None), ca
+
+
+def _readable(path: str) -> bool:
+    try:
+        with open(path, "rb"):
+            return True
+    except OSError:
+        return False

--- a/mlflow_oidc_auth/kubernetes.py
+++ b/mlflow_oidc_auth/kubernetes.py
@@ -90,8 +90,14 @@ class ServiceAccount:
         return GROUP_TEMPLATE.format(namespace=self.namespace)
 
 
-def _valid_label(value: str) -> bool:
-    return bool(value) and len(value) <= MAX_LABEL_LENGTH and bool(DNS_LABEL.match(value))
+def valid_dns_label(value: Any) -> bool:
+    """Whether ``value`` is a Kubernetes object name.
+
+    Shared with the registry deliberately: an allowlist entry is compared against a namespace
+    that came through :func:`parse_service_account`, so the two must agree on what a namespace
+    can look like or an entry silently never matches.
+    """
+    return isinstance(value, str) and bool(value) and len(value) <= MAX_LABEL_LENGTH and bool(DNS_LABEL.match(value))
 
 
 def parse_service_account(subject: Any) -> ServiceAccount:
@@ -120,7 +126,7 @@ def parse_service_account(subject: Any) -> ServiceAccount:
         raise ServiceAccountError("token subject is not 'system:serviceaccount:<namespace>:<name>'")
 
     namespace, name = match.group("namespace"), match.group("name")
-    if not _valid_label(namespace) or not _valid_label(name):
+    if not valid_dns_label(namespace) or not valid_dns_label(name):
         raise ServiceAccountError("service-account namespace and name must be DNS labels")
 
     return ServiceAccount(namespace=namespace, name=name)

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -208,10 +208,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
             return
 
-        # A Kubernetes service account is not a person and has no groups claim, so the gate
-        # below cannot apply to it (#314). Its own policy is the namespace allowlist.
+        # A Kubernetes service account never reaches here: _authenticate_bearer_token sends it
+        # to _authenticate_service_account instead, which applies its own policy (#314). Guarded
+        # rather than assumed, because the two resolve the provider independently.
         if provider.type == "k8s":
-            self._provision_service_account(username, payload, provider)
+            logger.debug("Not provisioning %s here; a service account is handled on its own path", username)
             return
 
         # Derive groups from the token, mirroring the login flow's group resolution.
@@ -316,9 +317,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
         deliberately does not reach this path: it opts into trusting a *directory's* group names,
         which is a different statement from trusting a namespace.
         """
-        if not config.OIDC_PROVISION_ON_BEARER_AUTH:
-            return
-
+        # ``OIDC_PROVISION_ON_BEARER_AUTH`` is deliberately *not* consulted. That flag is the
+        # opt-in for provisioning from an OIDC token, where the alternative is trusting whatever
+        # groups an arbitrary token from the corporate IdP carries. Here the opt-in already
+        # exists and is narrower: a provider the operator configured, and a namespace they named
+        # in its allowlist. Requiring a second, OIDC-named flag as well would mean the documented
+        # setup returns 401 for a valid token with nothing pointing at why.
         username = account.username
         try:
             if store.has_user(username):

--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -208,6 +208,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             )
             return
 
+        # A Kubernetes service account is not a person and has no groups claim, so the gate
+        # below cannot apply to it (#314). Its own policy is the namespace allowlist.
+        if provider.type == "k8s":
+            self._provision_service_account(username, payload, provider)
+            return
+
         # Derive groups from the token, mirroring the login flow's group resolution.
         try:
             if config.OIDC_GROUP_DETECTION_PLUGIN:
@@ -247,6 +253,100 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # A concurrent first request may have inserted the row (unique constraint) — benign.
             logger.warning("Bearer provisioning of %s did not complete (may already exist): %s", username, type(e).__name__)
 
+    @staticmethod
+    def _provider_for(token: str):
+        """The provider that validated ``token``, or None if it cannot be identified."""
+        try:
+            from mlflow_oidc_auth.auth import resolve_token_provider
+
+            return resolve_token_provider(token)
+        except Exception as e:
+            logger.debug("Could not identify the provider for a bearer token: %s", type(e).__name__)
+            return None
+
+    def _authenticate_service_account(self, token: str, payload, provider) -> Tuple[bool, Optional[str], str]:
+        """Authenticate a Kubernetes service account (#314).
+
+        The namespace allowlist is checked **here, on every request**, not only when the user
+        record is created. Checking it at provisioning alone would mean removing a namespace from
+        the list revoked nothing: every service account that had authenticated once would keep
+        its user row, its group and its permissions, while kubelet went on renewing its token. It
+        is a tuple membership test against configuration already in memory, so enforcing it per
+        request costs no query and no round trip.
+        """
+        from mlflow_oidc_auth.kubernetes import ServiceAccountError, namespace_is_allowed, parse_service_account
+
+        try:
+            account = parse_service_account(payload.get("sub"))
+        except ServiceAccountError as e:
+            logger.warning("Rejecting a token from provider '%s': %s", provider.id, e)
+            return False, None, "Invalid service account token"
+
+        if not namespace_is_allowed(account.namespace, provider.namespace_allowlist):
+            logger.info(
+                "Service account %s/%s presented a valid token, but its namespace is not in provider '%s' namespace_allowlist",
+                account.namespace,
+                account.name,
+                provider.id,
+            )
+            if _should_audit_denial(account.username, "namespace_not_allowed"):
+                emit_audit_event(
+                    "auth.denied_namespace",
+                    actor=account.username,
+                    resource_type="user",
+                    resource_id=account.username,
+                    detail={"provider": provider.id, "namespace": account.namespace},
+                    status="denied",
+                )
+            return False, None, "Service account namespace is not allowed"
+
+        self._provision_service_account(account, provider)
+        logger.debug("Service account %s authenticated via bearer token", account.username)
+        return True, account.username, ""
+
+    def _provision_service_account(self, account, provider) -> None:
+        """Create the user record for a Kubernetes service account (#314).
+
+        Called only after :meth:`_authenticate_service_account` has allowed the namespace, so
+        this is the record-keeping half: the authorization decision lives on the request path,
+        where it is re-made every time rather than frozen into a row.
+
+        The account is always non-admin. There is no claim a cluster could assert that should
+        confer administrator rights on an MLflow deployment, and ``OIDC_TRUST_BEARER_GROUP_CLAIMS``
+        deliberately does not reach this path: it opts into trusting a *directory's* group names,
+        which is a different statement from trusting a namespace.
+        """
+        if not config.OIDC_PROVISION_ON_BEARER_AUTH:
+            return
+
+        username = account.username
+        try:
+            if store.has_user(username):
+                return
+        except Exception as e:
+            logger.warning("Provisioning skipped; has_user check failed for %s: %s", username, type(e).__name__)
+            return
+
+        group = account.group
+        display_name = f"{account.namespace}/{account.name} (service account)"
+        try:
+            import mlflow_oidc_auth.user as user_module
+
+            user_module.create_user(username=username, display_name=display_name, is_admin=False, is_service_account=True)
+            user_module.populate_groups(group_names=[group])
+            user_module.update_user(username=username, group_names=[group])
+            logger.info("Provisioned service account %s from namespace %s", username, account.namespace)
+            emit_audit_event(
+                "user.provisioned",
+                actor=username,
+                resource_type="user",
+                resource_id=username,
+                detail={"provider": provider.id, "namespace": account.namespace, "service_account": account.name, "is_service_account": True},
+            )
+        except Exception as e:
+            # A concurrent first request may have inserted the row — benign.
+            logger.warning("Provisioning of service account %s did not complete (may already exist): %s", username, type(e).__name__)
+
     async def _authenticate_bearer_token(self, auth_header: str) -> Tuple[bool, Optional[str], str]:
         """
         Authenticate using bearer token.
@@ -261,6 +361,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
             token = auth_header.split(" ", 1)[1]
             # Validate token and extract user info
             payload = validate_token(token)
+
+            provider = self._provider_for(token)
+
+            if provider is not None and provider.type == "k8s":
+                # A service-account token names itself in ``sub`` and carries no email or
+                # preferred_username, so the OIDC username fields do not apply to it (#314). The
+                # identity is derived here rather than from OIDC_USERNAME_FIELD: a global field
+                # list that had to include ``sub`` to make this work would also change how every
+                # other provider's tokens are named.
+                return self._authenticate_service_account(token, payload, provider)
 
             # Extract username from configured fields. extract_username guarantees a
             # non-empty, normalized username whenever it returns no error.

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -32,7 +32,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from mlflow_oidc_auth.kubernetes import load_inline_jwks
+from mlflow_oidc_auth.kubernetes import load_inline_jwks, valid_dns_label
 from mlflow_oidc_auth.logger import get_logger
 
 logger = get_logger()
@@ -516,11 +516,23 @@ def _validate_kubernetes(entry: Dict[str, Any], label: str) -> List[str]:
         except ValueError as exc:
             errors.append(f"{label}: {exc}")
 
-    if not _as_tuple(entry.get("namespace_allowlist")):
+    allowlist = _as_tuple(entry.get("namespace_allowlist"))
+    if not allowlist:
         errors.append(
             f"{label}: 'namespace_allowlist' is required for a 'k8s' provider; a service-account token carries no group "
             "claim, so without it every pod in the cluster that can read its own token becomes a user"
         )
+
+    # An entry no namespace could ever equal is worse than a rejected one: it passes validation
+    # and then silently denies every pod in the namespace the operator meant to allow. Kubernetes
+    # namespaces are DNS labels, so anything else — 'Team-A', 'team_a', a whole
+    # 'system:serviceaccount:...' subject — can only ever fail to match.
+    for namespace in allowlist:
+        if not valid_dns_label(namespace):
+            errors.append(
+                f"{label}: namespace_allowlist entry {namespace!r} is not a Kubernetes namespace (a DNS label: lowercase "
+                "alphanumerics and '-', up to 63 characters), so it can never match a real token"
+            )
 
     return errors
 

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -32,6 +32,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
+from mlflow_oidc_auth.kubernetes import load_inline_jwks
 from mlflow_oidc_auth.logger import get_logger
 
 logger = get_logger()
@@ -54,6 +55,11 @@ GROUP_SYNC_STRATEGIES = ("additive", "authoritative")
 # Provider types whose credentials are bearer tokens verified against a JWKS. They carry the
 # extra requirements in _validate: an issuer to pin, and a key source of their own.
 TOKEN_PROVIDER_TYPES = ("oidc", "k8s")
+
+# Fields that only a Kubernetes provider may carry. They decide where signing keys come from and
+# what credential is presented to fetch them, so on any other type they are refused rather than
+# ignored (#314).
+KUBERNETES_ONLY_FIELDS = ("jwks_inline", "jwks_uri", "in_cluster", "ca_bundle_path", "namespace_allowlist")
 
 # "scim" is deliberately absent — see _validate_admin_source.
 ADMIN_SOURCES = ("claims", "none")
@@ -125,6 +131,14 @@ class ProviderConfig:
         issuer: Expected ``iss``, when known.
         discovery_url: OIDC discovery document, for ``oidc`` providers.
         client_id: OAuth client id, for ``oidc`` providers.
+        jwks_inline: Key set written into configuration, for a cluster whose JWKS cannot be
+            fetched. The only mode that needs no network at all.
+        jwks_uri: Key set URL, when it is known and discovery is not readable.
+        ca_bundle_path: CA bundle for fetching from the cluster's API server.
+        in_cluster: Fetch keys from the API server using the pod's own service-account token.
+        namespace_allowlist: Namespaces whose service accounts may be provisioned. Empty means
+            none — a service-account token carries no group claim, so nothing else narrows who
+            may become a user.
     """
 
     id: str
@@ -142,6 +156,14 @@ class ProviderConfig:
     issuer: Optional[str] = None
     discovery_url: Optional[str] = None
     client_id: Optional[str] = None
+    # Kubernetes service-account providers (#314). A cluster's JWKS is often not anonymously
+    # readable and often unreachable from wherever MLflow runs, so the keys can come from
+    # discovery, from configuration, or from the API server using the pod's own credentials.
+    jwks_inline: Optional[str] = None
+    jwks_uri: Optional[str] = None
+    ca_bundle_path: Optional[str] = None
+    in_cluster: bool = False
+    namespace_allowlist: Tuple[str, ...] = ()
 
     def has_own_key_source(self) -> bool:
         """Whether this entry names its own JWKS source rather than inheriting the flat one.
@@ -304,6 +326,17 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
         # than through a public discovery document, and legacy service-account tokens have no
         # discovery document at all. #314 is where that provider learns how it sources keys, and
         # it can state its own rule then — no k8s provider can be configured before it lands.
+        if provider_type == "k8s":
+            errors.extend(_validate_kubernetes(entry, label))
+        else:
+            # These four change how keys are fetched, and _get_provider_jwks consults them before
+            # discovery_url. On an OIDC entry a pasted 'jwks_inline' would silently pin the keys
+            # forever — a revoked signing key would keep verifying tokens — and 'in_cluster' would
+            # send the pod's Kubernetes credential to a public IdP's endpoints.
+            for field in KUBERNETES_ONLY_FIELDS:
+                if entry.get(field):
+                    errors.append(f"{label}: '{field}' applies only to a 'k8s' provider, not to '{provider_type}'")
+
         if provider_type == "oidc" and (not isinstance(discovery_url, str) or not discovery_url.strip()):
             errors.append(
                 f"{label}: 'discovery_url' is required for an 'oidc' provider; without it the provider shares the "
@@ -330,6 +363,13 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             allowed_email_domains=allowed_email_domains,
             allowed_algorithms=allowed_algorithms,
             audience=audience.strip(),
+            jwks_inline=entry.get("jwks_inline") if isinstance(entry.get("jwks_inline"), (str, dict)) else None,
+            jwks_uri=entry.get("jwks_uri").strip() if isinstance(entry.get("jwks_uri"), str) and entry.get("jwks_uri").strip() else None,
+            ca_bundle_path=(
+                entry.get("ca_bundle_path").strip() if isinstance(entry.get("ca_bundle_path"), str) and entry.get("ca_bundle_path").strip() else None
+            ),
+            in_cluster=bool(entry.get("in_cluster", False)),
+            namespace_allowlist=_as_tuple(entry.get("namespace_allowlist")),
             issuer=issuer.strip() if isinstance(issuer, str) else None,
             discovery_url=discovery_url.strip() if isinstance(discovery_url, str) else None,
             client_id=client_id.strip() if isinstance(client_id, str) else None,
@@ -442,6 +482,47 @@ def _validate_algorithms(value: Any, label: str) -> Tuple[Tuple[str, ...], List[
     if errors:
         return DEFAULT_ALGORITHMS, errors
     return tuple(algorithms), []
+
+
+def _validate_kubernetes(entry: Dict[str, Any], label: str) -> List[str]:
+    """Checks that only apply to a Kubernetes service-account provider (#314).
+
+    Two, both of which are the difference between a usable provider and an open door:
+
+    * **Some key source.** Unlike an OIDC provider, a cluster's discovery document is usually not
+      anonymously readable, so ``discovery_url`` alone is not assumed — but *something* has to
+      say where the keys come from, or the provider can never verify a signature.
+    * **A namespace allowlist.** Service-account tokens carry no groups claim, so the group gate
+      that guards OIDC bearer provisioning cannot apply to them. Without an allowlist every pod
+      in the cluster that can read its own projected token becomes an MLflow user.
+    """
+    errors: List[str] = []
+
+    sources = [
+        bool(entry.get("discovery_url")),
+        bool(entry.get("jwks_inline")),
+        bool(entry.get("jwks_uri")),
+        bool(entry.get("in_cluster")),
+    ]
+    if not any(sources):
+        errors.append(
+            f"{label}: a 'k8s' provider needs a key source — one of 'discovery_url', 'jwks_uri', 'jwks_inline' or "
+            "'in_cluster' — because a cluster's discovery document is usually not readable anonymously"
+        )
+
+    if entry.get("jwks_inline"):
+        try:
+            load_inline_jwks(entry["jwks_inline"])
+        except ValueError as exc:
+            errors.append(f"{label}: {exc}")
+
+    if not _as_tuple(entry.get("namespace_allowlist")):
+        errors.append(
+            f"{label}: 'namespace_allowlist' is required for a 'k8s' provider; a service-account token carries no group "
+            "claim, so without it every pod in the cluster that can read its own token becomes a user"
+        )
+
+    return errors
 
 
 def _validate_admin_source(admin_source: Any, label: str) -> List[str]:

--- a/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
+++ b/mlflow_oidc_auth/tests/adversarial/test_multi_issuer.py
@@ -11,6 +11,8 @@ The suite in ``suite.py`` runs twice here, once per provider, which is the accep
 that a new provider inherits the cases rather than restating them.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 import mlflow_oidc_auth.auth as auth_module
@@ -163,7 +165,7 @@ class TestKeyRotationIsPerIssuer:
         auth_module._provider_jwks_cache.clear()
         fetched = []
 
-        def fake_get(url, timeout=None, verify=None):
+        def fake_get(url, timeout=None, verify=None, **kwargs):
             fetched.append(url)
 
             class Response:
@@ -291,7 +293,7 @@ class TestTheSingleProviderDeploymentFetchesKeysTheSameWay:
 
         fetched = []
 
-        def fake_get(url, timeout=None, verify=None):
+        def fake_get(url, timeout=None, verify=None, **kwargs):
             fetched.append(url)
 
             class Response:
@@ -307,3 +309,110 @@ class TestTheSingleProviderDeploymentFetchesKeysTheSameWay:
         auth_module._get_provider_jwks(entra_provider, force_refresh=True)
 
         assert auth_module._provider_jwks_cache.get(("k8s", "https://k8s.invalid/.well-known/openid-configuration")) == kubernetes.jwks
+
+
+class TestAClusterProviderValidatesLikeAnyOther:
+    """#314's cluster provider inherits #313's routing, so what needs proving here is that its
+    *keys* reach the decoder in each reachability mode, and that a cluster token cannot be spent
+    at the human-login provider's audience."""
+
+    @pytest.fixture
+    def cluster(self):
+        return Issuer(name="cluster", iss="https://kubernetes.default.svc", audience="mlflow-api")
+
+    @pytest.fixture
+    def with_inline_keys(self, cluster, entra, monkeypatch):
+        """The mode with no network at all: the cluster's JWKS written into configuration."""
+        import json as _json
+
+        registry = registry_of(
+            provider_for(entra, provider_id="entra"),
+            provider_for(cluster, provider_id="cluster", type="k8s", interactive=False, jwks_inline=_json.dumps(cluster.jwks)),
+        )
+        monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry)
+        monkeypatch.setattr(auth_module, "_get_oidc_jwks", lambda force_refresh=False: entra.jwks)
+        monkeypatch.setattr(
+            auth_module.requests,
+            "get",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("inline keys must not be fetched")),
+        )
+        return auth_module.validate_token
+
+    def test_a_cluster_token_validates_from_inline_keys(self, with_inline_keys, cluster):
+        assert with_inline_keys(cluster.mint(sub="system:serviceaccount:team-a:trainer"))["iss"] == cluster.iss
+
+    def test_no_request_is_made_for_inline_keys(self, with_inline_keys, cluster):
+        """The point of the mode: it works when the API server is unreachable from here."""
+        with_inline_keys(cluster.mint())
+
+    def test_a_cluster_token_is_refused_at_the_human_providers_audience(self, with_inline_keys, cluster, entra):
+        """The acceptance criterion. A pod's token must not be spendable as a person."""
+        with pytest.raises(Exception):
+            with_inline_keys(cluster.mint(aud=entra.audience))
+
+    def test_a_human_token_is_refused_at_the_clusters_audience(self, with_inline_keys, cluster, entra):
+        with pytest.raises(Exception):
+            with_inline_keys(entra.mint(aud=cluster.audience))
+
+    def test_the_clusters_keys_do_not_verify_the_human_providers_tokens(self, with_inline_keys, cluster, entra):
+        with pytest.raises(Exception):
+            with_inline_keys(cluster.mint(iss=entra.iss, aud=entra.audience))
+
+    def test_a_known_jwks_uri_is_fetched_directly(self, cluster, entra, monkeypatch):
+        """The common cluster case: discovery is not anonymously readable, but the key-set URL
+        is known. It must be fetched as the key set, not treated as a discovery document."""
+        registry = registry_of(
+            provider_for(entra, provider_id="entra"),
+            provider_for(cluster, provider_id="cluster", type="k8s", interactive=False, jwks_uri="https://api.cluster.invalid/openid/v1/jwks"),
+        )
+        monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry)
+        auth_module._provider_jwks_cache.clear()
+        fetched = []
+
+        def fake_get(url, timeout=None, verify=None, **kwargs):
+            fetched.append(url)
+            return SimpleNamespace(json=lambda: cluster.jwks)
+
+        monkeypatch.setattr(auth_module.requests, "get", fake_get)
+
+        assert auth_module.validate_token(cluster.mint())["iss"] == cluster.iss
+        assert fetched == ["https://api.cluster.invalid/openid/v1/jwks"], "the key-set URL must not be treated as a discovery document"
+
+    def test_in_cluster_fetching_presents_the_pods_own_credential(self, cluster, entra, monkeypatch, tmp_path):
+        """The API server does not serve /openid/v1/jwks anonymously on most clusters, so the
+        fetch has to authenticate — as the pod, using the credential it already holds."""
+        token_file = tmp_path / "token"
+        token_file.write_text("pod-service-account-token")
+        ca_file = tmp_path / "ca.crt"
+        ca_file.write_text("--- CA ---")
+
+        monkeypatch.setattr(
+            auth_module,
+            "in_cluster_credentials",
+            lambda *a, **k: ("pod-service-account-token", str(ca_file)),
+        )
+        registry = registry_of(
+            provider_for(entra, provider_id="entra"),
+            provider_for(
+                cluster,
+                provider_id="cluster",
+                type="k8s",
+                interactive=False,
+                in_cluster=True,
+                jwks_uri="https://api.cluster.invalid/openid/v1/jwks",
+            ),
+        )
+        monkeypatch.setattr(auth_module.config, "AUTH_PROVIDERS", registry)
+        auth_module._provider_jwks_cache.clear()
+        seen = {}
+
+        def fake_get(url, timeout=None, verify=None, **kwargs):
+            seen["verify"] = verify
+            seen["headers"] = kwargs.get("headers")
+            return SimpleNamespace(json=lambda: cluster.jwks)
+
+        monkeypatch.setattr(auth_module.requests, "get", fake_get)
+
+        assert auth_module.validate_token(cluster.mint())["iss"] == cluster.iss
+        assert seen["headers"] == {"Authorization": "Bearer pod-service-account-token"}
+        assert seen["verify"] == str(ca_file), "the cluster CA pins the API server, rather than trusting every public root"

--- a/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
+++ b/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
@@ -24,7 +24,9 @@ def provider_carries_the_configured_scoping(monkeypatch):
 
     def resolve(token):
         cfg = middleware_module.config
-        return SimpleNamespace(id="default", audience=cfg.OIDC_AUDIENCE, issuer=cfg.OIDC_ISSUER)
+        # ``type`` matters since #314: a k8s provider takes the service-account path instead of
+        # the group gate these cases describe.
+        return SimpleNamespace(id="default", type="oidc", audience=cfg.OIDC_AUDIENCE, issuer=cfg.OIDC_ISSUER)
 
     monkeypatch.setattr(auth_module, "resolve_token_provider", resolve)
 

--- a/mlflow_oidc_auth/tests/test_auth.py
+++ b/mlflow_oidc_auth/tests/test_auth.py
@@ -40,8 +40,8 @@ class TestGetOidcJwks:
         result = _get_oidc_jwks()
 
         assert mock_requests.get.call_count == 2
-        mock_requests.get.assert_any_call("https://example.com/.well-known/openid_configuration", timeout=10, verify=True)
-        mock_requests.get.assert_any_call("https://example.com/jwks", timeout=10, verify=True)
+        mock_requests.get.assert_any_call("https://example.com/.well-known/openid_configuration", timeout=10, verify=True, allow_redirects=False)
+        mock_requests.get.assert_any_call("https://example.com/jwks", timeout=10, verify=True, allow_redirects=False)
         assert result == {"keys": [{"kty": "RSA", "kid": "test"}]}
 
     @patch("mlflow_oidc_auth.auth.requests")

--- a/mlflow_oidc_auth/tests/test_kubernetes_provider.py
+++ b/mlflow_oidc_auth/tests/test_kubernetes_provider.py
@@ -1,0 +1,337 @@
+"""Kubernetes service-account tokens as a bearer credential (issue #314).
+
+A projected token is an ordinary JWT that #313 already validates; what is new is everything
+around it — where a cluster's keys come from, what ``sub`` means, and who may become a user on
+the strength of it.
+
+The last question is the one that matters most. An OIDC bearer token is gated on a groups claim,
+so a token from a stranger's account provisions nothing. A service-account token has no groups
+claim at all, so if that gate is simply skipped, **every pod in the cluster** that can read its
+own projected token becomes an MLflow user. The namespace allowlist is the whole decision, and
+these cases pin it.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mlflow_oidc_auth.kubernetes import (
+    ServiceAccount,
+    ServiceAccountError,
+    load_inline_jwks,
+    namespace_is_allowed,
+    parse_service_account,
+)
+from mlflow_oidc_auth.middleware.auth_middleware import AuthMiddleware
+
+
+class TestParsingTheSubject:
+    def test_a_projected_token_subject_parses(self):
+        account = parse_service_account("system:serviceaccount:team-a:trainer")
+
+        assert account == ServiceAccount(namespace="team-a", name="trainer")
+
+    def test_the_username_is_readable_and_unmistakable(self):
+        """It ends up in the admin UI and on permission grants, so
+        ``system:serviceaccount:team-a:trainer`` is not usable as-is."""
+        account = parse_service_account("system:serviceaccount:team-a:trainer")
+
+        assert account.username == "trainer.team-a@serviceaccount.cluster.local"
+        assert account.group == "k8s:team-a"
+
+    def test_two_namespaces_cannot_render_the_same_username(self):
+        """``-`` is legal *inside* a DNS label, so ``{namespace}-{name}`` is ambiguous:
+        ``prod-etl``/``writer`` and ``prod``/``etl-writer`` collide.
+
+        That is not cosmetic. Anyone able to create a service account in one allowlisted
+        namespace could pick a name that renders as an account in another, and — since the
+        username is the identity key — inherit its permissions. ``.`` cannot appear in a label,
+        so the halves stay distinguishable.
+        """
+        first = parse_service_account("system:serviceaccount:prod-etl:writer")
+        second = parse_service_account("system:serviceaccount:prod:etl-writer")
+
+        assert first.username != second.username
+        assert first.group != second.group
+
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "system:serviceaccount:team-a",
+            "system:serviceaccount::trainer",
+            "system:serviceaccount:team-a:",
+            "system:serviceaccount:team-a:trainer:extra",
+            "serviceaccount:team-a:trainer",
+            "system:node:worker-1",
+            "alice@example.com",
+            "",
+        ],
+    )
+    def test_anything_that_is_not_a_service_account_subject_is_refused(self, subject):
+        with pytest.raises(ServiceAccountError):
+            parse_service_account(subject)
+
+    @pytest.mark.parametrize("subject", [None, 42, ["system:serviceaccount:a:b"], {"sub": "x"}])
+    def test_a_non_string_subject_is_refused(self, subject):
+        with pytest.raises(ServiceAccountError):
+            parse_service_account(subject)
+
+    @pytest.mark.parametrize(
+        "namespace",
+        ["Team-A", "team_a", "team a", "team/a", "team.a", "-team", "team-", "a" * 64, "team@a", "../etc"],
+    )
+    def test_a_namespace_outside_the_kubernetes_character_set_is_refused(self, namespace):
+        """The claim is signed, so a healthy cluster cannot assert this — but the value becomes a
+        username and a group name, and a hostile or compromised cluster configured as a provider
+        should not get to choose what those contain."""
+        with pytest.raises(ServiceAccountError):
+            parse_service_account(f"system:serviceaccount:{namespace}:trainer")
+
+    def test_a_name_outside_the_character_set_is_refused(self):
+        with pytest.raises(ServiceAccountError):
+            parse_service_account("system:serviceaccount:team-a:Trainer_1")
+
+
+class TestTheNamespaceAllowlist:
+    def test_a_listed_namespace_is_allowed(self):
+        assert namespace_is_allowed("team-a", ("team-a", "team-b")) is True
+
+    def test_an_unlisted_namespace_is_not(self):
+        assert namespace_is_allowed("kube-system", ("team-a",)) is False
+
+    def test_an_empty_allowlist_means_nobody(self):
+        """Not "everybody". With no groups claim to narrow on, a permissive empty list would make
+        every pod in the cluster an MLflow user the moment the provider was configured."""
+        assert namespace_is_allowed("team-a", ()) is False
+
+
+class TestInlineKeys:
+    """The mode that needs no network: the operator pastes the cluster's JWKS into config."""
+
+    def test_a_jwks_object_is_accepted(self):
+        jwks = {"keys": [{"kty": "RSA", "kid": "abc"}]}
+
+        assert load_inline_jwks(jwks) == jwks
+
+    def test_a_json_string_is_accepted(self):
+        jwks = {"keys": [{"kty": "RSA", "kid": "abc"}]}
+
+        assert load_inline_jwks(json.dumps(jwks)) == jwks
+
+    @pytest.mark.parametrize("bad", ["not json", "[]", '{"keys": []}', '{"keys": "abc"}', "{}", '{"kid": "abc"}'])
+    def test_anything_that_is_not_a_key_set_is_refused(self, bad):
+        with pytest.raises(ValueError):
+            load_inline_jwks(bad)
+
+
+class TestProvisioningAServiceAccount:
+    """The gate an OIDC token passes through does not exist for this one."""
+
+    @staticmethod
+    def _provider(**overrides):
+        fields = {
+            "id": "cluster",
+            "type": "k8s",
+            "audience": "mlflow-api",
+            "issuer": "https://kubernetes.default.svc",
+            "namespace_allowlist": ("team-a",),
+        }
+        fields.update(overrides)
+        return SimpleNamespace(**fields)
+
+    def _provision(self, payload, provider):
+        """Drive the real authentication path, so what is asserted is what a request does."""
+        with (
+            patch("mlflow_oidc_auth.user.create_user") as create_user,
+            patch("mlflow_oidc_auth.user.populate_groups") as populate_groups,
+            patch("mlflow_oidc_auth.user.update_user") as update_user,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.store") as store,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+        ):
+            cfg.OIDC_PROVISION_ON_BEARER_AUTH = True
+            store.has_user.return_value = False
+            self.outcome = AuthMiddleware(app=MagicMock())._authenticate_service_account("tok", payload, provider)
+            return create_user, populate_groups, update_user
+
+    def test_a_listed_namespace_is_provisioned_as_a_service_account(self):
+        payload = {"sub": "system:serviceaccount:team-a:trainer"}
+
+        create_user, populate_groups, update_user = self._provision(payload, self._provider())
+
+        assert self.outcome == (True, "trainer.team-a@serviceaccount.cluster.local", "")
+        create_user.assert_called_once()
+        assert create_user.call_args.kwargs["username"] == "trainer.team-a@serviceaccount.cluster.local"
+        assert create_user.call_args.kwargs["is_service_account"] is True
+        assert create_user.call_args.kwargs["is_admin"] is False
+        populate_groups.assert_called_once_with(group_names=["k8s:team-a"])
+
+    def test_an_unlisted_namespace_is_refused_outright(self):
+        """Not merely "not provisioned": the request does not authenticate at all, so an account
+        that was provisioned before the namespace was removed from the list loses access too."""
+        payload = {"sub": "system:serviceaccount:kube-system:default"}
+
+        create_user, _, _ = self._provision(payload, self._provider())
+
+        assert self.outcome[0] is False
+        create_user.assert_not_called()
+
+    def test_removing_a_namespace_revokes_an_existing_account(self):
+        """The allowlist is re-read on every request, so offboarding a team by editing it works.
+
+        Checked only at provisioning, it would revoke nothing: every service account that had
+        authenticated once would keep its user row, its group and its permissions while kubelet
+        went on renewing its token.
+        """
+        payload = {"sub": "system:serviceaccount:team-b:trainer"}
+
+        with (
+            patch("mlflow_oidc_auth.user.create_user"),
+            patch("mlflow_oidc_auth.middleware.auth_middleware.store") as store,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+        ):
+            cfg.OIDC_PROVISION_ON_BEARER_AUTH = True
+            store.has_user.return_value = True  # it authenticated before team-b was removed
+            allowed, username, _ = AuthMiddleware(app=MagicMock())._authenticate_service_account("tok", payload, self._provider())
+
+        assert allowed is False
+
+    def test_an_empty_allowlist_admits_nobody(self):
+        payload = {"sub": "system:serviceaccount:team-a:trainer"}
+
+        create_user, _, _ = self._provision(payload, self._provider(namespace_allowlist=()))
+
+        assert self.outcome[0] is False
+        create_user.assert_not_called()
+
+    def test_a_malformed_subject_does_not_authenticate(self):
+        create_user, _, _ = self._provision({"sub": "alice@example.com"}, self._provider())
+
+        assert self.outcome[0] is False
+        create_user.assert_not_called()
+
+    def test_a_missing_subject_does_not_authenticate(self):
+        create_user, _, _ = self._provision({}, self._provider())
+
+        assert self.outcome[0] is False
+        create_user.assert_not_called()
+
+    def test_a_service_account_is_never_an_admin(self):
+        """No claim a cluster can assert should confer administrator rights here, and
+        OIDC_TRUST_BEARER_GROUP_CLAIMS deliberately does not reach this path: it opts into
+        trusting a directory's group names, which is a different statement from trusting a
+        namespace."""
+        payload = {"sub": "system:serviceaccount:team-a:trainer", "groups": ["mlflow-admins"], "is_admin": True}
+
+        create_user, _, _ = self._provision(payload, self._provider())
+
+        assert create_user.call_args.kwargs["is_admin"] is False
+
+    def test_a_refusal_is_audited(self):
+        events = []
+        payload = {"sub": "system:serviceaccount:kube-system:default"}
+
+        import mlflow_oidc_auth.middleware.auth_middleware as middleware_module
+
+        middleware_module._denial_audit_seen.clear()
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.emit_audit_event", lambda event, **kw: events.append((event, kw))):
+            self._provision(payload, self._provider())
+
+        assert [event for event, _ in events] == ["auth.denied_namespace"]
+        assert events[0][1]["status"] == "denied"
+        assert events[0][1]["detail"]["namespace"] == "kube-system"
+
+
+class TestTheRegistryRefusesAnUnusableClusterProvider:
+    """Both requirements are the difference between a provider and an open door, so each is
+    refused at load with an error that says why."""
+
+    @staticmethod
+    def _build(entry):
+        from types import SimpleNamespace as NS
+
+        from mlflow_oidc_auth.provider_registry import build_provider_registry
+
+        class Manager:
+            @staticmethod
+            def get(key, default=None):
+                return json.dumps([entry]) if key == "AUTH_PROVIDERS" else default
+
+        app_config = NS(
+            OIDC_PROVIDER_DISPLAY_NAME="Login with OIDC",
+            OIDC_AUDIENCE=None,
+            OIDC_ISSUER=None,
+            OIDC_DISCOVERY_URL="https://idp.example.com/.well-known/openid-configuration",
+            OIDC_CLIENT_ID="client",
+        )
+        return build_provider_registry(Manager(), app_config)
+
+    @staticmethod
+    def _entry(**overrides):
+        entry = {
+            "id": "cluster",
+            "type": "k8s",
+            "audience": "mlflow-api",
+            "issuer": "https://kubernetes.default.svc",
+            "namespace_allowlist": ["team-a"],
+            "jwks_uri": "https://kubernetes.default.svc/openid/v1/jwks",
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_a_complete_entry_is_accepted(self):
+        result = self._build(self._entry())
+
+        assert [provider.id for provider in result.providers] == ["cluster"]
+        assert result.providers[0].namespace_allowlist == ("team-a",)
+
+    def test_no_namespace_allowlist_is_refused(self):
+        entry = self._entry()
+        entry.pop("namespace_allowlist")
+
+        result = self._build(entry)
+
+        assert result.providers == []
+        assert any("namespace_allowlist" in error for error in result.errors)
+
+    def test_an_empty_namespace_allowlist_is_refused(self):
+        result = self._build(self._entry(namespace_allowlist=[]))
+
+        assert result.providers == []
+
+    def test_no_key_source_at_all_is_refused(self):
+        entry = self._entry()
+        entry.pop("jwks_uri")
+
+        result = self._build(entry)
+
+        assert result.providers == []
+        assert any("key source" in error for error in result.errors)
+
+    def test_a_malformed_inline_key_set_is_refused(self):
+        entry = self._entry(jwks_inline="{not json")
+        entry.pop("jwks_uri")
+
+        result = self._build(entry)
+
+        assert result.providers == []
+        assert any("JWKS" in error for error in result.errors)
+
+    def test_in_cluster_alone_is_a_key_source(self):
+        entry = self._entry(in_cluster=True)
+        entry.pop("jwks_uri")
+
+        result = self._build(entry)
+
+        assert [provider.id for provider in result.providers] == ["cluster"]
+
+    def test_an_unpinned_audience_is_refused(self):
+        """Inherited from the shared rules, and it matters most here: an unpinned audience
+        accepts any pod's token minted for any service."""
+        entry = self._entry()
+        entry.pop("audience")
+
+        result = self._build(entry)
+
+        assert result.providers == []

--- a/mlflow_oidc_auth/tests/test_kubernetes_provider.py
+++ b/mlflow_oidc_auth/tests/test_kubernetes_provider.py
@@ -167,6 +167,29 @@ class TestProvisioningAServiceAccount:
         assert create_user.call_args.kwargs["is_admin"] is False
         populate_groups.assert_called_once_with(group_names=["k8s:team-a"])
 
+    def test_the_oidc_provisioning_flag_is_not_a_hidden_prerequisite(self):
+        """OIDC_PROVISION_ON_BEARER_AUTH gates provisioning from an *OIDC* token, where the
+        alternative is trusting whatever groups an arbitrary corporate token carries.
+
+        Here the opt-in already exists and is narrower — a provider the operator configured and a
+        namespace they named in its allowlist. Requiring the OIDC flag as well would mean the
+        documented setup authenticates the token and then returns 401 as an unknown user, with
+        nothing pointing at why.
+        """
+        payload = {"sub": "system:serviceaccount:team-a:trainer"}
+
+        with (
+            patch("mlflow_oidc_auth.user.create_user") as create_user,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.store") as store,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+        ):
+            cfg.OIDC_PROVISION_ON_BEARER_AUTH = False
+            store.has_user.return_value = False
+            allowed, username, _ = AuthMiddleware(app=MagicMock())._authenticate_service_account("tok", payload, self._provider())
+
+        assert allowed is True
+        create_user.assert_called_once()
+
     def test_an_unlisted_namespace_is_refused_outright(self):
         """Not merely "not provisioned": the request does not authenticate at all, so an account
         that was provisioned before the namespace was removed from the list loses access too."""
@@ -299,6 +322,20 @@ class TestTheRegistryRefusesAnUnusableClusterProvider:
         result = self._build(self._entry(namespace_allowlist=[]))
 
         assert result.providers == []
+
+    @pytest.mark.parametrize("namespace", ["Team-A", "team_a", "system:serviceaccount:team-a", "team a", "a" * 64])
+    def test_an_allowlist_entry_that_could_never_match_is_refused(self, namespace):
+        """Worse than a rejected entry: it passes validation and then silently denies every pod
+        in the namespace the operator meant to allow."""
+        result = self._build(self._entry(namespace_allowlist=[namespace]))
+
+        assert result.providers == []
+        assert any("never match" in error for error in result.errors)
+
+    def test_a_real_namespace_is_accepted(self):
+        result = self._build(self._entry(namespace_allowlist=["team-a", "kube-system", "ml-1"]))
+
+        assert result.providers[0].namespace_allowlist == ("team-a", "kube-system", "ml-1")
 
     def test_no_key_source_at_all_is_refused(self):
         entry = self._entry()

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -71,6 +71,10 @@ def valid_entry(**overrides) -> dict:
         "discovery_url": f"https://{provider_id}.example.com/.well-known/openid-configuration",
     }
     entry.update(overrides)
+    if entry.get("type") == "k8s":
+        # A cluster provider carries two more requirements (#314): somewhere to get keys, and a
+        # namespace allowlist, since a service-account token has no groups claim to gate on.
+        entry.setdefault("namespace_allowlist", ["team-a"])
     return entry
 
 


### PR DESCRIPTION
Closes #314. Completes Phase 1 of #304: a pod authenticates with its projected service-account token while human login stays on OIDC.

Validation itself is #313's and unchanged — a projected token is an ordinary JWT, routed by issuer and held to its provider's keys, algorithms, issuer and audience. What this adds is everything *around* that.

## Where the keys come from

Reachability is the real failure mode, not validation: `system:service-account-issuer-discovery` is rarely bound to `system:unauthenticated`, and the API server is often unreachable from wherever MLflow runs. Three modes, because deployments genuinely need all three:

| Mode | For |
|---|---|
| `jwks_uri` + `in_cluster` | MLflow runs in the cluster — fetches with the pod's own credential, verified against the mounted cluster CA |
| `jwks_inline` | The cluster is unreachable — key set in configuration, **no network in the auth path at all** |
| `discovery_url` | Managed clusters that publish public discovery (EKS/GKE/AKS) |

## Identity

`sub` is parsed into a namespace and an account name, each validated as a DNS label, and rendered as `<name>.<namespace>@serviceaccount.cluster.local`.

The separator is a **dot**, not a hyphen, and that is load-bearing: a hyphen is legal *inside* a DNS label, so `prod-etl`/`writer` and `prod`/`etl-writer` would render the same username. Since the username is the identity key, anyone able to create a service account in one allowlisted namespace could collide with an account in another and inherit its permissions.

The username comes from `sub` rather than `OIDC_USERNAME_FIELD` — a service-account token has no `email` or `preferred_username`, and widening that global list to include `sub` would change how every other provider's tokens are named.

## Authorization

A required `namespace_allowlist`, **checked on every request**. A service-account token carries no groups claim, so the gate that guards OIDC bearer provisioning cannot apply to it; an empty list means nobody, never everybody. Checked only at provisioning it would revoke nothing — every account that had authenticated once would keep its row and group while kubelet went on renewing its token.

Accounts are always non-admin, and `OIDC_TRUST_BEARER_GROUP_CLAIMS` deliberately does not reach this path: it opts into trusting a *directory's* group names, which is a different statement from trusting a namespace.

## Why not `TokenReview`

Evaluated and declined, with reasoning in [docs/kubernetes-auth.md](docs/kubernetes-auth.md): it puts a synchronous API-server call in the per-request auth path (the path #305 exists to protect), moves MLflow's availability under the control plane's, and needs `system:auth-delegator` where JWKS needs only public keys. Every cluster that can run it can also serve issuer discovery to the same credential, which mode 1 already covers.

## Review findings fixed in this PR

A `security-reviewer` pass found six, all fixed — three of them serious enough to be worth naming:

1. **The feature did not work as documented.** `username_template` was dead code: the identity actually came from `extract_username`, so an operator would have had to add `sub` to the global `OIDC_USERNAME_FIELD` — changing every other provider — and grants made to the documented username would have applied to nobody. The k8s path now derives the identity itself, and the configurable template is gone.
2. **The allowlist was provisioning-time only** (fixed as described above).
3. **The `{namespace}-{name}` scheme was ambiguous** (fixed as described above).
4. The pod's credential was attached to the discovery fetch, whose follow-up request goes to whatever host the discovery *body* names — routinely a third-party bucket on managed clusters. It is now sent only to an operator-configured `jwks_uri`.
5. `in_cluster` fell back to the global `OIDC_VERIFY_SSL` when no CA was mounted; that flag is often false to work around a private-CA IdP, so it now fails closed.
6. The k8s-only fields were accepted on any provider type, where a pasted `jwks_inline` would silently pin an IdP's keys forever. Refused at load.

Redirects are no longer followed on either JWKS fetch.

## Validation

```
pre-commit run --all-files              # passed
pytest -m 'not integration' .../tests   # 3774 passed, 14 skipped
pytest mlflow_oidc_auth/tests/perf/     # 37 passed — T0 budget unchanged
```

52 tests in `test_kubernetes_provider.py` plus 8 in the adversarial suite covering the cluster provider's key modes and audience confusion against the human-login provider.

## Not verified here

**The kind-cluster acceptance criterion is not met by this PR.** The tests mint tokens with a local key, not a cluster, so "a real projected token from a kind cluster authenticates end to end" needs a machine with a cluster. The exact procedure is written up at the end of [docs/kubernetes-auth.md](docs/kubernetes-auth.md) — `kind create cluster`, `kubectl create token --audience`, then `curl` against `/oidc/api/whoami` — and should be run before this is relied on in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)