### PR TITLE
feat(auth): per-provider login, mix-up defence, and per-provider provisioning (#316, #318)

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -237,8 +237,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
             logger.info("Bearer user %s is in no authorized group; not provisioning (parity with interactive login)", username)
             return
 
-        # Admin is conferred from a token only when the operator has explicitly opted in.
-        is_admin = is_admin_claim and config.OIDC_TRUST_BEARER_GROUP_CLAIMS
+        # Admin is conferred from a token only when the operator has explicitly opted in *and*
+        # the asserting provider is allowed to say so (#318). Without the second half, a provider
+        # configured ``admin_source: none`` — the answer for a tenant whose group names you do
+        # not control — could still mint administrators through this path.
+        from mlflow_oidc_auth.provisioning_policy import admin_from_claims
+
+        is_admin = is_admin_claim and config.OIDC_TRUST_BEARER_GROUP_CLAIMS and admin_from_claims(provider, user_groups, config.OIDC_ADMIN_GROUP_NAME)
         display_name, display_name_error = extract_display_name(payload, source=BEARER_TOKEN_SOURCE)
         if display_name_error:
             logger.debug("Bearer provisioning of %s falling back to username as display name: %s", username, display_name_error)

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -284,30 +284,6 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             f"{label}: type {provider_type!r} has no browser login flow, so 'interactive' cannot be true; "
             "its credentials are presented directly as bearer tokens"
         )
-    elif interactive and provider_id != DEFAULT_PROVIDER_ID:
-        # Coerced off rather than rejected: the entry is still a perfectly good *token* provider
-        # (#313, #314), and only the browser flow is unsafe. Rejecting it outright would take
-        # bearer authentication down with it.
-        interactive = False
-        # #316 gave every provider its own login and callback and defended the mix-up attack,
-        # but everything *after* the token exchange is still deployment-global: the username
-        # field, the groups attribute and the admin group come from flat configuration, and the
-        # user row is not namespaced by provider. A second interactive provider on that footing
-        # is account takeover, not a feature — a contractor tenant asserting
-        # ``email: alice@corp.com`` lands on Alice's account, and a group named as the admin
-        # group confers administrator rights across the deployment.
-        #
-        # #318 is what makes provisioning, identity binding and admin source per-provider. Until
-        # it lands this is refused, rather than shipped and documented as a caveat.
-        logger.warning(
-            "%s: 'interactive' is not yet supported for a provider other than %r, and has been turned off for it. Browser "
-            "login still resolves identity and administrator status from deployment-wide configuration, so a second "
-            "interactive provider could claim accounts belonging to the first. Bearer tokens from this provider are "
-            "unaffected; see #318.",
-            label,
-            DEFAULT_PROVIDER_ID,
-        )
-
     allowed_email_domains = _as_tuple(entry.get("allowed_email_domains"))
     if identity_binding == "email" and not allowed_email_domains:
         errors.append(
@@ -380,7 +356,11 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             provisioning=provisioning,
             group_sync=group_sync,
             group_sync_mode=group_sync_mode,
-            admin_source=entry.get("admin_source", "claims"),
+            # Defaults to ``none`` for anything but the deployment's own provider: the admin
+            # group name is deployment-wide, so a partner tenant that happens to name a group
+            # the same thing would otherwise confer administrator rights across the deployment.
+            # The operator opts in per provider, deliberately.
+            admin_source=entry.get("admin_source", "claims" if provider_id == DEFAULT_PROVIDER_ID else "none"),
             identity_binding=identity_binding,
             interactive=bool(interactive),
             allowed_email_domains=allowed_email_domains,

--- a/mlflow_oidc_auth/provider_registry.py
+++ b/mlflow_oidc_auth/provider_registry.py
@@ -284,6 +284,29 @@ def _validate(entry: Dict[str, Any], index: int, seen_ids: set) -> Tuple[Optiona
             f"{label}: type {provider_type!r} has no browser login flow, so 'interactive' cannot be true; "
             "its credentials are presented directly as bearer tokens"
         )
+    elif interactive and provider_id != DEFAULT_PROVIDER_ID:
+        # Coerced off rather than rejected: the entry is still a perfectly good *token* provider
+        # (#313, #314), and only the browser flow is unsafe. Rejecting it outright would take
+        # bearer authentication down with it.
+        interactive = False
+        # #316 gave every provider its own login and callback and defended the mix-up attack,
+        # but everything *after* the token exchange is still deployment-global: the username
+        # field, the groups attribute and the admin group come from flat configuration, and the
+        # user row is not namespaced by provider. A second interactive provider on that footing
+        # is account takeover, not a feature — a contractor tenant asserting
+        # ``email: alice@corp.com`` lands on Alice's account, and a group named as the admin
+        # group confers administrator rights across the deployment.
+        #
+        # #318 is what makes provisioning, identity binding and admin source per-provider. Until
+        # it lands this is refused, rather than shipped and documented as a caveat.
+        logger.warning(
+            "%s: 'interactive' is not yet supported for a provider other than %r, and has been turned off for it. Browser "
+            "login still resolves identity and administrator status from deployment-wide configuration, so a second "
+            "interactive provider could claim accounts belonging to the first. Bearer tokens from this provider are "
+            "unaffected; see #318.",
+            label,
+            DEFAULT_PROVIDER_ID,
+        )
 
     allowed_email_domains = _as_tuple(entry.get("allowed_email_domains"))
     if identity_binding == "email" and not allowed_email_domains:

--- a/mlflow_oidc_auth/provisioning_policy.py
+++ b/mlflow_oidc_auth/provisioning_policy.py
@@ -1,0 +1,184 @@
+"""Per-provider provisioning and group-sync policy (issue #318).
+
+Three decisions used to be made the same way for everyone, from deployment-wide configuration:
+who may become a user, whose group membership wins, and who may be an administrator. With one
+identity provider that is a reasonable simplification. With two it is a vulnerability — a second
+provider asserting ``email: alice@corp.com`` would reach Alice's account, and a tenant emitting a
+group named like the admin group would confer administrator rights across the deployment.
+
+Each decision now comes from the registry entry of the provider that actually asserted the
+identity:
+
+``provisioning``
+    ``jit`` creates a user on first login. ``scim`` and ``none`` never create: an unknown user is
+    refused with a message saying so, which is the enterprise gate where app assignment in the
+    directory is what controls access.
+
+``group_sync`` / ``group_sync_mode``
+    Whether claims refresh group membership, and whether they *replace* it. ``authoritative``
+    genuinely removes memberships the claims no longer assert — Keycloak's ``FORCE`` mapper is
+    add-only in practice ([keycloak#36578](https://github.com/keycloak/keycloak/issues/36578)),
+    so a deployment that expects revocation to propagate has to get it from here.
+
+``admin_source``
+    ``claims`` reads the admin group from the token as before; ``none`` means this provider can
+    never confer administrator rights, whatever it asserts. The admin group name itself stays
+    server-side configuration and is never SCIM-writable.
+
+The ``default`` provider's defaults are today's behaviour exactly — ``jit``, ``every_login``,
+``authoritative``, ``claims`` — so a deployment that changes no configuration sees no change.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+from mlflow_oidc_auth.identity_resolution import IdentityDecision, Resolution
+from mlflow_oidc_auth.provider_registry import DEFAULT_PROVIDER_ID
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+
+@dataclass(frozen=True)
+class ProvisioningOutcome:
+    """What the caller may do with a resolved identity.
+
+    Attributes:
+        allowed: Whether the login may proceed at all.
+        create: Whether a user record must be created first.
+        username: The local username, when allowed.
+        reason: Why, for logs and audit. Always set when refused.
+    """
+
+    allowed: bool
+    create: bool = False
+    username: Optional[str] = None
+    reason: str = ""
+
+
+def apply_provisioning_policy(
+    provider,
+    decision: IdentityDecision,
+    *,
+    derived_username: Optional[str],
+    user_exists,
+    providers_bound_to=None,
+) -> ProvisioningOutcome:
+    """Turn an identity decision into a provisioning decision for ``provider``.
+
+    Parameters:
+        provider: The registry entry of the provider that asserted the identity.
+        decision: What :func:`~mlflow_oidc_auth.identity_resolution.resolve_identity` decided.
+        derived_username: The username the deployment's configured claim fields produce.
+        user_exists: Callable ``(username) -> bool``.
+        providers_bound_to: Callable ``(username) -> list[str]`` naming the providers already
+            bound to that user. Used to tell "this account is mine, from before identities were
+            recorded" from "this account belongs to somebody else".
+
+    Returns:
+        ProvisioningOutcome: Check ``allowed`` before anything else.
+    """
+    if not decision.is_allowed:
+        return ProvisioningOutcome(allowed=False, reason=decision.reason or "identity refused")
+
+    if decision.resolution in (Resolution.MATCHED, Resolution.LINK):
+        return ProvisioningOutcome(allowed=True, create=False, username=decision.username, reason=decision.reason)
+
+    # CREATE. Two things have to be true: the provider may create users at all, and the name it
+    # would create is not already someone else's.
+    if not derived_username:
+        return ProvisioningOutcome(allowed=False, reason="no username could be derived from the provider's claims")
+
+    if user_exists(derived_username):
+        bound_to = list(providers_bound_to(derived_username)) if providers_bound_to else []
+        foreign = [bound for bound in bound_to if bound != provider.id]
+
+        if not foreign and provider.id == DEFAULT_PROVIDER_ID:
+            # The account predates identity records, or its only binding is this provider's own.
+            #
+            # This is every user of every deployment that upgrades: the Phase 0 backfill wrote
+            # ``subject = username`` because that was all it had, and a real ``sub`` is not a
+            # username — so the first login after upgrading resolves to CREATE, finds the name
+            # taken, and without this would refuse *every existing user, including every
+            # administrator*, with no way back that does not involve the database.
+            #
+            # Adoption is safe precisely here and nowhere else: this is the deployment's own
+            # provider, the one that named the account in the first place.
+            return ProvisioningOutcome(allowed=True, create=False, username=derived_username, reason="adopting an account from before identities were recorded")
+
+        # The name is taken by someone another provider owns. Under subject binding this is the
+        # cross-provider takeover: a second provider asserting an existing user's email or
+        # preferred_username would otherwise be handed their account.
+        return ProvisioningOutcome(
+            allowed=False,
+            reason=f"username {derived_username!r} already belongs to another identity; provider '{provider.id}' cannot claim it",
+        )
+
+    if provider.provisioning != "jit":
+        # The enterprise gate: the directory decides who exists, and login does not.
+        return ProvisioningOutcome(
+            allowed=False,
+            reason=f"provider '{provider.id}' has provisioning '{provider.provisioning}', so an unknown user is not created at login",
+        )
+
+    return ProvisioningOutcome(allowed=True, create=True, username=derived_username, reason="new principal")
+
+
+def local_group_name(provider, claimed: str) -> str:
+    """The local group a provider's claimed group name maps to.
+
+    Namespaced for every provider but the deployment's own. Group *names* are the permission
+    boundary — ``set_user_groups`` joins by name and ``populate_groups`` creates whatever is
+    missing — so an unnamespaced second provider could assert ``finance-ds`` and have its users
+    join the local group of that name, inheriting every permission granted to it without any
+    takeover or admin flag. Prefixing makes that impossible to say.
+
+    The ``default`` provider keeps raw names: they are the names every existing deployment
+    already has, and there is nothing to collide with.
+    """
+    if provider.id == DEFAULT_PROVIDER_ID:
+        return claimed
+    return f"{provider.id}:{claimed}"
+
+
+def groups_to_apply(provider, claimed_groups: Sequence[str], current_groups: Optional[Sequence[str]], *, is_new_user: bool) -> Optional[List[str]]:
+    """The group membership to write, or None to leave it alone.
+
+    Parameters:
+        provider: The asserting provider's registry entry.
+        claimed_groups: Groups the token asserts.
+        current_groups: Groups the user has locally.
+        is_new_user: Whether this login just created the account.
+
+    Returns:
+        The full membership to store, or None when this provider does not touch groups.
+    """
+    if provider.group_sync == "none":
+        return None
+    if provider.group_sync == "first_login" and not is_new_user:
+        return None
+
+    claimed = [local_group_name(provider, group) for group in claimed_groups if group]
+    if provider.group_sync_mode == "authoritative":
+        # Replaces, which is the point: a membership the claims no longer assert is removed.
+        return list(dict.fromkeys(claimed))
+
+    # additive: never removes. For a deployment where some groups are managed elsewhere — SCIM,
+    # or by hand — and the token only knows about its own.
+    if current_groups is None:
+        # The current membership could not be read. Writing the claimed set alone would *delete*
+        # everything else, turning an additive sync into the destructive one it exists to avoid.
+        logger.warning("Skipping additive group sync for provider '%s': current membership is unknown", provider.id)
+        return None
+    return list(dict.fromkeys([*current_groups, *claimed]))
+
+
+def admin_from_claims(provider, claimed_groups: Sequence[str], admin_group_names: Sequence[str]) -> bool:
+    """Whether this provider may confer administrator rights, and does.
+
+    ``admin_source: none`` means no claim from this provider makes anyone an administrator —
+    the answer for a partner or contractor tenant whose group names you do not control.
+    """
+    if provider.admin_source != "claims":
+        return False
+    return any(group in claimed_groups for group in admin_group_names)

--- a/mlflow_oidc_auth/repository/__init__.py
+++ b/mlflow_oidc_auth/repository/__init__.py
@@ -22,6 +22,7 @@ from mlflow_oidc_auth.repository.registered_model_permission_group import (
 )
 from mlflow_oidc_auth.repository.user import UserRepository
 from mlflow_oidc_auth.repository.auth_session import AuthSessionRepository
+from mlflow_oidc_auth.repository.auth_state import AuthStateRepository
 from mlflow_oidc_auth.repository.user_identity import UserIdentityRepository
 from mlflow_oidc_auth.repository.experiment_permission_regex import (
     ExperimentPermissionRegexRepository,
@@ -113,6 +114,7 @@ __all__ = [
     "UserRepository",
     "UserIdentityRepository",
     "AuthSessionRepository",
+    "AuthStateRepository",
     "ExperimentPermissionRegexRepository",
     "ExperimentPermissionGroupRegexRepository",
     "RegisteredModelPermissionRegexRepository",

--- a/mlflow_oidc_auth/repository/auth_state.py
+++ b/mlflow_oidc_auth/repository/auth_state.py
@@ -1,0 +1,145 @@
+"""In-flight authorization state, server-side (issue #316).
+
+A login is a round trip: the browser leaves for the provider and comes back with ``code`` and
+``state``, and the server has to remember what it started. That memory used to be a single
+``oauth_state`` key in the cookie, which two problems follow from:
+
+* **Two tabs clobber each other.** One key holds one attempt, so starting a second login
+  overwrites the first, and whichever comes back second fails a CSRF check it should have passed.
+* **Nothing records which provider started it.** With one provider that is answerable by
+  assumption. With several it is the [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html)
+  mix-up question — an authorization response says nothing about who sent it, and ``code`` and
+  ``state`` look identical whichever authorization server produced them.
+
+A row per attempt answers both. The row names the issuer the transaction began with, which is
+what ``validate_response_issuer`` (#307) compares the returned ``iss`` against.
+
+**Single use.** ``consume`` claims the row with the delete itself and reports the attempt only to
+the caller whose delete matched, so two callbacks racing one state cannot both proceed and a replay
+finds nothing.
+"""
+
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from sqlalchemy.orm import Session
+
+from mlflow_oidc_auth.db.models import SqlAuthState
+
+#: 256 bits. The value is a CSRF token: it must be unguessable, and it is the only thing tying a
+#: callback to the login attempt that started it.
+STATE_BYTES = 32
+
+#: How long an attempt may take. Long enough for a real login — including an MFA prompt and a
+#: password reset — and short enough that an abandoned row is not a lasting replay target.
+DEFAULT_STATE_LIFETIME_SECONDS = 15 * 60
+
+
+@dataclass(frozen=True)
+class AuthAttempt:
+    """What a login attempt recorded before leaving for the provider.
+
+    Attributes:
+        state: The CSRF value echoed back on the callback.
+        provider_id: Registry id of the provider the attempt went to. The issuer to compare the
+            response against is read from the registry under this id rather than copied here:
+            the registry is the authority on a provider's issuer, and a provider repointed at a
+            different one mid-flight *should* fail the comparison rather than pass it against a
+            stale copy.
+        redirect_after_login: Where to send the browser once it is authenticated.
+    """
+
+    state: str
+    provider_id: str
+    redirect_after_login: Optional[str] = None
+
+
+def _now() -> datetime:
+    """Naive UTC, matching the DateTime columns the migration created."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class AuthStateRepository:
+    """Creates, consumes and sweeps in-flight authorization state."""
+
+    def __init__(self, session_maker):
+        self._Session: Callable[[], Session] = session_maker
+
+    def create(
+        self,
+        provider_id: str,
+        *,
+        redirect_after_login: Optional[str] = None,
+        lifetime_seconds: int = DEFAULT_STATE_LIFETIME_SECONDS,
+    ) -> str:
+        """Start an attempt and return its ``state``.
+
+        Parameters:
+            provider_id: Registry id of the provider this attempt goes to.
+            redirect_after_login: Validated relative path to return the browser to.
+            lifetime_seconds: How long the attempt may take.
+
+        Returns:
+            The state value to send to the authorization endpoint.
+        """
+        state = secrets.token_urlsafe(STATE_BYTES)
+        with self._Session(read_only=False) as session:
+            session.add(
+                SqlAuthState(
+                    state=state,
+                    provider_id=provider_id,
+                    relay_state=redirect_after_login,
+                    expires_at=_now() + timedelta(seconds=lifetime_seconds),
+                )
+            )
+            session.flush()
+        return state
+
+    def consume(self, state: str) -> Optional[AuthAttempt]:
+        """Take the attempt named by ``state``, removing it.
+
+        Single use by construction: the row is deleted as it is read, so a callback replayed with
+        the same ``state`` — from a browser history entry, a proxy log, an attacker who captured
+        the redirect — finds nothing and is refused.
+
+        Returns None when the state is unknown, already used, or expired. The caller cannot tell
+        which, deliberately.
+        """
+        if not state:
+            return None
+        with self._Session(read_only=False) as session:
+            row = session.query(SqlAuthState).filter(SqlAuthState.state == state).one_or_none()
+            if row is None:
+                return None
+
+            attempt = AuthAttempt(
+                state=row.state,
+                provider_id=row.provider_id or "",
+                redirect_after_login=row.relay_state,
+            )
+            expired = row.expires_at is not None and row.expires_at <= _now()
+
+            # The delete is what claims the attempt, and its row count is what says whether *this*
+            # caller claimed it. Deleting the ORM object instead would let two concurrent callbacks
+            # with the same state both see the row and both proceed: the second delete matches
+            # nothing and SQLAlchemy only warns. Whoever's delete matched has the attempt.
+            claimed = session.query(SqlAuthState).filter(SqlAuthState.state == state).delete(synchronize_session=False)
+            session.flush()
+
+        if not claimed:
+            return None
+        return None if expired else attempt
+
+    def delete_expired(self, before: Optional[datetime] = None) -> int:
+        """Delete attempts that were never completed.
+
+        Housekeeping: ``consume`` already refuses an expired row. Abandoned logins would
+        otherwise accumulate one row per browser that changed its mind.
+        """
+        cutoff = before or _now()
+        if cutoff.tzinfo:
+            cutoff = cutoff.replace(tzinfo=None)
+        with self._Session(read_only=False) as session:
+            return int(session.query(SqlAuthState).filter(SqlAuthState.expires_at <= cutoff).delete(synchronize_session=False))

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -9,16 +9,18 @@ import time
 from collections.abc import Awaitable
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from authlib.jose.errors import BadSignatureError
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from mlflow_oidc_auth.audit import emit_audit_event
+from mlflow_oidc_auth.authorization_response import IssuerMismatchError, validate_response_issuer
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
-from mlflow_oidc_auth.oauth import PKCEUnsupportedError, assert_pkce_supported, is_oidc_configured, oauth
+from mlflow_oidc_auth.provider_registry import DEFAULT_PROVIDER_ID
+from mlflow_oidc_auth.oauth import PKCEUnsupportedError, assert_pkce_supported, get_client, is_oidc_configured, oauth
 from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils import get_configured_or_dynamic_redirect_uri, extract_username, extract_display_name
 
@@ -39,6 +41,7 @@ auth_router = APIRouter(
 
 CALLBACK = "/callback"
 LOGIN = "/login"
+PROVIDERS = "/providers"
 LOGOUT = "/logout"
 AUTH_STATUS = "/auth/status"
 
@@ -67,15 +70,21 @@ async def _refresh_oidc_jwks() -> None:
         logger.warning(f"Failed to refresh OIDC JWKS after bad signature: {exc}")
 
 
-async def _call_authorize_access_token(request: Request) -> Optional[dict[str, Any]]:
-    """Invoke authorize_access_token while supporting sync or async implementations."""
+async def _call_authorize_access_token(request: Request, provider_id: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Invoke authorize_access_token while supporting sync or async implementations.
 
-    token_call = oauth.oidc.authorize_access_token(request)  # type: ignore
+    The exchange goes to the token endpoint of the provider the attempt started at — never one
+    derived from the response, which is the other half of the RFC 9207 defence.
+    """
+
+    client = (get_client(provider_id) if provider_id else None) or oauth.oidc
+    token_call = client.authorize_access_token(request)  # type: ignore
     return await _maybe_await(token_call)
 
 
 async def _authorize_access_token_with_key_refresh(
     request: Request,
+    provider_id: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     """Exchange the code for tokens; on failure refresh the JWKS and raise what actually went wrong.
 
@@ -100,7 +109,7 @@ async def _authorize_access_token_with_key_refresh(
     """
 
     try:
-        return await _call_authorize_access_token(request)
+        return await _call_authorize_access_token(request, provider_id)
     except BadSignatureError as exc:
         logger.warning("OIDC token exchange failed with bad signature: %s", exc)
         # Most likely a rotated signing key. Refresh so the next login is not affected too.
@@ -203,13 +212,33 @@ def _persist_session_auth(session, token_response: dict[str, Any]) -> None:
         session.pop("refresh_token", None)
 
 
+async def _iss_parameter_supported(provider) -> bool:
+    """Whether the provider advertises ``authorization_response_iss_parameter_supported``.
+
+    RFC 9207 is recent and plenty of deployed servers do not implement it, so a missing ``iss``
+    is only fatal when the provider says it always sends one. Discovery being unreachable reads
+    as "does not advertise": this decides how strict to be about a *missing* parameter, and a
+    mismatch is refused either way.
+    """
+    client = get_client(provider.id)
+    loader = getattr(client, "load_server_metadata", None)
+    if loader is None:
+        return False
+    try:
+        metadata = await loader() or {}
+    except Exception as exc:
+        logger.debug("Could not load metadata for the RFC 9207 check on '%s': %s", provider.id, exc)
+        return False
+    return bool(metadata.get("authorization_response_iss_parameter_supported"))
+
+
 def _sanitize_next(value: Optional[str]) -> Optional[str]:
     """Validate a ``next`` redirect target. Only same-origin relative paths are
     accepted to prevent open-redirect attacks. Returns None on rejection.
 
     Accepts: ``/users``, ``/oidc/ui/groups``, ``/#/experiments/0``.
-    Rejects: ``http://evil``, ``//evil``, ``javascript:...``, anything not starting
-    with a single ``/``.
+    Rejects: ``http://evil``, ``//evil``, ``javascript:...``, ``/\\evil.com``,
+    ``/<tab>/evil.com``, and anything not starting with a single ``/``.
     """
 
     if not value:
@@ -220,7 +249,18 @@ def _sanitize_next(value: Optional[str]) -> Optional[str]:
         return None
     if value.startswith("//"):  # protocol-relative URL — would escape origin
         return None
-    if "\n" in value or "\r" in value:  # header-injection guard
+    # Browsers do not read this the way a prefix check does. WHATWG parsing treats ``\`` as ``/``
+    # for special schemes, so ``/\evil.com`` navigates to https://evil.com/, and leading C0
+    # controls are stripped before parsing, so ``/%09/evil.com`` becomes ``//evil.com``. Both
+    # start with a single ``/`` and would otherwise be accepted — and land the victim on an
+    # attacker's page immediately after authenticating, which is the ideal phishing moment.
+    if "\\" in value:
+        return None
+    if any(character in value for character in "\x00\t\n\r\x0b\x0c"):
+        return None
+
+    parsed = urlparse(value)
+    if parsed.scheme or parsed.netloc:
         return None
     return value
 
@@ -247,8 +287,71 @@ def _build_ui_url(request: Request, path: str, query_params: Optional[dict] = No
     return url
 
 
+def _interactive_provider(provider_id: str):
+    """The provider a browser login may use, or None.
+
+    Only interactive providers are reachable here. A Kubernetes service-account issuer verifies
+    tokens exactly as an OIDC provider does but has no authorization endpoint to redirect to, so
+    naming it in a login URL must be a 404 rather than a broken redirect.
+    """
+    for provider in config.AUTH_PROVIDERS.interactive_providers():
+        if provider.id == provider_id:
+            return provider
+    return None
+
+
+@auth_router.get(PROVIDERS)
+async def providers(request: Request):
+    """List the providers a browser may log in with (#317's login picker reads this).
+
+    Deliberately unauthenticated and deliberately thin: an id, a label and a login URL. It is
+    reachable before anyone has logged in — that is its purpose — so it carries nothing beyond
+    what a login page has to render, and nothing about how a provider is configured.
+    """
+    return JSONResponse(
+        content={
+            "providers": [
+                {
+                    "id": provider.id,
+                    "display_name": provider.display_name or provider.id,
+                    "type": provider.type,
+                    "login_url": _absolute_path(request, f"{LOGIN}/{provider.id}"),
+                }
+                for provider in config.AUTH_PROVIDERS.interactive_providers()
+            ]
+        }
+    )
+
+
+def _absolute_path(request: Request, path: str) -> str:
+    """Join ``path`` onto the deployment's base URL, honouring any prefix."""
+    return str(request.base_url).rstrip("/") + path
+
+
+@auth_router.get(f"{LOGIN}/{{provider_id}}")
+async def login_with_provider(request: Request, provider_id: str):
+    """Begin a login against a named provider (#316).
+
+    The legacy ``/login`` is this with ``default``, so redirect URIs already registered at
+    customers' IdPs keep working.
+    """
+    if _interactive_provider(provider_id) is None:
+        raise HTTPException(status_code=404, detail="Unknown identity provider")
+    return await _begin_login(request, provider_id)
+
+
 @auth_router.get(LOGIN)
 async def login(request: Request):
+    """The legacy login, which is the ``default`` provider's.
+
+    ``provider_id`` is deliberately not a parameter of this handler: FastAPI would expose it as a
+    *query* parameter, and `?provider_id=` would then reach the flow without passing the
+    interactive-provider check that the path-scoped route applies.
+    """
+    return await _begin_login(request, DEFAULT_PROVIDER_ID)
+
+
+async def _begin_login(request: Request, provider_id: str):
     """
     Initiate OIDC login flow.
 
@@ -264,8 +367,8 @@ async def login(request: Request):
 
     try:
         # Check if OIDC is properly configured before proceeding
-        if not is_oidc_configured():
-            logger.error("OIDC is not properly configured")
+        if not is_oidc_configured(provider_id):
+            logger.error("OIDC is not properly configured for provider '%s'", provider_id)
             raise HTTPException(
                 status_code=500,
                 detail="OIDC authentication not available - configuration error",
@@ -274,43 +377,54 @@ async def login(request: Request):
         # Get session for storing OAuth state (using Starlette's built-in session)
         session = request.session
 
-        # Generate OAuth state for CSRF protection
-        oauth_state = secrets.token_urlsafe(32)
-        session["oauth_state"] = oauth_state
-
-        # Capture an optional ?next= return target so the callback can return
-        # the user to where they were before the session expired. Validated to
-        # be a same-origin relative path; anything else is dropped silently.
+        # Capture an optional ?next= return target so the callback can return the user to where
+        # they were before the session expired. Validated to be a same-origin relative path;
+        # anything else is dropped silently.
         next_target = _sanitize_next(request.query_params.get("next"))
-        if next_target:
-            session["redirect_after_login"] = next_target
+
+        # The CSRF state, and everything this attempt needs to remember, is a row rather than a
+        # cookie key (#316). One key held one attempt, so a second tab overwrote the first and
+        # whichever came back second failed a check it should have passed — and nothing recorded
+        # *which* provider had been asked, which is the question RFC 9207 exists to answer.
+        oauth_state = store.create_auth_state(provider_id, redirect_after_login=next_target)
 
         # Get redirect URI (configured or dynamic). Use a safe fallback if dynamic calculation fails
         try:
+            # The default provider keeps the legacy callback path: redirect URIs already
+            # registered at customers' IdPs must not break. Every other provider gets its own,
+            # which is what lets the callback know who is answering before it reads anything.
+            callback_path = CALLBACK if provider_id == DEFAULT_PROVIDER_ID else f"{CALLBACK}/{provider_id}"
             redirect_url = get_configured_or_dynamic_redirect_uri(
                 request=request,
-                callback_path=CALLBACK,
-                configured_uri=config.OIDC_REDIRECT_URI,
+                callback_path=callback_path,
+                configured_uri=config.OIDC_REDIRECT_URI if provider_id == DEFAULT_PROVIDER_ID else None,
             )
         except Exception as e:
             logger.warning(f"Failed to get dynamic redirect URI: {e}")
             # Fallback to base_url + callback when request.url or other internals are not available in tests
             base = str(getattr(request, "base_url", "http://localhost:8000"))
-            redirect_url = base.rstrip("/") + CALLBACK
+            redirect_url = base.rstrip("/") + (CALLBACK if provider_id == DEFAULT_PROVIDER_ID else f"{CALLBACK}/{provider_id}")
 
         logger.debug(f"OIDC redirect URL: {redirect_url}")
 
+        # ``default`` resolves to the legacy ``oauth.oidc`` client, so a deployment that never
+        # adopted the registry keeps the client it already had.
+        client = get_client(provider_id) or (oauth.oidc if provider_id == DEFAULT_PROVIDER_ID else None)
+        if client is None:
+            logger.error("No registered OAuth client for provider '%s'", provider_id)
+            raise HTTPException(status_code=500, detail="OIDC authentication not available")
+
         # Redirect to OIDC provider
         try:
-            if not hasattr(oauth.oidc, "authorize_redirect"):
+            if not hasattr(client, "authorize_redirect"):
                 logger.error("OIDC client authorize_redirect method not available")
                 raise HTTPException(status_code=500, detail="OIDC authentication not available")
 
             # PKCE is on by default (#312). Checked here so a provider that cannot do it says so
             # in one sentence, rather than as an unexplained ``invalid_grant`` at the exchange.
-            await assert_pkce_supported(oauth.oidc)
+            await assert_pkce_supported(client, provider_id)
 
-            return await oauth.oidc.authorize_redirect(  # type: ignore
+            return await client.authorize_redirect(  # type: ignore
                 request,
                 redirect_uri=redirect_url,
                 state=oauth_state,
@@ -467,8 +581,29 @@ async def logout(request: Request):
         return RedirectResponse(url=auth_url, status_code=302)
 
 
+@auth_router.get(f"{CALLBACK}/{{provider_id}}")
+async def callback_for_provider(request: Request, provider_id: str):
+    """Complete a login that began at ``/login/{provider_id}`` (#316).
+
+    A separate path per provider so an authorization response cannot be delivered to a provider
+    it did not come from — the first thing a mix-up attack tries.
+    """
+    if _interactive_provider(provider_id) is None:
+        raise HTTPException(status_code=404, detail="Unknown identity provider")
+    return await _complete_login(request, provider_id)
+
+
 @auth_router.get(CALLBACK)
 async def callback(request: Request):
+    """The legacy callback, for a login that began at ``/login``.
+
+    As with ``login``, the provider is not a query parameter — it comes from the path or not at
+    all, so the 404 gate on the scoped route cannot be stepped around.
+    """
+    return await _complete_login(request, None)
+
+
+async def _complete_login(request: Request, provider_id: Optional[str]):
     """
     Handle OIDC callback after authentication.
 
@@ -486,8 +621,8 @@ async def callback(request: Request):
     try:
         # Ensure OIDC client is registered (critical for multi-replica deployments)
         # This handles the case where callback hits a replica that hasn't registered the client yet
-        if not is_oidc_configured():
-            logger.error("OIDC is not properly configured when processing callback")
+        if not is_oidc_configured(provider_id or DEFAULT_PROVIDER_ID):
+            logger.error("OIDC is not properly configured when processing the callback for '%s'", provider_id or DEFAULT_PROVIDER_ID)
             auth_error_url = _build_ui_url(
                 request,
                 "/auth",
@@ -498,13 +633,11 @@ async def callback(request: Request):
         # Get session (using Starlette's built-in session)
         session = request.session
 
-        # A new login supersedes whatever this browser was carrying, and must not inherit any of
-        # it. This runs before the exchange because the exchange writes into the same cookie.
-        # ``oauth_state`` and ``redirect_after_login`` belong to *this* login and are untouched.
-        _retire_previous_login(session)
-
-        # Process OIDC callback using FastAPI-native implementation
-        username, errors = await _process_oidc_callback_fastapi(request, session)
+        # Process OIDC callback using FastAPI-native implementation. The state check inside is
+        # what makes this callback attributable to a login this browser started; nothing
+        # destructive may happen before it, or an unauthenticated cross-site GET to /callback
+        # would log the victim out on demand.
+        username, errors = await _process_oidc_callback_fastapi(request, session, provider_id=provider_id)
 
         if errors:
             # Handle authentication errors
@@ -595,13 +728,15 @@ async def auth_status(request: Request):
         raise HTTPException(status_code=500, detail="Failed to get authentication status")
 
 
-async def _process_oidc_callback_fastapi(request: Request, session) -> tuple[Optional[str], list[str]]:
+async def _process_oidc_callback_fastapi(request: Request, session, provider_id: Optional[str] = None) -> tuple[Optional[str], list[str]]:
     """
     Process the OIDC callback logic using FastAPI-native implementation.
 
     Args:
         request: FastAPI request object
         session: SessionManager instance
+        provider_id: The provider whose callback path this is, when it is a scoped one. The
+            attempt has to have been started at the same provider.
 
     Returns:
         Tuple of (username, error_list)
@@ -620,18 +755,56 @@ async def _process_oidc_callback_fastapi(request: Request, session) -> tuple[Opt
             errors.append(f"{safe_desc}")
         return None, errors
 
-    # State check for CSRF protection
+    # The attempt this callback belongs to. Consuming the row *is* the CSRF check: an unknown,
+    # already-used or expired state finds nothing, so a replayed authorization response — from a
+    # browser history entry, a proxy log, an attacker who captured the redirect — is refused
+    # rather than exchanged a second time (#316).
     state = request.query_params.get("state")
-    stored_state = session.get("oauth_state")
-    if not stored_state:
-        errors.append("Missing OAuth state in session")
-        return None, errors
-    if state != stored_state:
+    attempt = store.consume_auth_state(state or "")
+    if attempt is None:
         errors.append("Invalid state parameter")
         return None, errors
 
-    # Clear the OAuth state after validation
-    session.pop("oauth_state", None)
+    provider = config.AUTH_PROVIDERS.by_id(attempt.provider_id)
+    if provider is None:
+        # The provider was reconfigured or removed while this login was in flight. Refusing is
+        # the only safe answer: there is no policy left to apply to the response.
+        logger.error("Login attempt named provider '%s', which is no longer configured", attempt.provider_id)
+        errors.append("Identity provider is no longer configured")
+        return None, errors
+
+    if provider_id is not None and provider.id != provider_id:
+        # The response arrived at another provider's callback path. Nothing about a mix-up needs
+        # to be subtle: an attempt started at one provider cannot be completed at another's URL.
+        logger.error("Login attempt for provider '%s' arrived at the callback for '%s'", provider.id, provider_id)
+        errors.append("Invalid state parameter")
+        return None, errors
+
+    # RFC 9207: the response must say which issuer sent it, and it must be the one this
+    # transaction began with. An authorization response is otherwise unattributable — code and
+    # state look identical whichever authorization server produced them — which is the whole
+    # mix-up attack.
+    try:
+        validate_response_issuer(
+            request.query_params.getlist("iss") if hasattr(request.query_params, "getlist") else request.query_params.get("iss"),
+            provider.issuer,
+            iss_parameter_supported=await _iss_parameter_supported(provider),
+        )
+    except IssuerMismatchError as exc:
+        logger.error("Refusing an authorization response for provider '%s': %s", provider.id, exc)
+        errors.append("Authorization response came from an unexpected issuer")
+        return None, errors
+
+    session["redirect_after_login"] = attempt.redirect_after_login or session.get("redirect_after_login")
+
+    # A new login supersedes whatever this browser was carrying, and must not inherit any of it:
+    # _persist_session_auth below keeps an existing refresh token when the new response has none,
+    # so anything left here would be inherited by the next user (#351).
+    #
+    # Both halves of the placement matter. After the state check, because retiring a session for
+    # a callback that turned out to be forged would be a drive-by logout any page could trigger.
+    # Before the exchange, because the exchange writes this login's tokens into the same cookie.
+    _retire_previous_login(session)
 
     # Get authorization code
     code = request.query_params.get("code")
@@ -641,11 +814,11 @@ async def _process_oidc_callback_fastapi(request: Request, session) -> tuple[Opt
 
     try:
         # Exchange authorization code for tokens
-        if not hasattr(oauth.oidc, "authorize_access_token"):
+        if not hasattr(get_client(provider.id) or oauth.oidc, "authorize_access_token"):
             errors.append("OIDC configuration error: OAuth client not properly initialized.")
             return None, errors
 
-        token_response = await _authorize_access_token_with_key_refresh(request)
+        token_response = await _authorize_access_token_with_key_refresh(request, provider.id)
 
         if not token_response:
             errors.append("Failed to exchange authorization code")

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -79,9 +79,27 @@ async def _call_authorize_access_token(request: Request, provider_id: Optional[s
     derived from the response, which is the other half of the RFC 9207 defence.
     """
 
-    client = (get_client(provider_id) if provider_id else None) or oauth.oidc
+    client = _client_for_exchange(provider_id)
     token_call = client.authorize_access_token(request)  # type: ignore
     return await _maybe_await(token_call)
+
+
+def _client_for_exchange(provider_id: Optional[str]):
+    """The client whose token endpoint an authorization code may be exchanged at.
+
+    A named provider resolves to its own client or to nothing. Falling back to ``oauth.oidc``
+    would post a code minted by one issuer to another issuer's token endpoint, with that other
+    issuer's client id — handing one IdP a credential belonging to a different one, which is the
+    confusion the rest of this flow exists to prevent.
+    """
+    if provider_id and provider_id != DEFAULT_PROVIDER_ID:
+        client = get_client(provider_id)
+        if client is None:
+            raise RuntimeError(f"No registered OAuth client for provider '{provider_id}'")
+        return client
+    # ``default`` keeps resolving to the legacy client, for a deployment that never adopted the
+    # registry.
+    return get_client(DEFAULT_PROVIDER_ID) or oauth.oidc
 
 
 async def _authorize_access_token_with_key_refresh(
@@ -340,7 +358,18 @@ async def providers(request: Request):
 
 
 def _absolute_path(request: Request, path: str) -> str:
-    """Join ``path`` onto the deployment's base URL, honouring any prefix."""
+    """Join ``path`` onto the deployment's own base URL.
+
+    Prefers the configured redirect URI's origin over ``request.base_url``, which is the ``Host``
+    header. These URLs are the buttons a login page offers, on an unauthenticated and cacheable
+    endpoint: one poisoned response would otherwise send every later visitor to an attacker's
+    host to authenticate.
+    """
+    configured = getattr(config, "OIDC_REDIRECT_URI", None)
+    if configured:
+        parsed = urlparse(configured)
+        if parsed.scheme and parsed.netloc:
+            return f"{parsed.scheme}://{parsed.netloc}{path}"
     return str(request.base_url).rstrip("/") + path
 
 
@@ -789,10 +818,13 @@ async def _process_oidc_callback_fastapi(request: Request, session, provider_id:
         errors.append("Identity provider is no longer configured")
         return None, errors
 
-    if provider_id is not None and provider.id != provider_id:
-        # The response arrived at another provider's callback path. Nothing about a mix-up needs
-        # to be subtle: an attempt started at one provider cannot be completed at another's URL.
-        logger.error("Login attempt for provider '%s' arrived at the callback for '%s'", provider.id, provider_id)
+    # The response has to arrive at the callback belonging to the provider the attempt started
+    # at. ``provider_id`` is None on the legacy unscoped path, which belongs to ``default`` — not
+    # to "whoever asks". Treating None as "no opinion" would let anyone who can deliver a
+    # response to the unscoped URL opt out of the path check entirely.
+    expected_callback_provider = provider_id if provider_id is not None else DEFAULT_PROVIDER_ID
+    if provider.id != expected_callback_provider:
+        logger.error("Login attempt for provider '%s' arrived at the callback for '%s'", provider.id, expected_callback_provider)
         errors.append("Invalid state parameter")
         return None, errors
 
@@ -830,7 +862,14 @@ async def _process_oidc_callback_fastapi(request: Request, session, provider_id:
 
     try:
         # Exchange authorization code for tokens
-        if not hasattr(get_client(provider.id) or oauth.oidc, "authorize_access_token"):
+        try:
+            exchange_client = _client_for_exchange(provider.id)
+        except RuntimeError as client_error:
+            logger.error("%s", client_error)
+            errors.append("OIDC configuration error: OAuth client not properly initialized.")
+            return None, errors
+
+        if not hasattr(exchange_client, "authorize_access_token"):
             errors.append("OIDC configuration error: OAuth client not properly initialized.")
             return None, errors
 

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -17,6 +17,8 @@ from fastapi.responses import JSONResponse, RedirectResponse
 
 from mlflow_oidc_auth.audit import emit_audit_event
 from mlflow_oidc_auth.authorization_response import IssuerMismatchError, validate_response_issuer
+from mlflow_oidc_auth.identity_resolution import IdentityDecision, Resolution, resolve_identity
+from mlflow_oidc_auth.provisioning_policy import admin_from_claims, apply_provisioning_policy, groups_to_apply
 from mlflow_oidc_auth.config import config
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.provider_registry import DEFAULT_PROVIDER_ID
@@ -230,6 +232,20 @@ async def _iss_parameter_supported(provider) -> bool:
         logger.debug("Could not load metadata for the RFC 9207 check on '%s': %s", provider.id, exc)
         return False
     return bool(metadata.get("authorization_response_iss_parameter_supported"))
+
+
+def _current_groups(username: str) -> Optional[list]:
+    """The user's groups as stored, for an additive sync, or None when they cannot be read.
+
+    None rather than an empty list: an additive sync that reads an unreadable membership as empty
+    writes only the claimed groups, which *deletes* everything managed elsewhere — the exact
+    thing the additive mode exists to prevent.
+    """
+    try:
+        return list(store.get_groups_for_user(username))
+    except Exception as exc:
+        logger.warning("Could not read current groups for %s: %s", username, exc)
+        return None
 
 
 def _sanitize_next(value: Optional[str]) -> Optional[str]:
@@ -867,17 +883,119 @@ async def _process_oidc_callback_fastapi(request: Request, session, provider_id:
 
             logger.debug(f"User groups: {user_groups}")
 
-            # Check authorization
-            # Determine admin and allowed groups
-            is_admin = any(group in user_groups for group in config.OIDC_ADMIN_GROUP_NAME)
+            # Whether this provider may confer administrator rights at all, and whether these
+            # claims do (#318). ``admin_source: none`` is the answer for a partner tenant whose
+            # group names you do not control; the admin group name itself stays server-side.
+            is_admin = admin_from_claims(provider, user_groups, config.OIDC_ADMIN_GROUP_NAME)
             if not is_admin and not any(group in user_groups for group in config.OIDC_GROUP_NAME):
                 errors.append("User is not allowed to login")
                 return None, errors
 
-            # Create/update user and groups using user_module so monkeypatched functions are used in tests
-            user_module.create_user(username=username, display_name=display_name, is_admin=is_admin)
-            user_module.populate_groups(group_names=user_groups)
-            user_module.update_user(username=username, group_names=user_groups)
+            # Which local user this identity reaches (#309), and whether this provider may bring
+            # it into existence (#318). Together these are what make a second provider safe: an
+            # unknown (provider, subject) is a *new* principal, never matched to an existing
+            # account by anything the token says about them, and a name already taken by another
+            # identity is refused rather than claimed.
+            subject = userinfo.get("sub")
+            if not isinstance(subject, str) or not subject.strip():
+                if provider.id == DEFAULT_PROVIDER_ID:
+                    # Today's behaviour, preserved. The single-provider login has never read
+                    # ``sub`` — it names accounts from the configured claim fields — and a
+                    # provider whose userinfo omits it (non-conformant, but deployed) would
+                    # otherwise stop working on upgrade. There is nothing to confuse it with:
+                    # one provider means one identity space.
+                    logger.debug("No subject in userinfo for the default provider; using the derived username")
+                    subject = None
+                else:
+                    logger.warning("Provider '%s' asserted no subject; refusing", provider.id)
+                    errors.append("This account cannot be used to sign in here")
+                    return None, errors
+
+            def _providers_bound_to(name: str) -> list:
+                try:
+                    return list(store.user_identity_repo.list_providers_for_username(name))
+                except Exception as lookup_error:
+                    # Fail closed: an unknown binding set must not read as "bound to nobody",
+                    # which is what would let a provider adopt someone else's account.
+                    logger.warning("Could not read bound providers for %s: %s", name, lookup_error)
+                    return ["<unknown>"]
+
+            if subject is None:
+                # The default provider whose userinfo carries no subject — non-conformant, but
+                # deployed, and it worked before. The username is the identity, as it always was.
+                decision = IdentityDecision(Resolution.CREATE, reason="no subject asserted")
+            else:
+                decision = resolve_identity(
+                    provider,
+                    subject,
+                    userinfo,
+                    store.user_identity_repo,
+                    user_lookup=store.has_user,
+                    username=username,
+                )
+
+            outcome = apply_provisioning_policy(
+                provider,
+                decision,
+                derived_username=username,
+                user_exists=store.has_user,
+                providers_bound_to=_providers_bound_to,
+            )
+            if not outcome.allowed:
+                logger.warning("Refusing login via provider '%s': %s", provider.id, outcome.reason)
+                emit_audit_event(
+                    "auth.identity_refused",
+                    actor=username,
+                    resource_type="user",
+                    resource_id=username,
+                    detail={"provider": provider.id, "reason": outcome.reason},
+                    status="denied",
+                )
+                errors.append("This account cannot be used to sign in here")
+                return None, errors
+
+            username = outcome.username or username
+
+            if outcome.create or provider.admin_source == "claims":
+                # ``create_user`` updates an existing row, so this is also how administrator
+                # status is *revoked*: losing the admin group has always demoted the user at
+                # their next login, and a provider allowed to grant admin must be allowed to take
+                # it away. A provider with ``admin_source: none`` says nothing either way, so it
+                # neither promotes nor demotes.
+                user_module.create_user(username=username, display_name=display_name, is_admin=is_admin)
+
+            # Bind the identity so the next login matches on it rather than on a claim.
+            #
+            # A failure here fails the login. Continuing would leave a user row with no binding,
+            # so every later login for this subject would take the create path, find the name
+            # taken and be refused — a permanent lockout from one transient error. It also means
+            # a login racing another provider's is refused rather than quietly issued a session
+            # for an account it does not own.
+            if subject:
+                try:
+                    store.user_identity_repo.link(provider.id, subject.strip(), username)
+                except Exception as link_error:
+                    logger.error("Could not bind identity for %s at provider '%s': %s", username, provider.id, link_error)
+                    emit_audit_event(
+                        "auth.identity_bind_failed",
+                        actor=username,
+                        resource_type="user",
+                        resource_id=username,
+                        detail={"provider": provider.id},
+                        status="denied",
+                    )
+                    errors.append("Could not complete sign-in for this account")
+                    return None, errors
+
+            groups = groups_to_apply(
+                provider,
+                user_groups,
+                _current_groups(username),
+                is_new_user=outcome.create,
+            )
+            if groups is not None:
+                user_module.populate_groups(group_names=groups)
+                user_module.update_user(username=username, group_names=groups)
 
             # Workspace detection (per D-07, D-08, WSOIDC-01/02/03)
             # Layered approach: plugin first, JWT claim fallback, then auto-assign

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -64,6 +64,7 @@ from mlflow_oidc_auth.repository import (
     UserRepository,
     UserIdentityRepository,
     AuthSessionRepository,
+    AuthStateRepository,
     WorkspacePermissionRepository,
     WorkspaceGroupPermissionRepository,
 )
@@ -86,6 +87,7 @@ class SqlAlchemyStore:
         self.user_repo = UserRepository(self.ManagedSessionMaker)
         self.user_identity_repo = UserIdentityRepository(self.ManagedSessionMaker)
         self.auth_session_repo = AuthSessionRepository(self.ManagedSessionMaker)
+        self.auth_state_repo = AuthStateRepository(self.ManagedSessionMaker)
         self.experiment_repo = ExperimentPermissionRepository(self.ManagedSessionMaker)
         self.experiment_group_repo = ExperimentPermissionGroupRepository(self.ManagedSessionMaker)
         self.group_repo = GroupRepository(self.ManagedSessionMaker)
@@ -330,6 +332,14 @@ class SqlAlchemyStore:
     def create_auth_session(self, username: str, expires_at, provider_id: Optional[str] = None) -> str:
         """Open a server-side session and return its opaque id (issue #310)."""
         return self.auth_session_repo.create(username, expires_at, provider_id)
+
+    def create_auth_state(self, provider_id: str, **kwargs) -> str:
+        """Start a login attempt and return its ``state`` (issue #316)."""
+        return self.auth_state_repo.create(provider_id, **kwargs)
+
+    def consume_auth_state(self, state: str):
+        """Take the login attempt named by ``state``, removing it. None if there is none."""
+        return self.auth_state_repo.consume(state)
 
     def resolve_auth_session(self, session_id: str):
         """Resolve a session id to its user in one statement, or None if it is not honoured."""

--- a/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
+++ b/mlflow_oidc_auth/tests/middleware/test_bearer_provisioning.py
@@ -26,7 +26,10 @@ def provider_carries_the_configured_scoping(monkeypatch):
         cfg = middleware_module.config
         # ``type`` matters since #314: a k8s provider takes the service-account path instead of
         # the group gate these cases describe.
-        return SimpleNamespace(id="default", type="oidc", audience=cfg.OIDC_AUDIENCE, issuer=cfg.OIDC_ISSUER)
+        # ``admin_source`` matters since #318: a provider that may not assert administrator
+        # status cannot mint one through this path either. These cases describe the deployment's
+        # own provider, which may.
+        return SimpleNamespace(id="default", type="oidc", admin_source="claims", audience=cfg.OIDC_AUDIENCE, issuer=cfg.OIDC_ISSUER)
 
     monkeypatch.setattr(auth_module, "resolve_token_provider", resolve)
 
@@ -207,3 +210,30 @@ class TestRobustness:
             store.has_user.return_value = False
             # must not raise
             _mw()._maybe_provision_bearer_user("a@x.com", "tok", {"groups": ["mlflow-users"]})
+
+
+class TestTheProviderMustBeAllowedToConferAdmin:
+    """#318: ``OIDC_TRUST_BEARER_GROUP_CLAIMS`` says the operator trusts group claims; the
+    provider's ``admin_source`` says whether *this* provider's claims may say "administrator"."""
+
+    def test_a_provider_with_no_admin_source_cannot_mint_an_admin(self, monkeypatch):
+        import mlflow_oidc_auth.auth as auth_module
+
+        monkeypatch.setattr(
+            auth_module,
+            "resolve_token_provider",
+            lambda token: SimpleNamespace(id="partner", type="oidc", admin_source="none", audience="mlflow", issuer="https://partner.invalid"),
+        )
+
+        with (
+            patch("mlflow_oidc_auth.middleware.auth_middleware.config") as cfg,
+            patch("mlflow_oidc_auth.middleware.auth_middleware.store") as store,
+            patch("mlflow_oidc_auth.user.create_user") as create_user,
+            patch("mlflow_oidc_auth.user.populate_groups"),
+            patch("mlflow_oidc_auth.user.update_user"),
+        ):
+            _cfg(cfg, OIDC_TRUST_BEARER_GROUP_CLAIMS=True)
+            store.has_user.return_value = False
+            _mw()._maybe_provision_bearer_user("a@x.com", "tok", {"groups": ["mlflow-admins"]})
+
+        assert create_user.call_args.kwargs["is_admin"] is False

--- a/mlflow_oidc_auth/tests/repository/test_auth_state.py
+++ b/mlflow_oidc_auth/tests/repository/test_auth_state.py
@@ -1,0 +1,117 @@
+"""In-flight authorization state as rows (issue #316).
+
+The state used to be one ``oauth_state`` key in the cookie, which cannot hold two logins and
+cannot say which provider started one. Both are what these cases pin.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+@pytest.fixture
+def store(tmp_path):
+    from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+    s = SqlAlchemyStore()
+    s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+    yield s
+    s.engine.dispose()
+
+
+class TestAnAttemptRoundTrips:
+    def test_what_was_started_is_what_comes_back(self, store):
+        state = store.create_auth_state("entra", redirect_after_login="/oidc/ui/models")
+
+        attempt = store.consume_auth_state(state)
+
+        assert attempt.provider_id == "entra"
+        assert attempt.redirect_after_login == "/oidc/ui/models"
+
+    def test_the_state_is_unguessable(self, store):
+        """It is the only thing tying a callback to the attempt that started it."""
+        first = store.create_auth_state("entra")
+        second = store.create_auth_state("entra")
+
+        assert first != second
+        assert len(first) >= 32
+        assert "entra" not in first
+
+
+class TestTwoTabsDoNotClobberEachOther:
+    """The concrete bug a single cookie key caused: start a login in one tab, start another in a
+    second, and the first tab's callback failed a CSRF check it should have passed."""
+
+    def test_both_attempts_survive(self, store):
+        first = store.create_auth_state("entra", redirect_after_login="/first")
+        second = store.create_auth_state("okta", redirect_after_login="/second")
+
+        assert store.consume_auth_state(first).redirect_after_login == "/first"
+        assert store.consume_auth_state(second).redirect_after_login == "/second"
+
+    def test_they_can_come_back_in_either_order(self, store):
+        first = store.create_auth_state("entra")
+        second = store.create_auth_state("okta")
+
+        assert store.consume_auth_state(second).provider_id == "okta"
+        assert store.consume_auth_state(first).provider_id == "entra"
+
+
+class TestAnAttemptIsSingleUse:
+    def test_the_second_use_finds_nothing(self, store):
+        """A callback replayed from a browser history entry, a proxy log, or an attacker who
+        captured the redirect must not be exchanged a second time."""
+        state = store.create_auth_state("entra")
+
+        assert store.consume_auth_state(state) is not None
+        assert store.consume_auth_state(state) is None
+
+    def test_an_unknown_state_finds_nothing(self, store):
+        assert store.consume_auth_state("never-issued") is None
+
+    def test_an_empty_state_finds_nothing(self, store):
+        assert store.consume_auth_state("") is None
+
+
+class TestExpiry:
+    def test_an_expired_attempt_is_refused(self, store):
+        state = store.create_auth_state("entra", lifetime_seconds=-1)
+
+        assert store.consume_auth_state(state) is None
+
+    def test_an_expired_attempt_is_still_consumed(self, store):
+        """Refusing it is not enough — the row goes, so a stale state cannot be retried until it
+        happens to race something."""
+        state = store.create_auth_state("entra", lifetime_seconds=-1)
+        store.consume_auth_state(state)
+
+        assert store.auth_state_repo.delete_expired() == 0
+
+    def test_abandoned_attempts_can_be_swept(self, store):
+        store.create_auth_state("entra", lifetime_seconds=-1)
+        live = store.create_auth_state("entra")
+
+        assert store.auth_state_repo.delete_expired() == 1
+        assert store.consume_auth_state(live) is not None
+
+
+class TestConcurrentCallbacks:
+    def test_only_one_of_two_racing_consumers_gets_the_attempt(self, store):
+        """Two callbacks arriving with the same state — the victim's real one and a captured copy
+        replayed at the same moment. Exactly one may proceed."""
+        import threading
+
+        state = store.create_auth_state("entra")
+        results = []
+        barrier = threading.Barrier(2)
+
+        def consume():
+            barrier.wait()
+            results.append(store.consume_auth_state(state))
+
+        threads = [threading.Thread(target=consume) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert sorted(result is None for result in results) == [False, True], f"expected exactly one winner, got {results}"

--- a/mlflow_oidc_auth/tests/repository/test_auth_state.py
+++ b/mlflow_oidc_auth/tests/repository/test_auth_state.py
@@ -4,8 +4,6 @@ The state used to be one ``oauth_state`` key in the cookie, which cannot hold tw
 cannot say which provider started one. Both are what these cases pin.
 """
 
-from datetime import datetime, timedelta, timezone
-
 import pytest
 
 

--- a/mlflow_oidc_auth/tests/repository/test_auth_state.py
+++ b/mlflow_oidc_auth/tests/repository/test_auth_state.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+
 @pytest.fixture
 def store(tmp_path):
     from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore

--- a/mlflow_oidc_auth/tests/routers/conftest.py
+++ b/mlflow_oidc_auth/tests/routers/conftest.py
@@ -298,6 +298,17 @@ def mock_config():
     config_mock.OIDC_GROUP_NAME = ["user-group", "test-group"]
     config_mock.OIDC_GEN_AI_GATEWAY_ENABLED = False
     config_mock.MLFLOW_ENABLE_WORKSPACES = False
+
+    # A real registry, not a MagicMock: since #316 the callback looks the provider up here and
+    # then uses its id and issuer. A mock would hand those paths a MagicMock where a string is
+    # required, which fails in ways that say nothing about the case under test.
+    from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+
+    config_mock.AUTH_PROVIDERS = RegistryLoadResult(
+        providers=[ProviderConfig(id="default", type="oidc", display_name="Test Provider", audience="mlflow")],
+        errors=[],
+        source="legacy",
+    )
     return config_mock
 
 

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -86,7 +86,7 @@ class TestLoginEndpoint:
     """Test the login endpoint functionality."""
 
     @pytest.mark.asyncio
-    async def test_login_success(self, mock_request_with_session, mock_oauth, mock_config):
+    async def test_login_success(self, mock_request_with_session, mock_oauth, mock_config, created_states):
         """Test successful login initiation."""
         request = mock_request_with_session({"oauth_state": None})
 
@@ -103,7 +103,9 @@ class TestLoginEndpoint:
             await login(request)
 
             # Verify state was set in session
-            assert request.session["oauth_state"] == "test_state_token"
+            # The attempt is a row now, not a cookie key: what login must do is start one and
+            # send its state to the provider (#316).
+            assert created_states, "login must record an attempt"
 
             # Verify OAuth redirect was called
             mock_oauth.oidc.authorize_redirect.assert_called_once_with(
@@ -113,7 +115,7 @@ class TestLoginEndpoint:
             )
 
     @pytest.mark.asyncio
-    async def test_login_captures_safe_next_param(self, mock_request_with_session, mock_oauth, mock_config):
+    async def test_login_captures_safe_next_param(self, mock_request_with_session, mock_oauth, mock_config, created_states):
         """``/login?next=<relative-path>`` is stored so the callback can return there."""
         request = mock_request_with_session({"oauth_state": None})
         request.query_params = {"next": "/oidc/ui/groups"}
@@ -127,7 +129,9 @@ class TestLoginEndpoint:
             mock_redirect.return_value = "http://localhost:8000/callback"
             await login(request)
 
-        assert request.session["redirect_after_login"] == "/oidc/ui/groups"
+        # The return target travels with the attempt, not in the cookie: a second tab starting
+        # its own login would otherwise overwrite where the first one meant to come back to.
+        assert created_states[-1]["redirect_after_login"] == "/oidc/ui/groups"
 
     @pytest.mark.asyncio
     async def test_login_drops_unsafe_next_param(self, mock_request_with_session, mock_oauth, mock_config):
@@ -507,7 +511,7 @@ class TestProcessOIDCCallbackFastAPI:
         assert "User denied access" in errors[1]
 
     @pytest.mark.asyncio
-    async def test_process_callback_missing_state(self, mock_request_with_session):
+    async def test_process_callback_missing_state(self, mock_request_with_session, no_attempt):
         """Test callback processing with missing OAuth state."""
         request = mock_request_with_session({})  # No oauth_state in session
         request.query_params = {"state": "test_state", "code": "auth_code_123"}
@@ -516,10 +520,12 @@ class TestProcessOIDCCallbackFastAPI:
 
         assert email is None
         assert len(errors) == 1
-        assert "Missing OAuth state in session" in errors[0]
+        # "Missing" and "wrong" give the same answer now — the row is the check, and telling
+        # them apart would tell an attacker which of the two they had.
+        assert "Invalid state parameter" in errors[0]
 
     @pytest.mark.asyncio
-    async def test_process_callback_invalid_state(self, mock_request_with_session):
+    async def test_process_callback_invalid_state(self, mock_request_with_session, no_attempt):
         """Test callback processing with invalid OAuth state."""
         request = mock_request_with_session({"oauth_state": "correct_state"})
         request.query_params = {"state": "wrong_state", "code": "auth_code_123"}
@@ -935,3 +941,56 @@ class TestSanitizeNext:
         assert _sanitize_next(None) is None
         assert _sanitize_next("") is None
         assert _sanitize_next("no-leading-slash") is None
+
+
+@pytest.fixture(autouse=True)
+def in_flight_login_attempt(monkeypatch):
+    """Answer the callback's state lookup with a live attempt (#316).
+
+    The CSRF state moved out of the cookie and into an ``auth_state`` row, so a callback test
+    that seeds ``session["oauth_state"]`` no longer describes anything. This stands in for the
+    row: any non-empty ``state`` resolves to an attempt at the ``default`` provider, which is
+    what these cases were always about — the user-management half of the callback.
+
+    The state machinery itself is tested directly in ``test_auth_state.py`` and
+    ``test_provider_login.py``.
+    """
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+    from mlflow_oidc_auth.repository.auth_state import AuthAttempt
+
+    monkeypatch.setattr(
+        auth_router_mod.store,
+        "consume_auth_state",
+        lambda state: AuthAttempt(state=state, provider_id="default") if state else None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auth_router_mod.config,
+        "AUTH_PROVIDERS",
+        RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
+        raising=False,
+    )
+
+
+@pytest.fixture
+def created_states(monkeypatch):
+    """Record the login attempts ``login`` starts, in place of the old cookie key."""
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+
+    recorded = []
+
+    def create(provider_id, **kwargs):
+        recorded.append({"provider_id": provider_id, **kwargs})
+        return "test_state_token"
+
+    monkeypatch.setattr(auth_router_mod.store, "create_auth_state", create, raising=False)
+    return recorded
+
+
+@pytest.fixture
+def no_attempt(monkeypatch):
+    """No in-flight attempt matches — an unknown, replayed or expired state."""
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+
+    monkeypatch.setattr(auth_router_mod.store, "consume_auth_state", lambda state: None, raising=False)

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -955,7 +955,7 @@ def in_flight_login_attempt(monkeypatch):
     The state machinery itself is tested directly in ``test_auth_state.py`` and
     ``test_provider_login.py``.
     """
-    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.routers import auth as auth_router_mod
     from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
     from mlflow_oidc_auth.repository.auth_state import AuthAttempt
 
@@ -994,7 +994,7 @@ def in_flight_login_attempt(monkeypatch):
 @pytest.fixture
 def created_states(monkeypatch):
     """Record the login attempts ``login`` starts, in place of the old cookie key."""
-    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.routers import auth as auth_router_mod
 
     recorded = []
 
@@ -1009,6 +1009,6 @@ def created_states(monkeypatch):
 @pytest.fixture
 def no_attempt(monkeypatch):
     """No in-flight attempt matches — an unknown, replayed or expired state."""
-    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.routers import auth as auth_router_mod
 
     monkeypatch.setattr(auth_router_mod.store, "consume_auth_state", lambda state: None, raising=False)

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -972,6 +972,24 @@ def in_flight_login_attempt(monkeypatch):
         raising=False,
     )
 
+    # Identity resolution and provisioning policy (#318) run inside the callback now, so the
+    # store has to answer two questions: is this username taken, and is this identity bound.
+    # A fresh principal at a jit provider — which is what these cases describe.
+    class _Identities:
+        def __init__(self):
+            self.bound = {}
+
+        def get_username_by_identity(self, provider_id, subject):
+            return self.bound.get((provider_id, subject))
+
+        def link(self, provider_id, subject, username, **kwargs):
+            self.bound[(provider_id, subject)] = username
+            return True
+
+    monkeypatch.setattr(auth_router_mod.store, "user_identity_repo", _Identities(), raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "has_user", lambda username: False, raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "get_groups_for_user", lambda username: [], raising=False)
+
 
 @pytest.fixture
 def created_states(monkeypatch):

--- a/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
@@ -234,7 +234,7 @@ class TestOidcWorkspaceAutoCreate:
 @pytest.fixture(autouse=True)
 def in_flight_login_attempt(monkeypatch):
     """Stand in for the ``auth_state`` row the callback consumes (#316)."""
-    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.routers import auth as auth_router_mod
     from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
     from mlflow_oidc_auth.repository.auth_state import AuthAttempt
 

--- a/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
@@ -31,6 +31,11 @@ class TestOidcWorkspaceAutoCreate:
         config_mock.OIDC_WORKSPACE_DETECTION_PLUGIN = plugin
         config_mock.OIDC_WORKSPACE_CLAIM_NAME = claim
         config_mock.OIDC_WORKSPACE_DEFAULT_PERMISSION = "READ"
+        # A real registry: the callback looks the provider up here since #316 and then uses its
+        # id, which a MagicMock cannot stand in for.
+        from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+
+        config_mock.AUTH_PROVIDERS = RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy")
         config_mock.OIDC_GROUP_DETECTION_PLUGIN = None
         config_mock.OIDC_GROUPS_ATTRIBUTE = "groups"
         config_mock.OIDC_ADMIN_GROUP_NAME = ["admin-group"]
@@ -224,3 +229,24 @@ class TestOidcWorkspaceAutoCreate:
 
         assert email == "user@example.com"
         assert errors == []
+
+
+@pytest.fixture(autouse=True)
+def in_flight_login_attempt(monkeypatch):
+    """Stand in for the ``auth_state`` row the callback consumes (#316)."""
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+    from mlflow_oidc_auth.repository.auth_state import AuthAttempt
+
+    monkeypatch.setattr(
+        auth_router_mod.store,
+        "consume_auth_state",
+        lambda state: AuthAttempt(state=state, provider_id="default") if state else None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auth_router_mod.config,
+        "AUTH_PROVIDERS",
+        RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
+        raising=False,
+    )

--- a/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth_workspace_autocreate.py
@@ -250,3 +250,21 @@ def in_flight_login_attempt(monkeypatch):
         RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
         raising=False,
     )
+
+    # Identity resolution and provisioning policy (#318) run inside the callback now, so the
+    # store has to answer two questions: is this username taken, and is this identity bound.
+    # A fresh principal at a jit provider — which is what these cases describe.
+    class _Identities:
+        def __init__(self):
+            self.bound = {}
+
+        def get_username_by_identity(self, provider_id, subject):
+            return self.bound.get((provider_id, subject))
+
+        def link(self, provider_id, subject, username, **kwargs):
+            self.bound[(provider_id, subject)] = username
+            return True
+
+    monkeypatch.setattr(auth_router_mod.store, "user_identity_repo", _Identities(), raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "has_user", lambda username: False, raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "get_groups_for_user", lambda username: [], raising=False)

--- a/mlflow_oidc_auth/tests/test_pkce_default.py
+++ b/mlflow_oidc_auth/tests/test_pkce_default.py
@@ -217,7 +217,7 @@ class TestTheErrorReachesTheUser:
             # imported here may not be the one its ``except`` clause names.
             raise auth_router_mod.PKCEUnsupportedError("Provider 'default' does not support the configured PKCE method 'S256'. Set OIDC_CODE_CHALLENGE to ...")
 
-        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
         monkeypatch.setattr(auth_router_mod, "assert_pkce_supported", _unsupported)
         # A registered client has to exist, or login fails earlier for an unrelated reason.
         monkeypatch.setattr(auth_router_mod.oauth, "oidc", SimpleNamespace(authorize_redirect=_never_called), raising=False)
@@ -258,7 +258,17 @@ class TestTheErrorReachesTheUser:
         async def _no_refresh():
             return None
 
+        from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+        from mlflow_oidc_auth.repository.auth_state import AuthAttempt
+
         monkeypatch.setattr(auth_router_mod, "_call_authorize_access_token", _boom)
+        monkeypatch.setattr(auth_router_mod.store, "consume_auth_state", lambda state: AuthAttempt(state=state, provider_id="default"), raising=False)
+        monkeypatch.setattr(
+            auth_router_mod.config,
+            "AUTH_PROVIDERS",
+            RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
+            raising=False,
+        )
         monkeypatch.setattr(auth_router_mod, "_refresh_oidc_jwks", _no_refresh)
         monkeypatch.setattr(auth_router_mod.oauth, "oidc", SimpleNamespace(authorize_access_token=_boom), raising=False)
 

--- a/mlflow_oidc_auth/tests/test_provider_login.py
+++ b/mlflow_oidc_auth/tests/test_provider_login.py
@@ -311,16 +311,12 @@ class TestTheProviderCannotComeFromTheQueryString:
         assert "provider_id" not in inspect.signature(auth_router_mod.callback).parameters
 
 
-class TestASecondInteractiveProviderIsRefusedForNow:
-    """#316 gives every provider a login route and defends the mix-up attack. What it does not
-    give is per-provider identity: the username field, the groups attribute and the admin group
-    are still read from deployment-wide configuration, and the user row is not namespaced by
-    provider.
+class TestASecondProviderCanNowLogIn:
+    """#318 landed with this branch, so the hold-back is gone.
 
-    A second interactive provider on top of that is account takeover, not a feature — a
-    contractor tenant asserting ``email: alice@corp.com`` would land on Alice's account. #318 is
-    what makes provisioning and identity binding per-provider; until then this is refused at
-    load rather than shipped.
+    What makes it safe is not the login route — it is that an unbound identity from a second
+    provider is a *new* principal (#309) and cannot take a username someone else already answers
+    to (#318). Those are asserted in ``test_provisioning_policy.py``; this is the plumbing.
     """
 
     @staticmethod
@@ -358,48 +354,17 @@ class TestASecondInteractiveProviderIsRefusedForNow:
         entry.update(overrides)
         return entry
 
-    def test_a_second_provider_gets_no_login_button(self, caplog):
-        """Coerced off rather than rejected: the entry is still a usable *token* provider, and
-        only the browser flow is unsafe."""
-        with caplog.at_level("WARNING"):
-            result = self._build([self._entry(interactive=True)])
+    def test_a_second_provider_is_interactive(self):
+        result = self._build([self._entry(interactive=True)])
 
         assert [provider.id for provider in result.providers] == ["okta"]
-        assert result.providers[0].interactive is False
-        assert result.interactive_providers() == []
-        assert any("#318" in record.getMessage() for record in caplog.records)
+        assert result.providers[0].interactive is True
+        assert [provider.id for provider in result.interactive_providers()] == ["okta"]
 
-    def test_the_same_provider_is_fine_for_bearer_tokens(self):
-        """Only the browser flow is gated: a token from this issuer is validated per-provider
-        already (#313), and none of the identity questions arise."""
+    def test_a_provider_can_still_be_bearer_only(self):
         result = self._build([self._entry(interactive=False)])
 
-        assert [provider.id for provider in result.providers] == ["okta"]
-
-    def test_the_default_provider_is_unaffected(self):
-        assert build_default().providers[0].interactive is True
-
-
-def build_default():
-    from types import SimpleNamespace as NS
-
-    from mlflow_oidc_auth.provider_registry import build_provider_registry
-
-    class Manager:
-        @staticmethod
-        def get(key, default=None):
-            return default
-
-    return build_provider_registry(
-        Manager(),
-        NS(
-            OIDC_PROVIDER_DISPLAY_NAME="Login with OIDC",
-            OIDC_AUDIENCE=None,
-            OIDC_ISSUER=None,
-            OIDC_DISCOVERY_URL="https://idp.example.com/.well-known/openid-configuration",
-            OIDC_CLIENT_ID="client",
-        ),
-    )
+        assert result.interactive_providers() == []
 
 
 class TestTheReturnTargetCannotLeaveTheOrigin:
@@ -416,3 +381,102 @@ class TestTheReturnTargetCannotLeaveTheOrigin:
     @pytest.mark.parametrize("target", ["/users", "/oidc/ui/groups", "/#/experiments/0", "/a?b=c"])
     def test_real_paths_survive(self, target):
         assert auth_router_mod._sanitize_next(target) == target
+
+
+class TestAnExistingUserCanStillLogIn:
+    """The path every user of every upgraded deployment takes, driven through the callback
+    itself rather than the policy function.
+
+    The unit tests for adoption live in ``test_provisioning_policy.py``; this is here because the
+    callback fixtures elsewhere patch ``has_user`` to False, so the existing-user branch was
+    never exercised end to end — which is exactly how a change that locked out every existing
+    user passed a green suite.
+    """
+
+    @pytest.fixture
+    def existing_user_callback(self, monkeypatch):
+        registry = RegistryLoadResult(
+            providers=[ProviderConfig(id="default", type="oidc", audience="mlflow", issuer=ENTRA)],
+            errors=[],
+            source="legacy",
+        )
+        monkeypatch.setattr(auth_router_mod.config, "AUTH_PROVIDERS", registry, raising=False)
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_GROUP_DETECTION_PLUGIN", None, raising=False)
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_GROUPS_ATTRIBUTE", "groups", raising=False)
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_GROUP_NAME", ["mlflow"], raising=False)
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_ADMIN_GROUP_NAME", ["mlflow-admin"], raising=False)
+        monkeypatch.setattr(auth_router_mod.config, "MLFLOW_ENABLE_WORKSPACES", False, raising=False)
+        monkeypatch.setattr(
+            auth_router_mod.store,
+            "consume_auth_state",
+            lambda state: AuthAttempt(state=state, provider_id="default"),
+            raising=False,
+        )
+
+        class _Identities:
+            """The state the Phase 0 backfill leaves: a legacy row keyed on the username."""
+
+            def __init__(self):
+                self.bound = {("default", "alice@corp.com"): "alice@corp.com"}
+                self.links = []
+
+            def get_username_by_identity(self, provider_id, subject):
+                return self.bound.get((provider_id, subject))
+
+            def list_providers_for_username(self, username):
+                return [provider for (provider, _), name in self.bound.items() if name == username]
+
+            def link(self, provider_id, subject, username, **kwargs):
+                self.links.append((provider_id, subject, username))
+                self.bound[(provider_id, subject)] = username
+                return True
+
+        identities = _Identities()
+        monkeypatch.setattr(auth_router_mod.store, "user_identity_repo", identities, raising=False)
+        monkeypatch.setattr(auth_router_mod.store, "has_user", lambda username: username == "alice@corp.com", raising=False)
+        monkeypatch.setattr(auth_router_mod.store, "get_groups_for_user", lambda username: ["mlflow"], raising=False)
+
+        created = []
+        monkeypatch.setattr("mlflow_oidc_auth.user.create_user", lambda **kwargs: created.append(kwargs))
+        monkeypatch.setattr("mlflow_oidc_auth.user.populate_groups", lambda **kwargs: None)
+        monkeypatch.setattr("mlflow_oidc_auth.user.update_user", lambda **kwargs: None)
+
+        async def _exchange(request, provider_id=None):
+            return {
+                "access_token": "at",
+                "userinfo": {"sub": "auth0|6f3a", "email": "alice@corp.com", "name": "Alice", "groups": ["mlflow"]},
+            }
+
+        monkeypatch.setattr(auth_router_mod, "_authorize_access_token_with_key_refresh", _exchange)
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: SimpleNamespace(authorize_access_token=_exchange), raising=False)
+        monkeypatch.setattr(auth_router_mod, "_iss_parameter_supported", _no_iss)
+        return identities, created
+
+    @pytest.mark.asyncio
+    async def test_a_pre_existing_user_signs_in_and_is_adopted(self, existing_user_callback):
+        """A real ``sub`` is not a username, so the backfilled row does not match it. The account
+        is adopted rather than refused, and the real subject is bound for next time."""
+        identities, _ = existing_user_callback
+        request = DummyRequest(state="state-1", code="c")
+
+        username, errors = await auth_router_mod._process_oidc_callback_fastapi(request, request.session)
+
+        assert errors == []
+        assert username == "alice@corp.com"
+        assert ("default", "auth0|6f3a", "alice@corp.com") in identities.links
+
+    @pytest.mark.asyncio
+    async def test_the_second_login_matches_on_the_bound_identity(self, existing_user_callback):
+        identities, _ = existing_user_callback
+        first = DummyRequest(state="state-1", code="c")
+        await auth_router_mod._process_oidc_callback_fastapi(first, first.session)
+
+        second = DummyRequest(state="state-1", code="c")
+        username, errors = await auth_router_mod._process_oidc_callback_fastapi(second, second.session)
+
+        assert errors == []
+        assert username == "alice@corp.com"
+
+
+async def _no_iss(provider):
+    return False

--- a/mlflow_oidc_auth/tests/test_provider_login.py
+++ b/mlflow_oidc_auth/tests/test_provider_login.py
@@ -1,0 +1,418 @@
+"""Per-provider login and the RFC 9207 mix-up defence (issue #316).
+
+Three things become possible once a deployment has more than one authorization server, and all
+three are decided here:
+
+* **A response can arrive from the wrong one.** An authorization response carries ``code`` and
+  ``state`` and nothing that says who sent it, so with two providers the client cannot tell them
+  apart by looking. RFC 9207 adds ``iss``; the decision function landed with the adversarial
+  suite in #307, and this is where it is wired in.
+* **Two logins can be in flight at once.** The state used to be one cookie key, so a second tab
+  overwrote the first. It is a row per attempt now.
+* **A response can be replayed.** Consuming the row *is* the CSRF check, so the second use of a
+  captured callback finds nothing.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import mlflow_oidc_auth.routers.auth as auth_router_mod
+from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+from mlflow_oidc_auth.repository.auth_state import AuthAttempt
+
+ENTRA = "https://login.entra.invalid/tenant"
+OKTA = "https://okta.invalid"
+
+
+class DummyRequest:
+    def __init__(self, **query):
+        self.session = {}
+        self.base_url = "http://testserver"
+        self.query_params = _Query(query)
+
+
+class _Query(dict):
+    """A query-params mapping with ``getlist``, as Starlette's has."""
+
+    def getlist(self, key):
+        value = self.get(key)
+        if value is None:
+            return []
+        return value if isinstance(value, list) else [value]
+
+
+@pytest.fixture
+def two_providers(monkeypatch):
+    registry = RegistryLoadResult(
+        providers=[
+            ProviderConfig(id="entra", type="oidc", display_name="Entra ID", audience="mlflow", issuer=ENTRA),
+            ProviderConfig(id="okta", type="oidc", display_name="Okta", audience="mlflow", issuer=OKTA),
+            ProviderConfig(id="cluster", type="k8s", display_name="Kubernetes", audience="mlflow-api", issuer="https://k8s.invalid", interactive=False),
+        ],
+        errors=[],
+        source="env",
+    )
+    monkeypatch.setattr(auth_router_mod.config, "AUTH_PROVIDERS", registry, raising=False)
+    return registry
+
+
+@pytest.fixture
+def attempt_at(monkeypatch):
+    """Make the callback see an in-flight attempt at a chosen provider."""
+
+    def _install(provider_id, state="state-1", redirect_after_login=None):
+        monkeypatch.setattr(
+            auth_router_mod.store,
+            "consume_auth_state",
+            lambda s: AuthAttempt(state=s, provider_id=provider_id, redirect_after_login=redirect_after_login) if s == state else None,
+            raising=False,
+        )
+
+    return _install
+
+
+@pytest.fixture
+def advertises_iss(monkeypatch):
+    """Control whether the provider claims to send ``iss``."""
+
+    def _install(supported):
+        async def _check(provider):
+            return supported
+
+        monkeypatch.setattr(auth_router_mod, "_iss_parameter_supported", _check)
+
+    return _install
+
+
+class TestTheProviderList:
+    """What #317's login picker renders."""
+
+    @pytest.mark.asyncio
+    async def test_only_interactive_providers_are_listed(self, two_providers):
+        response = await auth_router_mod.providers(DummyRequest())
+
+        import json
+
+        listed = json.loads(response.body)["providers"]
+        assert [entry["id"] for entry in listed] == ["entra", "okta"], "a cluster issuer has no browser flow to start"
+
+    @pytest.mark.asyncio
+    async def test_each_entry_carries_a_login_url(self, two_providers):
+        import json
+
+        listed = json.loads((await auth_router_mod.providers(DummyRequest())).body)["providers"]
+
+        assert listed[0]["login_url"].endswith("/login/entra")
+        assert listed[0]["display_name"] == "Entra ID"
+
+    @pytest.mark.asyncio
+    async def test_nothing_about_the_configuration_leaks(self, two_providers):
+        """It is reachable before anyone has logged in, so it carries what a login page needs
+        and nothing else — no issuer, no audience, no client id, no key source."""
+        import json
+
+        body = json.loads((await auth_router_mod.providers(DummyRequest())).body)
+
+        assert set(body["providers"][0]) == {"id", "display_name", "type", "login_url"}
+        assert ENTRA not in json.dumps(body)
+
+
+class TestAnUnknownProviderIs404:
+    @pytest.mark.asyncio
+    async def test_login_at_an_unknown_provider(self, two_providers):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as excinfo:
+            await auth_router_mod.login_with_provider(DummyRequest(), "nope")
+
+        assert excinfo.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_login_at_a_non_interactive_provider(self, two_providers):
+        """A Kubernetes issuer verifies tokens but has no authorization endpoint to redirect to,
+        so naming it in a login URL is a 404 rather than a broken redirect."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as excinfo:
+            await auth_router_mod.login_with_provider(DummyRequest(), "cluster")
+
+        assert excinfo.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_callback_for_an_unknown_provider(self, two_providers):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as excinfo:
+            await auth_router_mod.callback_for_provider(DummyRequest(), "nope")
+
+        assert excinfo.value.status_code == 404
+
+
+class TestTheMixUpDefence:
+    """The attack: an authorization response from one server delivered to a client that is
+    waiting for another."""
+
+    async def _callback(self, request, provider_id=None):
+        return await auth_router_mod._process_oidc_callback_fastapi(request, {}, provider_id=provider_id)
+
+    @pytest.mark.asyncio
+    async def test_a_response_from_another_issuer_is_refused(self, two_providers, attempt_at, advertises_iss):
+        attempt_at("entra")
+        advertises_iss(True)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c", iss=OKTA))
+
+        assert errors and "unexpected issuer" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_a_stripped_iss_is_refused_when_the_provider_sends_one(self, two_providers, attempt_at, advertises_iss):
+        """Otherwise the defence is one deleted query parameter away from being switched off."""
+        attempt_at("entra")
+        advertises_iss(True)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c"))
+
+        assert errors and "unexpected issuer" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_iss_is_allowed_when_the_provider_advertises_nothing(self, two_providers, attempt_at, advertises_iss):
+        """RFC 9207 is recent; refusing here would break logins that work today."""
+        attempt_at("entra")
+        advertises_iss(False)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c"))
+
+        assert not any("issuer" in error for error in errors), errors
+
+    @pytest.mark.asyncio
+    async def test_a_matching_iss_passes(self, two_providers, attempt_at, advertises_iss):
+        attempt_at("entra")
+        advertises_iss(True)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c", iss=ENTRA))
+
+        assert not any("issuer" in error for error in errors), errors
+
+    @pytest.mark.asyncio
+    async def test_a_repeated_iss_is_refused(self, two_providers, attempt_at, advertises_iss):
+        """``?iss=honest&iss=attacker`` names two issuers, so it can be attributed to neither."""
+        attempt_at("entra")
+        advertises_iss(True)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c", iss=[ENTRA, OKTA]))
+
+        assert errors and "unexpected issuer" in errors[0]
+
+    @pytest.mark.asyncio
+    async def test_a_response_cannot_be_completed_at_another_providers_callback(self, two_providers, attempt_at, advertises_iss):
+        """The first thing a mix-up tries: deliver the response to the wrong callback path."""
+        attempt_at("entra")
+        advertises_iss(False)
+
+        _, errors = await self._callback(DummyRequest(state="state-1", code="c"), provider_id="okta")
+
+        assert errors and "Invalid state parameter" in errors[0]
+
+
+class TestTheAttemptIsSingleUse:
+    @pytest.mark.asyncio
+    async def test_an_unknown_state_is_refused(self, two_providers, attempt_at):
+        attempt_at("entra", state="state-1")
+
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(DummyRequest(state="other", code="c"), {})
+
+        assert errors == ["Invalid state parameter"]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_state_is_refused(self, two_providers, attempt_at):
+        attempt_at("entra")
+
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(DummyRequest(code="c"), {})
+
+        assert errors == ["Invalid state parameter"]
+
+    @pytest.mark.asyncio
+    async def test_a_provider_removed_mid_flight_is_refused(self, two_providers, attempt_at):
+        """There is no policy left to apply to the response, so there is nothing safe to do with
+        it."""
+        attempt_at("retired-provider")
+
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(DummyRequest(state="state-1", code="c"), {})
+
+        assert errors and "no longer configured" in errors[0]
+
+
+class TestLoginStartsAnAttempt:
+    @pytest.mark.asyncio
+    async def test_the_attempt_names_the_provider(self, two_providers, monkeypatch):
+        recorded = {}
+
+        def create(provider_id, **kwargs):
+            recorded.update({"provider_id": provider_id, **kwargs})
+            return "state-1"
+
+        monkeypatch.setattr(auth_router_mod.store, "create_auth_state", create, raising=False)
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
+        monkeypatch.setattr(auth_router_mod, "assert_pkce_supported", _noop)
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: SimpleNamespace(authorize_redirect=_redirect), raising=False)
+        monkeypatch.setattr(auth_router_mod, "get_configured_or_dynamic_redirect_uri", lambda request, callback_path, configured_uri=None: "http://cb")
+
+        await auth_router_mod._begin_login(DummyRequest(), "okta")
+
+        assert recorded["provider_id"] == "okta"
+
+    @pytest.mark.asyncio
+    async def test_each_provider_gets_its_own_callback_path(self, two_providers, monkeypatch):
+        """A shared callback path would mean a response could be delivered to a provider it did
+        not come from, which is the ambiguity the whole defence exists to remove."""
+        paths = []
+
+        monkeypatch.setattr(auth_router_mod.store, "create_auth_state", lambda provider_id, **kwargs: "state-1", raising=False)
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
+        monkeypatch.setattr(auth_router_mod, "assert_pkce_supported", _noop)
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: SimpleNamespace(authorize_redirect=_redirect), raising=False)
+        monkeypatch.setattr(
+            auth_router_mod,
+            "get_configured_or_dynamic_redirect_uri",
+            lambda request, callback_path, configured_uri=None: paths.append(callback_path) or "http://cb",
+        )
+
+        await auth_router_mod._begin_login(DummyRequest(), "okta")
+        await auth_router_mod._begin_login(DummyRequest(), "default")
+
+        assert paths == ["/callback/okta", "/callback"], "the default keeps the legacy path, so registered redirect URIs still work"
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+async def _redirect(request, redirect_uri=None, state=None):
+    from fastapi.responses import RedirectResponse
+
+    return RedirectResponse(url=redirect_uri)
+
+
+class TestTheProviderCannotComeFromTheQueryString:
+    """``/login?provider_id=x`` must not reach the flow: the 404 gate lives on the path-scoped
+    route, and a query parameter would step around it."""
+
+    @pytest.mark.asyncio
+    async def test_login_takes_no_provider_query_parameter(self):
+        import inspect
+
+        assert "provider_id" not in inspect.signature(auth_router_mod.login).parameters
+
+    @pytest.mark.asyncio
+    async def test_callback_takes_no_provider_query_parameter(self):
+        import inspect
+
+        assert "provider_id" not in inspect.signature(auth_router_mod.callback).parameters
+
+
+class TestASecondInteractiveProviderIsRefusedForNow:
+    """#316 gives every provider a login route and defends the mix-up attack. What it does not
+    give is per-provider identity: the username field, the groups attribute and the admin group
+    are still read from deployment-wide configuration, and the user row is not namespaced by
+    provider.
+
+    A second interactive provider on top of that is account takeover, not a feature — a
+    contractor tenant asserting ``email: alice@corp.com`` would land on Alice's account. #318 is
+    what makes provisioning and identity binding per-provider; until then this is refused at
+    load rather than shipped.
+    """
+
+    @staticmethod
+    def _build(entries):
+        from types import SimpleNamespace as NS
+        import json
+
+        from mlflow_oidc_auth.provider_registry import build_provider_registry
+
+        class Manager:
+            @staticmethod
+            def get(key, default=None):
+                return json.dumps(entries) if key == "AUTH_PROVIDERS" else default
+
+        return build_provider_registry(
+            Manager(),
+            NS(
+                OIDC_PROVIDER_DISPLAY_NAME="Login with OIDC",
+                OIDC_AUDIENCE=None,
+                OIDC_ISSUER=None,
+                OIDC_DISCOVERY_URL="https://idp.example.com/.well-known/openid-configuration",
+                OIDC_CLIENT_ID="client",
+            ),
+        )
+
+    @staticmethod
+    def _entry(**overrides):
+        entry = {
+            "id": "okta",
+            "type": "oidc",
+            "audience": "mlflow",
+            "issuer": "https://okta.example.com",
+            "discovery_url": "https://okta.example.com/.well-known/openid-configuration",
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_a_second_provider_gets_no_login_button(self, caplog):
+        """Coerced off rather than rejected: the entry is still a usable *token* provider, and
+        only the browser flow is unsafe."""
+        with caplog.at_level("WARNING"):
+            result = self._build([self._entry(interactive=True)])
+
+        assert [provider.id for provider in result.providers] == ["okta"]
+        assert result.providers[0].interactive is False
+        assert result.interactive_providers() == []
+        assert any("#318" in record.getMessage() for record in caplog.records)
+
+    def test_the_same_provider_is_fine_for_bearer_tokens(self):
+        """Only the browser flow is gated: a token from this issuer is validated per-provider
+        already (#313), and none of the identity questions arise."""
+        result = self._build([self._entry(interactive=False)])
+
+        assert [provider.id for provider in result.providers] == ["okta"]
+
+    def test_the_default_provider_is_unaffected(self):
+        assert build_default().providers[0].interactive is True
+
+
+def build_default():
+    from types import SimpleNamespace as NS
+
+    from mlflow_oidc_auth.provider_registry import build_provider_registry
+
+    class Manager:
+        @staticmethod
+        def get(key, default=None):
+            return default
+
+    return build_provider_registry(
+        Manager(),
+        NS(
+            OIDC_PROVIDER_DISPLAY_NAME="Login with OIDC",
+            OIDC_AUDIENCE=None,
+            OIDC_ISSUER=None,
+            OIDC_DISCOVERY_URL="https://idp.example.com/.well-known/openid-configuration",
+            OIDC_CLIENT_ID="client",
+        ),
+    )
+
+
+class TestTheReturnTargetCannotLeaveTheOrigin:
+    """``?next=`` is stored in the attempt row and redirected to after a successful login — the
+    ideal moment to land a victim on a lookalike page."""
+
+    @pytest.mark.parametrize(
+        "target",
+        ["//evil.com", "https://evil.com", "javascript:alert(1)", "/\\evil.com", "/\tevil.com", "/\r\n/evil.com", "\\\\evil.com"],
+    )
+    def test_anything_a_browser_would_resolve_off_origin_is_dropped(self, target):
+        assert auth_router_mod._sanitize_next(target) is None
+
+    @pytest.mark.parametrize("target", ["/users", "/oidc/ui/groups", "/#/experiments/0", "/a?b=c"])
+    def test_real_paths_survive(self, target):
+        assert auth_router_mod._sanitize_next(target) == target

--- a/mlflow_oidc_auth/tests/test_provider_login.py
+++ b/mlflow_oidc_auth/tests/test_provider_login.py
@@ -153,7 +153,9 @@ class TestTheMixUpDefence:
     """The attack: an authorization response from one server delivered to a client that is
     waiting for another."""
 
-    async def _callback(self, request, provider_id=None):
+    async def _callback(self, request, provider_id="entra"):
+        """Arrives at the callback of the provider the attempt started at, unless a case says
+        otherwise — the path check comes first, and these cases are about ``iss``."""
         return await auth_router_mod._process_oidc_callback_fastapi(request, {}, provider_id=provider_id)
 
     @pytest.mark.asyncio
@@ -480,3 +482,107 @@ class TestAnExistingUserCanStillLogIn:
 
 async def _no_iss(provider):
     return False
+
+
+class TestTheLegacyCallbackBelongsToTheDefaultProvider:
+    """``/callback`` is not "whoever asks" — it is the ``default`` provider's URL.
+
+    Treating an unscoped path as having no opinion about the provider would let anyone able to
+    deliver an authorization response there opt out of the path check entirely, which is one of
+    the three mix-up defences.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_second_providers_response_is_refused_at_the_legacy_callback(self, two_providers, attempt_at, advertises_iss):
+        attempt_at("entra")
+        advertises_iss(False)
+
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(DummyRequest(state="state-1", code="c"), {}, provider_id=None)
+
+        assert errors == ["Invalid state parameter"]
+
+    @pytest.mark.asyncio
+    async def test_the_default_providers_response_is_accepted_there(self, monkeypatch, attempt_at, advertises_iss):
+        monkeypatch.setattr(
+            auth_router_mod.config,
+            "AUTH_PROVIDERS",
+            RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow", issuer=ENTRA)], errors=[], source="legacy"),
+            raising=False,
+        )
+        attempt_at("default")
+        advertises_iss(False)
+
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(DummyRequest(state="state-1", code="c"), {}, provider_id=None)
+
+        assert "Invalid state parameter" not in errors
+
+    @pytest.mark.asyncio
+    async def test_login_at_the_default_provider_uses_the_legacy_callback_path(self, monkeypatch):
+        """Its redirect URI is the one already registered at the operator's IdP, whichever route
+        started the login."""
+        monkeypatch.setattr(
+            auth_router_mod.config,
+            "AUTH_PROVIDERS",
+            RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow", issuer=ENTRA)], errors=[], source="legacy"),
+            raising=False,
+        )
+        paths = []
+        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
+        monkeypatch.setattr(auth_router_mod.store, "create_auth_state", lambda provider_id, **kwargs: "state-1", raising=False)
+        monkeypatch.setattr(auth_router_mod, "assert_pkce_supported", _noop)
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: SimpleNamespace(authorize_redirect=_redirect), raising=False)
+        monkeypatch.setattr(
+            auth_router_mod,
+            "get_configured_or_dynamic_redirect_uri",
+            lambda request, callback_path, configured_uri=None: paths.append(callback_path) or "http://cb",
+        )
+
+        await auth_router_mod.login_with_provider(DummyRequest(), "default")
+
+        assert paths == ["/callback"]
+
+
+class TestTheExchangeNeverBorrowsAnotherProvidersClient:
+    """An authorization code minted by one issuer must never be posted to another's token
+    endpoint — that hands one IdP a credential belonging to a different one."""
+
+    @pytest.mark.asyncio
+    async def test_a_named_provider_with_no_client_fails(self, monkeypatch):
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: None, raising=False)
+
+        with pytest.raises(RuntimeError, match="partner"):
+            auth_router_mod._client_for_exchange("partner")
+
+    @pytest.mark.asyncio
+    async def test_the_default_provider_still_resolves_to_the_legacy_client(self, monkeypatch):
+        legacy = SimpleNamespace(authorize_access_token=_redirect)
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: None, raising=False)
+        monkeypatch.setattr(auth_router_mod.oauth, "oidc", legacy, raising=False)
+
+        assert auth_router_mod._client_for_exchange("default") is legacy
+
+
+class TestTheLoginUrlsDoNotComeFromTheHostHeader:
+    """They are the buttons a login page offers, on an unauthenticated, cacheable endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_the_configured_origin_wins(self, two_providers, monkeypatch):
+        import json
+
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_REDIRECT_URI", "https://mlflow.corp.example/callback", raising=False)
+        request = DummyRequest()
+        request.base_url = "http://evil.example"
+
+        listed = json.loads((await auth_router_mod.providers(request)).body)["providers"]
+
+        assert listed[0]["login_url"] == "https://mlflow.corp.example/login/entra"
+
+    @pytest.mark.asyncio
+    async def test_it_falls_back_to_the_request_when_nothing_is_configured(self, two_providers, monkeypatch):
+        import json
+
+        monkeypatch.setattr(auth_router_mod.config, "OIDC_REDIRECT_URI", None, raising=False)
+
+        listed = json.loads((await auth_router_mod.providers(DummyRequest())).body)["providers"]
+
+        assert listed[0]["login_url"] == "http://testserver/login/entra"

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -380,8 +380,14 @@ class TestInteractiveFlag:
     login button for it that cannot complete.
     """
 
-    def test_oidc_providers_are_interactive_by_default(self):
-        assert build([valid_entry()]).providers[0].interactive is True
+    def test_the_default_provider_is_interactive(self):
+        """The type's default is interactive, and the ``default`` provider keeps it.
+
+        A *second* OIDC provider has its browser login held back until identity resolution
+        becomes per-provider (#318) — it remains a token provider. That is asserted in
+        ``test_provider_login.py``.
+        """
+        assert build([valid_entry(id=DEFAULT_PROVIDER_ID)]).providers[0].interactive is True
 
     def test_k8s_providers_are_not_interactive_by_default(self):
         result = build([valid_entry(type="k8s")])
@@ -414,7 +420,9 @@ class TestInteractiveFlag:
         result = build([valid_entry(id="okta"), valid_entry(id="cluster", type="k8s")])
 
         assert [p.id for p in result.providers] == ["okta", "cluster"]
-        assert [p.id for p in result.interactive_providers()] == ["okta"]
+        # ``okta`` is a second provider, so its browser login is held back until identity
+        # becomes per-provider (#318) — it is still a token provider.
+        assert [p.id for p in result.interactive_providers()] == []
 
     def test_the_legacy_provider_is_interactive(self):
         """Today's single provider is a browser login provider, and must stay on the page."""

--- a/mlflow_oidc_auth/tests/test_provider_registry.py
+++ b/mlflow_oidc_auth/tests/test_provider_registry.py
@@ -380,14 +380,8 @@ class TestInteractiveFlag:
     login button for it that cannot complete.
     """
 
-    def test_the_default_provider_is_interactive(self):
-        """The type's default is interactive, and the ``default`` provider keeps it.
-
-        A *second* OIDC provider has its browser login held back until identity resolution
-        becomes per-provider (#318) — it remains a token provider. That is asserted in
-        ``test_provider_login.py``.
-        """
-        assert build([valid_entry(id=DEFAULT_PROVIDER_ID)]).providers[0].interactive is True
+    def test_oidc_providers_are_interactive_by_default(self):
+        assert build([valid_entry()]).providers[0].interactive is True
 
     def test_k8s_providers_are_not_interactive_by_default(self):
         result = build([valid_entry(type="k8s")])
@@ -420,9 +414,7 @@ class TestInteractiveFlag:
         result = build([valid_entry(id="okta"), valid_entry(id="cluster", type="k8s")])
 
         assert [p.id for p in result.providers] == ["okta", "cluster"]
-        # ``okta`` is a second provider, so its browser login is held back until identity
-        # becomes per-provider (#318) — it is still a token provider.
-        assert [p.id for p in result.interactive_providers()] == []
+        assert [p.id for p in result.interactive_providers()] == ["okta"]
 
     def test_the_legacy_provider_is_interactive(self):
         """Today's single provider is a browser login provider, and must stay on the page."""

--- a/mlflow_oidc_auth/tests/test_provisioning_policy.py
+++ b/mlflow_oidc_auth/tests/test_provisioning_policy.py
@@ -1,0 +1,269 @@
+"""Per-provider provisioning, group sync and admin source (issue #318).
+
+These three decisions used to come from deployment-wide configuration, which is defensible with
+one identity provider and is account takeover with two. Each case below is a policy combination
+the registry can express, and the ones that matter most are the refusals: a provider that may not
+create users, and a provider that may not claim a username someone else already answers to.
+"""
+
+import pytest
+
+from mlflow_oidc_auth.identity_resolution import IdentityDecision, Resolution
+from mlflow_oidc_auth.provider_registry import ProviderConfig
+from mlflow_oidc_auth.provisioning_policy import admin_from_claims, apply_provisioning_policy, groups_to_apply
+
+ADMIN_GROUPS = ["mlflow-admins"]
+
+
+def provider(**overrides):
+    fields = {"id": "entra", "type": "oidc", "audience": "mlflow", "issuer": "https://entra.invalid"}
+    fields.update(overrides)
+    return ProviderConfig(**fields)
+
+
+def nobody_exists(_username):
+    return False
+
+
+def everybody_exists(_username):
+    return True
+
+
+class TestProvisioning:
+    def test_jit_creates_a_new_principal(self):
+        outcome = apply_provisioning_policy(
+            provider(provisioning="jit"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="new@corp.com",
+            user_exists=nobody_exists,
+        )
+
+        assert outcome.allowed is True
+        assert outcome.create is True
+        assert outcome.username == "new@corp.com"
+
+    @pytest.mark.parametrize("policy", ["scim", "none"])
+    def test_a_non_jit_provider_never_creates(self, policy):
+        """The enterprise gate: the directory decides who exists, and login does not."""
+        outcome = apply_provisioning_policy(
+            provider(provisioning=policy),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="new@corp.com",
+            user_exists=nobody_exists,
+        )
+
+        assert outcome.allowed is False
+        assert policy in outcome.reason
+
+    @pytest.mark.parametrize("policy", ["scim", "none"])
+    def test_a_known_user_still_signs_in(self, policy):
+        """Not creating is not the same as not admitting."""
+        outcome = apply_provisioning_policy(
+            provider(provisioning=policy),
+            IdentityDecision(Resolution.MATCHED, username="alice@corp.com"),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+        )
+
+        assert outcome.allowed is True
+        assert outcome.create is False
+        assert outcome.username == "alice@corp.com"
+
+    def test_a_refused_identity_is_never_upgraded_into_a_create(self):
+        outcome = apply_provisioning_policy(
+            provider(provisioning="jit"),
+            IdentityDecision(Resolution.REFUSED, reason="email domain not allowed"),
+            derived_username="mallory@evil.invalid",
+            user_exists=nobody_exists,
+        )
+
+        assert outcome.allowed is False
+        assert outcome.create is False
+        assert "email domain" in outcome.reason
+
+
+class TestOneProviderCannotClaimAnothersAccount:
+    """The reason #318 had to land with #316: with two providers, an unbound identity whose
+    claims name an existing user is a takeover attempt, not a new principal."""
+
+    def test_an_unbound_identity_cannot_take_an_existing_username(self):
+        outcome = apply_provisioning_policy(
+            provider(id="partner-okta", provisioning="jit"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+        )
+
+        assert outcome.allowed is False
+        assert "already belongs to another identity" in outcome.reason
+        assert "partner-okta" in outcome.reason
+
+    def test_the_same_identity_bound_already_is_fine(self):
+        """Once bound, the account *is* theirs — that is what binding means."""
+        outcome = apply_provisioning_policy(
+            provider(id="partner-okta"),
+            IdentityDecision(Resolution.MATCHED, username="alice@corp.com"),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+        )
+
+        assert outcome.allowed is True
+
+    def test_no_username_at_all_is_refused(self):
+        outcome = apply_provisioning_policy(
+            provider(),
+            IdentityDecision(Resolution.CREATE),
+            derived_username=None,
+            user_exists=nobody_exists,
+        )
+
+        assert outcome.allowed is False
+
+
+class TestGroupSync:
+    def test_every_login_authoritative_replaces(self):
+        """Today's behaviour, and the default."""
+        groups = groups_to_apply(provider(), ["a", "b"], ["b", "c"], is_new_user=False)
+
+        assert groups == ["entra:a", "entra:b"]
+
+    def test_authoritative_genuinely_removes(self):
+        """The acceptance criterion the issue calls out. Keycloak's FORCE mapper is add-only in
+        practice, so a deployment expecting revocation to propagate gets it from here or nowhere."""
+        groups = groups_to_apply(provider(group_sync_mode="authoritative"), ["a"], ["entra:a", "entra:revoked"], is_new_user=False)
+
+        assert "entra:revoked" not in groups
+
+    def test_additive_never_removes(self):
+        """For a deployment where some memberships come from elsewhere — SCIM, or by hand — and
+        the token only knows about its own."""
+        groups = groups_to_apply(provider(group_sync_mode="additive"), ["a"], ["kept-by-scim"], is_new_user=False)
+
+        assert set(groups) == {"entra:a", "kept-by-scim"}
+
+    def test_none_leaves_membership_alone(self):
+        assert groups_to_apply(provider(group_sync="none"), ["a"], ["b"], is_new_user=False) is None
+
+    def test_first_login_applies_only_on_creation(self):
+        first = groups_to_apply(provider(group_sync="first_login"), ["a"], [], is_new_user=True)
+        later = groups_to_apply(provider(group_sync="first_login"), ["a", "b"], ["a"], is_new_user=False)
+
+        assert first == ["entra:a"]
+        assert later is None
+
+    def test_duplicates_are_collapsed(self):
+        assert groups_to_apply(provider(), ["a", "a", "b"], [], is_new_user=True) == ["entra:a", "entra:b"]
+
+    def test_blank_group_names_are_dropped(self):
+        assert groups_to_apply(provider(), ["a", "", None], [], is_new_user=True) == ["entra:a"]
+
+
+class TestAdminSource:
+    def test_claims_confer_admin(self):
+        assert admin_from_claims(provider(admin_source="claims"), ["mlflow-admins"], ADMIN_GROUPS) is True
+
+    def test_a_provider_with_no_admin_source_never_does(self):
+        """The answer for a partner or contractor tenant whose group names you do not control:
+        it can assert whatever it likes and still confer nothing."""
+        assert admin_from_claims(provider(admin_source="none"), ["mlflow-admins"], ADMIN_GROUPS) is False
+
+    def test_a_non_member_is_not_an_admin(self):
+        assert admin_from_claims(provider(), ["engineering"], ADMIN_GROUPS) is False
+
+
+class TestTheDefaultProviderIsUnchanged:
+    """A deployment that configures nothing must behave exactly as before."""
+
+    @staticmethod
+    def _default():
+        return ProviderConfig(id="default", type="oidc")
+
+    def test_it_creates_on_first_login(self):
+        outcome = apply_provisioning_policy(self._default(), IdentityDecision(Resolution.CREATE), derived_username="a@b.c", user_exists=nobody_exists)
+
+        assert (outcome.allowed, outcome.create) == (True, True)
+
+    def test_it_replaces_groups_on_every_login(self):
+        assert groups_to_apply(self._default(), ["a"], ["stale"], is_new_user=False) == ["a"]
+
+    def test_it_reads_admin_from_claims(self):
+        assert admin_from_claims(self._default(), ["mlflow-admins"], ADMIN_GROUPS) is True
+
+
+class TestASecondProviderCannotJoinLocalGroupsByName:
+    """Group names are the permission boundary: ``set_user_groups`` joins by name and
+    ``populate_groups`` creates whatever is missing."""
+
+    def test_a_second_providers_groups_are_namespaced(self):
+        groups = groups_to_apply(provider(id="partner"), ["finance-ds"], [], is_new_user=True)
+
+        assert groups == ["partner:finance-ds"], "an unnamespaced claim would join the local finance-ds group"
+
+    def test_the_default_providers_groups_are_not(self):
+        """Those are the names every existing deployment already has."""
+        default = ProviderConfig(id="default", type="oidc")
+
+        assert groups_to_apply(default, ["finance-ds"], [], is_new_user=True) == ["finance-ds"]
+
+    def test_a_second_provider_cannot_reach_the_admin_group_by_name_either(self):
+        groups = groups_to_apply(provider(id="partner"), ["mlflow-admin"], [], is_new_user=True)
+
+        assert groups == ["partner:mlflow-admin"]
+
+
+class TestAdoptingAnAccountFromBeforeIdentitiesWereRecorded:
+    """Every user of every upgraded deployment takes this path on their first login.
+
+    The Phase 0 backfill wrote ``subject = username`` because that was all it had, and a real
+    ``sub`` is not a username — so the first login after upgrading resolves to CREATE and finds
+    the name taken. Without adoption that refuses *every existing user, including every
+    administrator*, with no way back that does not involve the database.
+    """
+
+    def test_the_default_provider_adopts_an_unbound_account(self):
+        outcome = apply_provisioning_policy(
+            ProviderConfig(id="default", type="oidc"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+            providers_bound_to=lambda _name: [],
+        )
+
+        assert outcome.allowed is True
+        assert outcome.create is False
+        assert outcome.username == "alice@corp.com"
+
+    def test_it_does_not_adopt_an_account_another_provider_owns(self):
+        outcome = apply_provisioning_policy(
+            ProviderConfig(id="default", type="oidc"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="mallory@partner.com",
+            user_exists=everybody_exists,
+            providers_bound_to=lambda _name: ["partner"],
+        )
+
+        assert outcome.allowed is False
+
+    def test_a_second_provider_never_adopts(self):
+        """Adoption is safe only for the provider that named the account in the first place."""
+        outcome = apply_provisioning_policy(
+            provider(id="partner"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+            providers_bound_to=lambda _name: [],
+        )
+
+        assert outcome.allowed is False
+
+    def test_an_unreadable_binding_set_refuses_rather_than_adopts(self):
+        """Fail closed: "cannot tell" must not read as "bound to nobody"."""
+        outcome = apply_provisioning_policy(
+            ProviderConfig(id="default", type="oidc"),
+            IdentityDecision(Resolution.CREATE),
+            derived_username="alice@corp.com",
+            user_exists=everybody_exists,
+            providers_bound_to=lambda _name: ["<unknown>"],
+        )
+
+        assert outcome.allowed is False

--- a/mlflow_oidc_auth/tests/test_routers_auth.py
+++ b/mlflow_oidc_auth/tests/test_routers_auth.py
@@ -75,7 +75,7 @@ async def test_a_bad_signature_refreshes_the_keys_and_reports_itself(monkeypatch
     """
     calls = {"count": 0}
 
-    async def _fake(request):
+    async def _fake(request, provider_id=None):
         calls["count"] += 1
         raise BadSignatureError("bad")
 
@@ -99,7 +99,7 @@ async def test_a_bad_signature_refreshes_the_keys_and_reports_itself(monkeypatch
 async def test_the_original_error_is_what_propagates(monkeypatch):
     """Not a substitute error produced by a doomed second attempt."""
 
-    async def _fake(request):
+    async def _fake(request, provider_id=None):
         raise ValueError("invalid_grant: PKCE verification failed")
 
     monkeypatch.setattr(auth_router_mod, "_call_authorize_access_token", _fake)
@@ -130,7 +130,7 @@ def test_build_ui_url_with_and_without_query():
 
 @pytest.mark.asyncio
 async def test_login_not_configured(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: False)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: False)
     req = DummyRequest()
 
     with pytest.raises(HTTPException) as ex:
@@ -140,7 +140,7 @@ async def test_login_not_configured(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_login_authorize_redirect_success(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
     async def fake_authorize_redirect(request, redirect_uri=None, state=None):
         return RedirectResponse(url=redirect_uri)
@@ -160,15 +160,24 @@ async def test_login_authorize_redirect_success(monkeypatch):
         lambda request, callback_path, configured_uri: "http://cb",
     )
 
+    created = {}
+    monkeypatch.setattr(
+        auth_router_mod.store,
+        "create_auth_state",
+        lambda provider_id, **kwargs: created.setdefault("state", "state-token") or "state-token",
+        raising=False,
+    )
+    monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: auth_router_mod.oauth.oidc, raising=False)
+
     req = DummyRequest()
     res = await auth_router_mod.login(req)
     assert isinstance(res, RedirectResponse)
-    assert "oauth_state" in req.session
+    assert created["state"], "the attempt is a row now, not a cookie key"
 
 
 @pytest.mark.asyncio
 async def test_login_no_authorize_redirect_raises(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
     # ensure oidc client present and remove authorize_redirect
     import types
@@ -235,7 +244,7 @@ async def test_logout_exception_clears_session(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_callback_not_configured(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: False)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: False)
     req = DummyRequest()
 
     res = await auth_router_mod.callback(req)
@@ -245,9 +254,9 @@ async def test_callback_not_configured(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_callback_process_errors_redirect(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
-    async def _fake_proc(request, session):
+    async def _fake_proc(request, session, provider_id=None):
         return None, ["err"]
 
     monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _fake_proc)
@@ -260,10 +269,10 @@ async def test_callback_process_errors_redirect(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_callback_success_redirects(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
     # return email and no errors
-    async def _fake_proc2(request, session):
+    async def _fake_proc2(request, session, provider_id=None):
         return "User@Example.COM", []
 
     monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _fake_proc2)
@@ -287,9 +296,9 @@ async def test_callback_success_redirects(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_callback_auth_failed_without_errors(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
-    async def _fake_proc3(request, session):
+    async def _fake_proc3(request, session, provider_id=None):
         return None, []
 
     monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _fake_proc3)
@@ -342,17 +351,19 @@ async def test_process_oidc_callback_fastapi_various_paths(monkeypatch):
     req.query_params = {}
     session = {}
     email, errors = await auth_router_mod._process_oidc_callback_fastapi(req, session)
-    assert "Missing OAuth state" in errors[0]
+    # "Missing" and "wrong" are one answer now: the row is the check, and an absent state and a
+    # forged one both fail to find one. Telling them apart would tell an attacker which they had.
+    assert "Invalid state parameter" in errors[0]
 
-    # invalid state
-    req.query_params = {"state": "x"}
-    session = {"oauth_state": "y"}
+    # a state with no attempt behind it — unknown, already used, or expired
+    req.query_params = {"state": "unknown-state"}
+    session = {}
     email, errors = await auth_router_mod._process_oidc_callback_fastapi(req, session)
     assert "Invalid state" in errors[0]
 
     # no code
     req.query_params = {"state": "ok"}
-    session = {"oauth_state": "ok"}
+    session = {}
     email, errors = await auth_router_mod._process_oidc_callback_fastapi(req, session)
     assert "No authorization code" in errors[0]
 
@@ -560,7 +571,7 @@ async def test_call_authorize_access_token_sync_implementation(monkeypatch):
 async def test_a_successful_exchange_does_not_refresh_the_keys(monkeypatch):
     calls = {"count": 0}
 
-    async def _succeed(request):
+    async def _succeed(request, provider_id=None):
         calls["count"] += 1
         return {"access_token": "x"}
 
@@ -582,7 +593,7 @@ async def test_a_successful_exchange_does_not_refresh_the_keys(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_login_fallback_redirect_uri_on_error(monkeypatch):
-    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+    monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda provider_id=None: True)
 
     # make the redirect helper raise so the fallback path is used
     async def fake_authorize_redirect(request, redirect_uri=None, state=None):
@@ -655,91 +666,74 @@ async def test_process_oidc_callback_final_except(monkeypatch):
 class TestSessionHandoverOnReLogin:
     """Two logins in the same browser must not leave the first user's session id in the cookie.
 
-    Found by security review of #310: the callback writes the new login's refresh token into the
-    cookie *before* opening the session row. If opening it then failed and the old ``session_id``
-    were still there, the browser would stay authenticated as the previous user and go on
-    refreshing that session with the new user's IdP grant.
+    Driven through ``_process_oidc_callback_fastapi`` rather than around it: since #316 the
+    handover happens between the state check and the token exchange, and both halves of that
+    placement are load-bearing. After the check, because retiring a session for a callback that
+    turns out to be forged is a drive-by logout. Before the exchange, because
+    ``_persist_session_auth`` keeps an existing refresh token when the new response carries none,
+    so anything left in the cookie is inherited by the next user.
     """
+
+    @staticmethod
+    def _exchange(monkeypatch, seen, token_response):
+        async def _fake(request, provider_id=None):
+            seen["at_exchange"] = dict(request.session)
+            return token_response
+
+        monkeypatch.setattr(auth_router_mod, "_authorize_access_token_with_key_refresh", _fake)
+        # A client has to exist for the exchange to be attempted at all.
+        monkeypatch.setattr(auth_router_mod, "get_client", lambda provider_id=None: types.SimpleNamespace(authorize_access_token=_fake), raising=False)
 
     @pytest.mark.asyncio
     async def test_the_previous_session_is_revoked_and_replaced(self, monkeypatch):
-        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
-
-        async def _proc(request, session):
-            return "second@example.com", []
-
-        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
-        monkeypatch.setattr(auth_router_mod, "_open_server_session", lambda username: "sid-second")
         revoked = []
         monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: revoked.append(sid) or True)
+        self._exchange(monkeypatch, {}, None)  # the exchange itself may fail; the handover is what matters
 
         req = DummyRequest()
         req.session["session_id"] = "sid-first"
+        req.query_params = {"state": "state-1", "code": "c"}
 
-        await auth_router_mod.callback(req)
+        await auth_router_mod._process_oidc_callback_fastapi(req, req.session)
 
         assert revoked == ["sid-first"]
-        assert req.session["session_id"] == "sid-second"
+        assert "session_id" not in req.session
 
     @pytest.mark.asyncio
     async def test_the_previous_users_refresh_token_is_not_inherited(self, monkeypatch):
-        """The finding this ordering exists for.
-
-        ``_persist_session_auth`` keeps an existing refresh token when the new token response
-        carries none, so retiring the old login *after* the exchange would hand the next user
-        the previous user's grant — their session would then outlive their own IdP session and
-        die with someone else's.
-        """
-        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
+        """The finding this ordering exists for: a token response with no refresh token of its
+        own would otherwise keep the previous user's."""
         seen = {}
-
-        async def _proc(request, session):
-            # Stands in for the token exchange: records what the previous login left behind,
-            # then persists a token response that carries no refresh token of its own.
-            seen["at_exchange"] = dict(session)
-            auth_router_mod._persist_session_auth(session, {"expires_at": 4102444800})
-            return "second@example.com", []
-
-        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
-        monkeypatch.setattr(auth_router_mod, "_open_server_session", lambda username: "sid-second")
         monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: True)
-        monkeypatch.setattr(config, "OIDC_USE_REFRESH_TOKEN", True)
+        self._exchange(monkeypatch, seen, None)
 
         req = DummyRequest()
         req.session["session_id"] = "sid-first"
         req.session["refresh_token"] = "rt-first"
         req.session["expires_at"] = 100
+        req.query_params = {"state": "state-1", "code": "c"}
 
-        await auth_router_mod.callback(req)
+        await auth_router_mod._process_oidc_callback_fastapi(req, req.session)
 
         assert "refresh_token" not in seen["at_exchange"], "the exchange must not see the previous login's token"
         assert "refresh_token" not in req.session
-        assert req.session["session_id"] == "sid-second"
 
     @pytest.mark.asyncio
-    async def test_a_failure_to_open_a_session_clears_the_cookie(self, monkeypatch):
-        monkeypatch.setattr(auth_router_mod, "is_oidc_configured", lambda: True)
-
-        async def _proc(request, session):
-            return "second@example.com", []
-
-        monkeypatch.setattr(auth_router_mod, "_process_oidc_callback_fastapi", _proc)
-
-        def _boom(username):
-            raise RuntimeError("database is down")
-
-        monkeypatch.setattr(auth_router_mod, "_open_server_session", _boom)
-        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: True)
+    async def test_a_forged_callback_cannot_force_a_logout(self, monkeypatch):
+        """An unauthenticated cross-site GET to the callback must not end a live session: the
+        state check comes first, and nothing destructive happens before it."""
+        revoked = []
+        monkeypatch.setattr(auth_router_mod.store, "revoke_auth_session", lambda sid: revoked.append(sid) or True)
 
         req = DummyRequest()
-        req.session["session_id"] = "sid-first"
-        req.session["refresh_token"] = "rt-second"  # written by _persist_session_auth already
+        req.session["session_id"] = "sid-live"
+        req.query_params = {"state": "unknown-state", "code": "c"}
 
-        res = await auth_router_mod.callback(req)
+        _, errors = await auth_router_mod._process_oidc_callback_fastapi(req, req.session)
 
-        assert isinstance(res, RedirectResponse)
-        assert "session_error" in res.headers["location"]
-        assert req.session == {}, "a failed login must not leave any credential in the cookie"
+        assert errors == ["Invalid state parameter"]
+        assert revoked == [], "a forged callback revoked a live session"
+        assert req.session["session_id"] == "sid-live"
 
 
 class TestLogoutSurfacesRevocationFailure:
@@ -815,3 +809,35 @@ class TestLogoutSurfacesRevocationFailure:
 
         assert revoked == ["sid-live"]
         assert isinstance(res, RedirectResponse)
+
+
+@pytest.fixture(autouse=True)
+def in_flight_login_attempt(monkeypatch):
+    """Answer the callback's state lookup with a live attempt (#316).
+
+    The CSRF state moved out of the cookie and into an ``auth_state`` row, so a callback test
+    that seeds ``session["oauth_state"]`` no longer describes anything. This stands in for the
+    row: any non-empty ``state`` resolves to an attempt at the ``default`` provider, which is
+    what these cases were always about — the user-management half of the callback.
+
+    The state machinery itself is tested directly in ``test_auth_state.py`` and
+    ``test_provider_login.py``.
+    """
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+    from mlflow_oidc_auth.repository.auth_state import AuthAttempt
+
+    monkeypatch.setattr(
+        auth_router_mod.store,
+        "consume_auth_state",
+        # "unknown-state" stands for a state with no attempt behind it: unknown, already used,
+        # or expired. Everything else resolves, so a case can exercise the rest of the callback.
+        lambda state: None if not state or state == "unknown-state" else AuthAttempt(state=state, provider_id="default"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        auth_router_mod.config,
+        "AUTH_PROVIDERS",
+        RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
+        raising=False,
+    )

--- a/mlflow_oidc_auth/tests/test_routers_auth.py
+++ b/mlflow_oidc_auth/tests/test_routers_auth.py
@@ -841,3 +841,21 @@ def in_flight_login_attempt(monkeypatch):
         RegistryLoadResult(providers=[ProviderConfig(id="default", type="oidc", audience="mlflow")], errors=[], source="legacy"),
         raising=False,
     )
+
+    # Identity resolution and provisioning policy (#318) run inside the callback now, so the
+    # store has to answer two questions: is this username taken, and is this identity bound.
+    # A fresh principal at a jit provider — which is what these cases describe.
+    class _Identities:
+        def __init__(self):
+            self.bound = {}
+
+        def get_username_by_identity(self, provider_id, subject):
+            return self.bound.get((provider_id, subject))
+
+        def link(self, provider_id, subject, username, **kwargs):
+            self.bound[(provider_id, subject)] = username
+            return True
+
+    monkeypatch.setattr(auth_router_mod.store, "user_identity_repo", _Identities(), raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "has_user", lambda username: False, raising=False)
+    monkeypatch.setattr(auth_router_mod.store, "get_groups_for_user", lambda username: [], raising=False)

--- a/mlflow_oidc_auth/tests/test_routers_auth.py
+++ b/mlflow_oidc_auth/tests/test_routers_auth.py
@@ -823,7 +823,7 @@ def in_flight_login_attempt(monkeypatch):
     The state machinery itself is tested directly in ``test_auth_state.py`` and
     ``test_provider_login.py``.
     """
-    import mlflow_oidc_auth.routers.auth as auth_router_mod
+    from mlflow_oidc_auth.routers import auth as auth_router_mod
     from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
     from mlflow_oidc_auth.repository.auth_state import AuthAttempt
 


### PR DESCRIPTION
Closes #316 and #318. #318 is pulled forward because #316 without it is unsafe — see below.

## #316: per-provider login

- **`/login/{provider_id}` and `/callback/{provider_id}`**, legacy `/login` and `/callback` preserved for `default` so registered redirect URIs keep working. Each provider gets its own callback path.
- **`/providers`** — id, display name, type, login URL, for #317's picker. Unauthenticated by design.
- **State moved from the cookie into single-use `auth_state` rows.** One key held one attempt, so a second tab overwrote the first. Consuming the row *is* the CSRF check, and it is atomic: the delete claims the attempt, and a test runs two threads through one state asserting exactly one winner.
- **The RFC 9207 mix-up defence**, using the decision function from #354: the response must name the issuer the attempt began with, must arrive at that provider's callback path, and is exchanged at that provider's token endpoint.

## #318: per-provider provisioning, group sync and admin source

The first review of #316 found that a second browser login was account takeover: identity and admin came from deployment-wide configuration, so a partner tenant asserting `email: alice@corp.com` reached Alice's account. I initially held `interactive` back; you asked for #318 instead, so:

- **Identity via #309.** An unknown provider+subject is a **new principal**, never matched to an existing account by a claim, and the binding is recorded so the next login matches on it.
- **`provisioning`** — `jit` creates; `scim`/`none` refuse an unknown user (the enterprise gate).
- **`group_sync` / `group_sync_mode`** — none/first_login/every_login, additive/authoritative. `authoritative` genuinely removes what the claims no longer assert, which Keycloak's `FORCE` mapper does not.
- **`admin_source`** — `claims` or `none`, and it **defaults to `none` for any provider but the deployment's own**, because the admin group name is deployment-wide.
- **Group names are namespaced per provider** (`partner:finance-ds`). Names are the permission boundary — `set_user_groups` joins by name — so an unnamespaced second provider could assert `finance-ds` and inherit everything granted to the local group of that name. `default` keeps raw names.

## The finding that mattered most

The second review caught something that would have **locked every existing deployment out of its own MLflow**. The Phase 0 backfill wrote `user_identities(subject = username)`, but a real OIDC `sub` is not a username — so the first login after upgrading resolved to CREATE, found the name taken, and refused. Every user, every administrator, recoverable only through the database.

The `default` provider now **adopts** an account whose only binding is its own; no other provider may, and an unreadable binding set refuses rather than adopts. Every callback fixture patched `has_user` to `False`, which is exactly how a green suite hid this — the existing-user path is now driven end to end in `test_provider_login.py`.

Also fixed from that review: administrator status is **revoked** again when the claims stop asserting it (the new branching had made promotion one-way); a failed identity binding **fails the login** rather than leaving a row that can never log in again; an unreadable group membership **skips** an additive sync instead of writing an empty base over it; and the bearer path honours `admin_source` too.

## From the first review

- `provider_id` was reachable as a **query parameter**, bypassing the 404 gate on the scoped route. Path-only now.
- **Open redirect**: `?next=/\evil.com` and `/<tab>/evil.com` are resolved off-origin by browsers and passed the prefix check.
- **A forged cross-site `GET /callback` could force a logout**, because session handover ran before the state check. It now runs after the check and before the exchange — the second half matters because `_persist_session_auth` keeps an existing refresh token when the new response has none (#351).
- `is_oidc_configured()` gated every provider on the default's configuration.
- `/providers` was not on the unprotected list.

## Validation

```
pre-commit run --all-files              # passed
pytest -m 'not integration' .../tests   # 3856 passed, 14 skipped
pytest mlflow_oidc_auth/tests/perf/     # 37 passed — T0 budget unchanged
```

New: `test_provider_login.py`, `test_provisioning_policy.py`, `tests/repository/test_auth_state.py`.

## Known, not addressed

- The PKCE verifier still lives in authlib's cookie entry rather than the `auth_state` row, so login-CSRF ultimately rests on that cookie.
- `auth_state` and `auth_session` rows still have no sweep wired up.
- `auth.login` events and `auth_session` rows do not record which provider authenticated.
- Refusing on a username collision is a username-existence oracle for anyone controlling an onboarded provider. Inherent to refuse-on-collision; the audit event is the place to rate-limit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)