### PR TITLE
feat(auth): staged managed_by write guard with dry-run reconcile (#319)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,17 @@ so the telemetry exists a release before the enforcement does. Run on `report`, 
 `user.ownership_conflict` events you actually get, then move to `enforce`.
 
 An administrator action is permitted in every mode and always audited. That is deliberate: an
-operator who cannot fix ownership from the admin UI is left with the database.
+operator who cannot fix ownership without database access has been locked out by the thing that
+was supposed to protect them. There are two ways to do it:
+
+```bash
+# From the API, as an administrator — the decommissioned-directory case
+curl -X PATCH "$MLFLOW/api/2.0/mlflow/users/ownership" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"username": "alice@corp.example", "managed_by": "manual"}'
+```
+
+or in bulk with the CLI below, for an operator who has a shell.
 
 ### Changing ownership
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ The plugin uses TTL caches to avoid repeated database lookups on every request. 
 | `OIDC_HTTP_TIMEOUT_SECONDS` | Integer | `10` | Timeout (seconds) applied to OIDC discovery and JWKS HTTP fetches. Set lower for faster failover when the IdP is unreachable; without a timeout a hung IdP can block request threads until the OS-level TCP timeout (~2 minutes), causing cascading auth failures |
 | `OIDC_VERIFY_SSL` | Boolean | `true` | Verify the OIDC provider's TLS certificate on discovery, JWKS, and token requests. Only set to `false` for providers using self-signed certificates in a trusted network |
 | `OIDC_CODE_CHALLENGE` | String | `S256` | PKCE code-challenge method for the authorization-code flow. `S256` (or `true`/`yes`/`on`/`1`), or `none`/`off`/`false`/`no`/`0` to disable. An unrecognised value warns and falls back to `S256`. See [PKCE](#pkce) |
+| `MANAGED_BY_ENFORCEMENT` | String | `report` | What happens when one source writes a row another owns: `off`, `report` (audit only) or `enforce`. See [Row ownership](#row-ownership) |
 | `PERMISSION_CACHE_TTL_SECONDS` | Integer | `30` | Time-to-live (seconds) for the permission resolution cache. Cached permission decisions expire after this duration. Lower values mean faster propagation of permission changes; higher values reduce database load |
 | `CACHE_BACKEND` | String | `local` | Cache backend for permission and workspace caches. Options: `local` (in-process TTL cache) or `redis` (shared Redis instance). Use `redis` for multi-replica deployments where permission changes must propagate immediately across all replicas |
 | `CACHE_REDIS_URL` | String | None | Redis connection URL. Required when `CACHE_BACKEND=redis`. Example: `redis://localhost:6379/0` or `redis://:password@redis-host:6379/1` |
@@ -110,6 +111,49 @@ These settings only apply when `MLFLOW_ENABLE_WORKSPACES=true`.
 |----------|------|---------|-------------|
 | `LOG_LEVEL` | String | `INFO` | Application log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 | `LOGGING_LOGGER_NAME` | String | `uvicorn` | Logger name to configure. Defaults to the uvicorn logger for FastAPI compatibility |
+
+## Row ownership
+
+`managed_by` records which source a user row belongs to — `manual`, `scim`, or
+`oidc:<provider>`. `MANAGED_BY_ENFORCEMENT` decides what happens when a *different* source tries
+to write it:
+
+| Value | Behaviour |
+|---|---|
+| `off` | No evaluation at all |
+| `report` | **Default.** The conflict is audited as `user.ownership_conflict`, and the write proceeds |
+| `enforce` | The write is refused |
+
+It defaults to `report` on purpose. The failure mode of a write guard is lockout, and lockout
+cannot be repaired from inside a system that has just refused the write that would repair it —
+so the telemetry exists a release before the enforcement does. Run on `report`, look at what
+`user.ownership_conflict` events you actually get, then move to `enforce`.
+
+An administrator action is permitted in every mode and always audited. That is deliberate: an
+operator who cannot fix ownership from the admin UI is left with the database.
+
+### Changing ownership
+
+Ownership never changes implicitly — not at startup, not when a provider's configuration
+changes, not as a side effect of a login. It is an operator action with a diff you read first:
+
+```bash
+mlflow-oidc db reconcile-ownership --url "$DB" --from-owner scim --set-owner manual
+```
+
+That prints the diff and changes nothing. Add `--apply` to write it, and `--journal FILE` to
+record the prior ownership of every row it touches:
+
+```bash
+mlflow-oidc db reconcile-ownership --url "$DB" --from-owner scim --set-owner manual --apply --journal /tmp/ownership.json
+mlflow-oidc db restore-ownership --url "$DB" --journal /tmp/ownership.json --apply
+```
+
+The dry-run diff and the applied diff come from the same query, so what you approve is what
+runs. `restore-ownership` is also a dry run without `--apply`.
+
+**This is the repair path when a source is turned off.** Point `--from-owner` at it and
+`--set-owner` at `manual`, and the rows it used to own become editable again.
 
 ## PKCE
 

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -23,6 +23,7 @@ from dotenv import load_dotenv
 
 from mlflow_oidc_auth.config_providers import config_manager
 from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.ownership import parse_enforcement
 from mlflow_oidc_auth.provider_registry import build_provider_registry
 
 load_dotenv()  # take environment variables from .env.
@@ -144,6 +145,12 @@ class AppConfig:
         self.OIDC_CODE_CHALLENGE = self._parse_code_challenge(_code_challenge)
 
         # Permission cache settings
+        # Whether a write from one source may overwrite a row another source owns (#319).
+        # ``report`` by default and deliberately: the guard's failure mode is lockout, so the
+        # telemetry ships a release before the enforcement and an operator can look at their own
+        # traffic before turning it on.
+        self.MANAGED_BY_ENFORCEMENT = parse_enforcement(config_manager.get("MANAGED_BY_ENFORCEMENT", "report"))
+
         self.PERMISSION_CACHE_TTL_SECONDS = config_manager.get_int("PERMISSION_CACHE_TTL_SECONDS", default=30)
 
         # username source

--- a/mlflow_oidc_auth/db/cli.py
+++ b/mlflow_oidc_auth/db/cli.py
@@ -107,3 +107,160 @@ def prune_sessions(url: str, dry_run: bool) -> None:
         click.echo(f"deleted {expired} expired session(s)")
     finally:
         engine.dispose()
+
+
+@commands.command(name="reconcile-ownership")
+@click.option("--url", required=True, help="Database URL, e.g. sqlite:///auth.db")
+@click.option("--set-owner", required=True, help="The managed_by value to write, e.g. 'manual' or 'scim'.")
+@click.option("--from-owner", default=None, help="Only rows currently owned by this. Omit to match any owner.")
+@click.option("--username", default=None, help="Only this user. Omit for every matching row.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Actually write. Without it, nothing is changed.")
+@click.option("--all", "all_rows", is_flag=True, help="Required to match every row: without a filter this rewrites the whole user table.")
+@click.option("--journal", default=None, help="Where to record prior ownership, so a mistaken run can be rolled back.")
+def reconcile_ownership(url: str, set_owner: str, from_owner: str, username: str, apply_changes: bool, all_rows: bool, journal: str) -> None:
+    """Change which source owns user rows (issue #319).
+
+    **Dry run unless ``--apply`` is given**, and it never runs implicitly — not at startup, not
+    on a configuration change, not as a side effect of anything. Grafana shipped a silent runtime
+    branch that reset existing users ([grafana#73752](https://github.com/grafana/grafana/issues/73752));
+    the lesson is that ownership changes are an operator action with a diff they read first.
+
+    The diff a dry run prints is the diff an apply performs: both come from the same query, so
+    what you approve is what runs.
+
+    With ``--journal`` the prior ownership of every changed row is written to a JSON file before
+    anything is modified, and ``restore-ownership`` puts it back.
+
+    This is also the repair path when a source is turned off: point ``--from-owner`` at it and
+    ``--set-owner`` at ``manual``, and the rows it used to own become editable again.
+    """
+    import json as _json
+    import re as _re
+    from datetime import datetime, timezone
+
+    from mlflow_oidc_auth.db.models import SqlUser
+
+    # An owner string no source will ever present is worse than a rejected one: under 'enforce'
+    # every writer then conflicts with it forever, and the operator was usually in the middle of
+    # repairing a lockout when they typed it.
+    if not _re.fullmatch(r"manual|scim|oidc:[A-Za-z0-9._-]+", set_owner or ""):
+        raise click.ClickException(f"--set-owner {set_owner!r} is not an owner any source presents. Expected 'manual', 'scim', or 'oidc:<provider-id>'.")
+
+    if not from_owner and not username and not all_rows:
+        raise click.ClickException("refusing to re-own every user row without --all. Narrow it with --from-owner or --username, or pass --all deliberately.")
+
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.begin() as conn:
+            query = sqlalchemy.select(SqlUser.username, SqlUser.managed_by)
+            if from_owner:
+                query = query.where(SqlUser.managed_by == from_owner)
+            if username:
+                # Stored normalized, so a targeted repair typed in display capitalisation would
+                # otherwise match nothing and report "ownership is already fine".
+                query = query.where(SqlUser.username == username.strip().lower())
+            rows = [row for row in conn.execute(query).fetchall() if (row.managed_by or "manual") != set_owner]
+
+            if not rows:
+                click.echo("no rows to change")
+                return
+
+            for row in rows:
+                click.echo(f"{row.username}: {row.managed_by or 'manual'} -> {set_owner}")
+
+            if not apply_changes:
+                click.echo(f"\n{len(rows)} row(s) would change. Re-run with --apply to write them.")
+                return
+
+            if journal:
+                # 'x' rather than 'w': two runs pointed at one path would otherwise leave only
+                # the second recoverable, and the first run's prior ownership gone.
+                with open(journal, "x", encoding="utf-8") as handle:
+                    _json.dump(
+                        {
+                            "recorded_at": datetime.now(timezone.utc).isoformat(),
+                            "set_owner": set_owner,
+                            "previous": [{"username": row.username, "managed_by": row.managed_by} for row in rows],
+                        },
+                        handle,
+                        indent=2,
+                    )
+                click.echo(f"prior ownership recorded in {journal}")
+
+            for row in rows:
+                conn.execute(sqlalchemy.update(SqlUser).where(SqlUser.username == row.username).values(managed_by=set_owner))
+
+        emit_ownership_audit("user.ownership_reconciled", set_owner, [row.username for row in rows])
+        click.echo(f"\nchanged {len(rows)} row(s)")
+    finally:
+        engine.dispose()
+
+
+@commands.command(name="restore-ownership")
+@click.option("--url", required=True, help="Database URL, e.g. sqlite:///auth.db")
+@click.option("--journal", required=True, help="A journal written by reconcile-ownership --apply --journal.")
+@click.option("--apply", "apply_changes", is_flag=True, help="Actually write. Without it, nothing is changed.")
+def restore_ownership(url: str, journal: str, apply_changes: bool) -> None:
+    """Put ownership back the way a journalled reconciliation found it (issue #319).
+
+    Reversibility is the point: a reconciliation that turns out to have been wrong is otherwise
+    a hand-written UPDATE against production, from someone who has just learned they should not
+    be trusted with hand-written UPDATEs against production.
+    """
+    import json as _json
+
+    from mlflow_oidc_auth.db.models import SqlUser
+
+    with open(journal, "r", encoding="utf-8") as handle:
+        recorded = _json.load(handle)
+
+    previous = recorded.get("previous") or []
+    if not previous:
+        click.echo("journal records no changes")
+        return
+
+    engine = sqlalchemy.create_engine(url)
+    try:
+        for entry in previous:
+            click.echo(f"{entry['username']}: -> {entry['managed_by'] or 'manual'}")
+
+        if not apply_changes:
+            click.echo(f"\n{len(previous)} row(s) would be restored. Re-run with --apply to write them.")
+            return
+
+        restored = 0
+        skipped = []
+        with engine.begin() as conn:
+            for entry in previous:
+                # Only rows that still hold what the reconcile wrote. A row re-owned since then
+                # is somebody's newer decision, and silently reverting it would be a second,
+                # unjournalled loss.
+                result = conn.execute(
+                    sqlalchemy.update(SqlUser)
+                    .where(SqlUser.username == entry["username"], SqlUser.managed_by == recorded.get("set_owner"))
+                    .values(managed_by=entry["managed_by"])
+                )
+                if result.rowcount:
+                    restored += int(result.rowcount)
+                else:
+                    skipped.append(entry["username"])
+
+        emit_ownership_audit("user.ownership_restored", recorded.get("set_owner"), [entry["username"] for entry in previous])
+        click.echo(f"\nrestored {restored} row(s)")
+        if skipped:
+            click.echo(f"left alone (changed since the journal was written): {', '.join(skipped)}")
+    finally:
+        engine.dispose()
+
+
+def emit_ownership_audit(event: str, owner, usernames) -> None:
+    """Record a bulk ownership change. Out of band by nature, so it belongs in the audit log."""
+    from mlflow_oidc_auth.audit import emit_audit_event
+
+    emit_audit_event(
+        event,
+        actor="cli",
+        resource_type="user",
+        resource_id=",".join(usernames[:20]) + ("..." if len(usernames) > 20 else ""),
+        detail={"owner": owner, "count": len(usernames)},
+    )

--- a/mlflow_oidc_auth/db/cli.py
+++ b/mlflow_oidc_auth/db/cli.py
@@ -174,8 +174,13 @@ def reconcile_ownership(url: str, set_owner: str, from_owner: str, username: str
 
             if journal:
                 # 'x' rather than 'w': two runs pointed at one path would otherwise leave only
-                # the second recoverable, and the first run's prior ownership gone.
-                with open(journal, "x", encoding="utf-8") as handle:
+                # the second recoverable, and the first run's prior ownership gone. Reported as
+                # an operator error, because this command is read during a repair.
+                try:
+                    handle = open(journal, "x", encoding="utf-8")
+                except FileExistsError:
+                    raise click.ClickException(f"{journal} already exists, and overwriting it would discard the prior run's rollback. Choose another path.")
+                with handle:
                     _json.dump(
                         {
                             "recorded_at": datetime.now(timezone.utc).isoformat(),

--- a/mlflow_oidc_auth/ownership.py
+++ b/mlflow_oidc_auth/ownership.py
@@ -1,0 +1,129 @@
+"""Who may write a row that another source owns (issue #319).
+
+``managed_by`` (#311) records which source a user row belongs to — ``manual``, ``scim``, or
+``oidc:<provider>``. Per-provider policy (#318) is a promise about what each source *should* do;
+this is what stops one source silently overwriting another's row when it does something else.
+
+**Staged, because the failure mode is lockout.** A guard that refuses writes cannot be recovered
+from inside the system once it has refused the write that would have fixed it — and a
+directory sync that suddenly stops updating the accounts it has always updated is the same
+outage from the other direction. So enforcement has three states and defaults to the middle one:
+
+``off``
+    No evaluation. What a deployment that has never heard of this gets.
+
+``report``
+    The guard evaluates and records what it *would* have refused, and changes nothing. The
+    default, so the telemetry ships a release before the enforcement does and an operator can
+    look at real traffic before turning it on.
+
+``enforce``
+    The refusal is real.
+
+**The break-glass rule.** An explicit administrator action is always permitted, in every mode,
+and is always audited. An operator who cannot repair ownership from the admin UI has only the
+database left, and a guard that produces that state has failed at its job rather than done it.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from mlflow_oidc_auth.logger import get_logger
+
+logger = get_logger()
+
+#: Row owner meaning "no external source claims this" — a hand-created account, or one whose
+#: source was turned off. Always writable.
+MANUAL = "manual"
+
+
+class Enforcement(str, Enum):
+    """How seriously a cross-source write is taken."""
+
+    OFF = "off"
+    REPORT = "report"
+    ENFORCE = "enforce"
+
+
+@dataclass(frozen=True)
+class OwnershipDecision:
+    """Whether a write may proceed, and what to say about it.
+
+    Attributes:
+        allowed: Whether the caller may write.
+        conflict: Whether the write crosses ownership — true even when ``allowed`` is, which is
+            exactly the ``report`` case worth counting.
+        reason: Human-readable explanation. Empty when there is nothing to say.
+        owner: The row's current owner, when there is a conflict.
+    """
+
+    allowed: bool
+    conflict: bool = False
+    reason: str = ""
+    owner: Optional[str] = None
+
+
+def parse_enforcement(value) -> Enforcement:
+    """Read the configured enforcement mode, defaulting to ``report``.
+
+    An unrecognised value reports rather than enforces: getting this wrong should not be the
+    thing that starts refusing writes.
+    """
+    if value is None:
+        return Enforcement.REPORT
+    try:
+        return Enforcement(str(value).strip().lower())
+    except ValueError:
+        logger.warning("Unrecognised MANAGED_BY_ENFORCEMENT %r; using 'report'. Expected one of: off, report, enforce.", value)
+        return Enforcement.REPORT
+
+
+def evaluate_write(current_owner: Optional[str], writer: Optional[str], *, enforcement: Enforcement, admin_override: bool = False) -> OwnershipDecision:
+    """Decide whether ``writer`` may write a row owned by ``current_owner``.
+
+    Parameters:
+        current_owner: The row's ``managed_by``. None or ``manual`` means unowned.
+        writer: The source attempting the write. None means an unattributed internal write, which
+            is treated as manual.
+        enforcement: The configured mode.
+        admin_override: Whether an administrator asked for this explicitly.
+
+    Returns:
+        OwnershipDecision: ``allowed`` says whether to proceed; ``conflict`` says whether it
+        crossed ownership, which is what ``report`` mode exists to count.
+    """
+    writer = writer or MANUAL
+    owner = current_owner or MANUAL
+
+    if owner == writer or owner == MANUAL:
+        # Nothing owns it, or the same source owns it. The overwhelmingly common case, and it is
+        # deliberately not audited: a guard that logs every ordinary write teaches operators to
+        # ignore it.
+        return OwnershipDecision(allowed=True)
+
+    if admin_override:
+        # Break glass. Always permitted, always recorded — an operator who cannot repair
+        # ownership from the admin UI is left with the database, which is how a guard turns into
+        # an outage.
+        return OwnershipDecision(
+            allowed=True,
+            conflict=True,
+            owner=owner,
+            reason=f"administrator override: writing a row owned by {owner!r} as {writer!r}",
+        )
+
+    reason = f"{writer!r} may not write a row owned by {owner!r}"
+    # ``==`` rather than ``is``: ``Enforcement`` is a str-Enum, so a caller holding the raw
+    # configured string — a plugin, a config reload, a test helper mirroring the environment —
+    # would miss both identity checks and fall through to "allowed", leaving the guard silently
+    # off while every log line said ``enforce``.
+    if enforcement == Enforcement.ENFORCE:
+        return OwnershipDecision(allowed=False, conflict=True, owner=owner, reason=reason)
+
+    if enforcement == Enforcement.OFF:
+        return OwnershipDecision(allowed=True)
+
+    # Anything else reports, including a value that is neither of the three: an unreadable
+    # setting must not be the thing that turns the guard off.
+    return OwnershipDecision(allowed=True, conflict=True, owner=owner, reason=f"{reason} (report mode: permitted, and recorded)")

--- a/mlflow_oidc_auth/ownership.py
+++ b/mlflow_oidc_auth/ownership.py
@@ -21,8 +21,9 @@ outage from the other direction. So enforcement has three states and defaults to
     The refusal is real.
 
 **The break-glass rule.** An explicit administrator action is always permitted, in every mode,
-and is always audited. An operator who cannot repair ownership from the admin UI has only the
-database left, and a guard that produces that state has failed at its job rather than done it.
+and is always audited: ``PATCH /api/2.0/mlflow/users/ownership`` hands a row to another source,
+and ``mlflow-oidc db reconcile-ownership`` does it in bulk. A guard whose only recovery needs
+database access has produced the state it exists to prevent.
 """
 
 from dataclasses import dataclass

--- a/mlflow_oidc_auth/repository/user.py
+++ b/mlflow_oidc_auth/repository/user.py
@@ -3,6 +3,7 @@ from typing import Callable, List, Optional
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
+    INVALID_PARAMETER_VALUE,
     INVALID_STATE,
     RESOURCE_ALREADY_EXISTS,
     RESOURCE_DOES_NOT_EXIST,
@@ -16,9 +17,30 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from mlflow_oidc_auth.db.models import SqlAuthSession, SqlGroup, SqlUser
 from mlflow_oidc_auth.entities import User
 from mlflow_oidc_auth.logger import get_logger
+from mlflow_oidc_auth.config import config
+from mlflow_oidc_auth.ownership import evaluate_write
 from mlflow_oidc_auth.repository.utils import get_user
 
 logger = get_logger()
+
+
+def _audit_ownership_conflict(username: str, decision, written_by: Optional[str], *, allowed: bool) -> None:
+    """Record a write that crossed ownership.
+
+    Emitted in ``report`` mode as well as ``enforce`` — that is what ``report`` is *for*: the
+    same event, with ``status`` saying whether it was permitted, so an operator can count what
+    enforcement would refuse before enabling it.
+    """
+    from mlflow_oidc_auth.audit import emit_audit_event
+
+    emit_audit_event(
+        "user.ownership_conflict",
+        actor=written_by or "manual",
+        resource_type="user",
+        resource_id=username,
+        detail={"owner": decision.owner, "written_by": written_by or "manual", "reason": decision.reason, "permitted": allowed},
+        status="success" if allowed else "denied",
+    )
 
 
 def _audit_sessions_revoked(username: str, count: int, reason: str) -> None:
@@ -247,6 +269,8 @@ class UserRepository:
         is_service_account: Optional[bool] = None,
         active: Optional[bool] = None,
         managed_by: Optional[str] = None,
+        written_by: Optional[str] = None,
+        admin_override: bool = False,
     ) -> User:
         """Update the supplied fields of a user, leaving omitted ones untouched.
 
@@ -278,6 +302,10 @@ class UserRepository:
             active: Whether the account may authenticate. Setting it False is how a directory
                 deprovisions a user (issue #311).
             managed_by: Which source owns this row.
+            written_by: Which source is performing this write, for the ownership guard (#319).
+                None means an unattributed internal write, treated as ``manual``.
+            admin_override: Whether an administrator asked for this explicitly. Break glass:
+                always permitted, always audited.
 
         Returns:
             User: The updated user entity.
@@ -290,8 +318,33 @@ class UserRepository:
 
         username = normalize_username(username)
         sessions_revoked = 0
+        permitted_conflict = None
         with self._Session(read_only=False) as session:
             user = get_user(session, username)
+            # A write from one source must not silently overwrite a row another source owns.
+            # Evaluated before anything is changed, so ``enforce`` refuses rather than
+            # half-applies, and ``report`` records the conflict without altering the outcome.
+            decision = evaluate_write(
+                getattr(user, "managed_by", None),
+                written_by,
+                enforcement=config.MANAGED_BY_ENFORCEMENT,
+                admin_override=admin_override,
+            )
+            if decision.conflict and not decision.allowed:
+                # Refusals are recorded immediately: nothing was written, so there is no commit
+                # for the record to outlive.
+                _audit_ownership_conflict(username, decision, written_by, allowed=False)
+            elif decision.conflict:
+                # A permitted conflict is recorded *after* the commit, further down. Written
+                # here it would claim a cross-source write that a later rollback undid — and
+                # this event is the one thing an operator reads to decide whether to enforce.
+                permitted_conflict = decision
+            if not decision.allowed:
+                raise MlflowException(
+                    f"User '{username}' is managed by {decision.owner!r} and cannot be changed by {written_by or 'manual'!r}.",
+                    INVALID_PARAMETER_VALUE,
+                )
+
             if password is not None:
                 user.password_hash = generate_password_hash(password, method=TOKEN_HASH_METHOD)
                 # A new secret gets the lifetime it was issued with, never the old one's.
@@ -331,7 +384,9 @@ class UserRepository:
             session.flush()
             entity = user.to_mlflow_entity()
 
-        # Past the ``with``: the transaction has committed, so the event is true when written.
+        # Past the ``with``: the transaction has committed, so the events are true when written.
+        if permitted_conflict is not None:
+            _audit_ownership_conflict(username, permitted_conflict, written_by, allowed=True)
         if sessions_revoked:
             _audit_sessions_revoked(username, sessions_revoked, "user_deactivated")
         return entity

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -1001,7 +1001,7 @@ async def _process_oidc_callback_fastapi(request: Request, session, provider_id:
                 # their next login, and a provider allowed to grant admin must be allowed to take
                 # it away. A provider with ``admin_source: none`` says nothing either way, so it
                 # neither promotes nor demotes.
-                user_module.create_user(username=username, display_name=display_name, is_admin=is_admin)
+                user_module.create_user(username=username, display_name=display_name, is_admin=is_admin, written_by=f"oidc:{provider.id}")
 
             # Bind the identity so the next login matches on it rather than on a claim.
             #

--- a/mlflow_oidc_auth/routers/users.py
+++ b/mlflow_oidc_auth/routers/users.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import re
 from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException
@@ -34,6 +35,7 @@ users_router = APIRouter(
 
 USERS_ROOT = ""
 CREATE_ACCESS_TOKEN = "/access-token"
+USER_OWNERSHIP = "/ownership"
 CURRENT_USER = "/current"
 USERNAME = "/{username}"
 
@@ -272,6 +274,59 @@ async def create_new_user(
     except Exception as e:
         logger.error(f"Error creating user: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to create user")
+
+
+@users_router.patch(
+    USER_OWNERSHIP,
+    summary="Change which source owns a user",
+    description="Sets a user's managed_by. Admins only. This is the break-glass path when a directory is decommissioned.",
+)
+async def set_user_ownership(
+    username: str = Body(..., description="The user whose ownership is being changed"),
+    managed_by: str = Body(..., description="The new owner: 'manual', 'scim', or 'oidc:<provider-id>'"),
+    admin_username: str = Depends(check_admin_permission),
+) -> JSONResponse:
+    """Hand a user row to a different source (issue #319).
+
+    The guard's whole failure mode is lockout, and lockout is only survivable if an
+    administrator can undo it *without* database access. That is what this is: an explicit,
+    audited administrator write, permitted in every enforcement mode.
+
+    The common case is a directory being decommissioned — its rows are set back to ``manual``
+    and become editable again. ``mlflow-oidc db reconcile-ownership`` does the same thing in
+    bulk, for an operator who does have a shell.
+
+    Parameters:
+        username: The user whose ownership is being changed.
+        managed_by: The new owner.
+        admin_username: The authenticated administrator (injected).
+
+    Returns:
+        JSONResponse: What changed.
+
+    Raises:
+        HTTPException: 400 if the owner is not one a source presents, 404 if there is no such
+            user.
+    """
+    if not re.fullmatch(r"manual|scim|oidc:[A-Za-z0-9._-]+", managed_by or ""):
+        raise HTTPException(status_code=400, detail="managed_by must be 'manual', 'scim', or 'oidc:<provider-id>'")
+
+    try:
+        store.get_user_profile(username)
+    except MlflowException:
+        raise HTTPException(status_code=404, detail=f"User {username} not found")
+
+    previous = store.get_user_profile(username).managed_by
+    store.update_user(username=username, managed_by=managed_by, written_by="manual", admin_override=True)
+    emit_audit_event(
+        "user.ownership_set",
+        actor=admin_username,
+        resource_type="user",
+        resource_id=username,
+        detail={"from": previous, "to": managed_by},
+    )
+    logger.info("Administrator %s set ownership of %s from %s to %s", admin_username, username, previous, managed_by)
+    return JSONResponse(content={"username": username, "managed_by": managed_by, "previous": previous}, status_code=200)
 
 
 @users_router.delete(

--- a/mlflow_oidc_auth/routers/users.py
+++ b/mlflow_oidc_auth/routers/users.py
@@ -133,7 +133,9 @@ async def create_access_token(
         # requested here; it never inherits the previous token's (issue #338).
         previous_expiration = user.password_expiration
         new_token = generate_token()
-        store.update_user(username=target_username, password=new_token, password_expiration=expiration)
+        # An administrator acting through the admin API is break glass by definition: they must
+        # be able to repair a row a directory owns, and the attempt is audited either way (#319).
+        store.update_user(username=target_username, password=new_token, password_expiration=expiration, written_by="manual", admin_override=True)
         emit_audit_event(
             "user.token_rotate",
             actor=current_username,

--- a/mlflow_oidc_auth/sqlalchemy_store.py
+++ b/mlflow_oidc_auth/sqlalchemy_store.py
@@ -384,6 +384,8 @@ class SqlAlchemyStore:
         is_service_account: Optional[bool] = None,
         active: Optional[bool] = None,
         managed_by: Optional[str] = None,
+        written_by: Optional[str] = None,
+        admin_override: bool = False,
     ) -> User:
         """Update the supplied fields of a user, leaving omitted ones untouched.
 
@@ -424,6 +426,8 @@ class SqlAlchemyStore:
             is_service_account=is_service_account,
             active=active,
             managed_by=managed_by,
+            written_by=written_by,
+            admin_override=admin_override,
         )
 
     def delete_user(self, username: str):

--- a/mlflow_oidc_auth/tests/routers/test_auth.py
+++ b/mlflow_oidc_auth/tests/routers/test_auth.py
@@ -634,7 +634,9 @@ class TestProcessOIDCCallbackFastAPI:
 
             assert username == "test@example.com"
             assert errors == []
-            mock_user_management["create_user"].assert_called_once_with(username="test@example.com", display_name="test@example.com", is_admin=False)
+            mock_user_management["create_user"].assert_called_once_with(
+                username="test@example.com", display_name="test@example.com", is_admin=False, written_by="oidc:default"
+            )
 
     @pytest.mark.asyncio
     async def test_process_callback_unauthorized_user(self, mock_request_with_session, mock_oauth, mock_config):

--- a/mlflow_oidc_auth/tests/test_ownership_guard.py
+++ b/mlflow_oidc_auth/tests/test_ownership_guard.py
@@ -1,0 +1,419 @@
+"""The managed_by write guard, staged (issue #319).
+
+Per-provider policy (#318) says what each source *should* write. This is what stops one source
+silently overwriting a row another owns when it writes something else.
+
+The failure mode being designed against is **lockout**, which cannot be recovered from inside a
+system that has just refused the write that would fix it. That is why enforcement has three
+states, why it defaults to the middle one, and why an administrator override exists in every
+mode. Those three properties get the most cases here.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow_oidc_auth.db.cli import commands
+from mlflow_oidc_auth.ownership import Enforcement, evaluate_write, parse_enforcement
+
+PASSWORD = "ownership-token"  # not a credential: only ever seeded into a tmp_path database
+
+
+class TestTheEnforcementModes:
+    def test_it_defaults_to_report(self):
+        """The telemetry ships a release before the enforcement does."""
+        assert parse_enforcement(None) is Enforcement.REPORT
+
+    @pytest.mark.parametrize("value,expected", [("off", Enforcement.OFF), ("report", Enforcement.REPORT), ("enforce", Enforcement.ENFORCE)])
+    def test_the_three_states_parse(self, value, expected):
+        assert parse_enforcement(value) is expected
+        assert parse_enforcement(value.upper()) is expected
+
+    def test_an_unrecognised_value_reports_rather_than_enforces(self):
+        """Getting this setting wrong must not be the thing that starts refusing writes."""
+        assert parse_enforcement("enfroce") is Enforcement.REPORT
+
+
+class TestOrdinaryWrites:
+    """The common case, which must stay silent: a guard that logs every write teaches operators
+    to ignore it."""
+
+    def test_a_source_may_write_its_own_rows(self):
+        decision = evaluate_write("scim", "scim", enforcement=Enforcement.ENFORCE)
+
+        assert (decision.allowed, decision.conflict) == (True, False)
+
+    def test_anyone_may_write_an_unowned_row(self):
+        for owner in (None, "manual"):
+            decision = evaluate_write(owner, "scim", enforcement=Enforcement.ENFORCE)
+
+            assert (decision.allowed, decision.conflict) == (True, False)
+
+    def test_an_unattributed_write_counts_as_manual(self):
+        assert evaluate_write("manual", None, enforcement=Enforcement.ENFORCE).allowed is True
+
+
+class TestCrossSourceWrites:
+    def test_enforce_refuses(self):
+        decision = evaluate_write("scim", "oidc:entra", enforcement=Enforcement.ENFORCE)
+
+        assert decision.allowed is False
+        assert decision.conflict is True
+        assert decision.owner == "scim"
+
+    def test_report_permits_and_records(self):
+        """The whole point of the middle state: the same event, counted, with nothing changed."""
+        decision = evaluate_write("scim", "oidc:entra", enforcement=Enforcement.REPORT)
+
+        assert decision.allowed is True
+        assert decision.conflict is True
+        assert "report mode" in decision.reason
+
+    def test_off_says_nothing_at_all(self):
+        decision = evaluate_write("scim", "oidc:entra", enforcement=Enforcement.OFF)
+
+        assert (decision.allowed, decision.conflict) == (True, False)
+
+
+class TestBreakGlass:
+    """An operator who cannot repair ownership from the admin UI has only the database left."""
+
+    @pytest.mark.parametrize("mode", list(Enforcement))
+    def test_an_administrator_override_is_always_permitted(self, mode):
+        decision = evaluate_write("scim", "manual", enforcement=mode, admin_override=True)
+
+        assert decision.allowed is True
+
+    def test_and_is_always_recorded(self):
+        decision = evaluate_write("scim", "manual", enforcement=Enforcement.ENFORCE, admin_override=True)
+
+        assert decision.conflict is True
+        assert "override" in decision.reason
+
+
+class TestTheGuardOnTheWritePath:
+    @pytest.fixture
+    def store(self, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        s.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        s.create_user("scim-owned@example.com", PASSWORD, "Directory User")
+        s.user_repo.update("scim-owned@example.com", managed_by="scim")
+        yield s
+        s.engine.dispose()
+
+    @pytest.fixture
+    def enforcing(self, monkeypatch):
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.ENFORCE)
+
+    def test_a_foreign_source_is_refused_under_enforce(self, store, enforcing):
+        from mlflow.exceptions import MlflowException
+
+        with pytest.raises(MlflowException, match="managed by"):
+            store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="oidc:entra")
+
+    def test_nothing_is_written_when_it_is_refused(self, store, enforcing):
+        from mlflow.exceptions import MlflowException
+
+        with pytest.raises(MlflowException):
+            store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="oidc:entra")
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is False
+
+    def test_the_owning_source_still_writes(self, store, enforcing):
+        store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="scim")
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is True
+
+    def test_report_mode_lets_the_write_through(self, store, monkeypatch):
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.REPORT)
+
+        store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="oidc:entra")
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is True
+
+    def test_an_administrator_override_writes_under_enforce(self, store, enforcing):
+        store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="manual", admin_override=True)
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is True
+
+    def test_the_conflict_is_audited_in_both_modes(self, store, monkeypatch):
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        events = []
+        monkeypatch.setattr("mlflow_oidc_auth.audit.emit_audit_event", lambda event, **kwargs: events.append((event, kwargs)))
+
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.REPORT)
+        store.user_repo.update("scim-owned@example.com", is_admin=True, written_by="oidc:entra")
+
+        assert [event for event, _ in events] == ["user.ownership_conflict"]
+        assert events[0][1]["status"] == "success", "report mode permitted it, and says so"
+        assert events[0][1]["detail"]["owner"] == "scim"
+
+
+class TestLockout:
+    """The scenario the whole design is arranged around, tested rather than reviewed."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        s.create_user("admin@example.com", PASSWORD, "Admin", is_admin=True)
+        s.create_user("second-admin@example.com", PASSWORD, "Second", is_admin=True)
+        yield s
+        s.engine.dispose()
+
+    def test_an_admin_owned_by_a_directory_can_still_be_repaired(self, store, monkeypatch):
+        """The lockout: the directory owns every admin, the directory is gone, and the guard is
+        enforcing. An administrator override has to be able to hand ownership back."""
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        store.user_repo.update("admin@example.com", managed_by="scim")
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.ENFORCE)
+
+        store.user_repo.update("admin@example.com", managed_by="manual", written_by="manual", admin_override=True)
+
+        assert store.get_user_profile("admin@example.com").managed_by == "manual"
+
+    def test_the_break_glass_cli_is_not_subject_to_the_guard(self, store, tmp_path, monkeypatch):
+        """``restore-admin`` talks to the database directly, precisely so that a guard cannot be
+        the reason an operator cannot recover."""
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        store.user_repo.update("admin@example.com", managed_by="scim", is_admin=False)
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.ENFORCE)
+
+        result = CliRunner().invoke(commands, ["restore-admin", "--url", str(store.engine.url), "--username", "admin@example.com"])
+
+        assert result.exit_code == 0, result.output
+        profile = store.get_user_profile("admin@example.com")
+        assert (profile.is_admin, profile.managed_by) == (True, "manual")
+
+
+class TestReconcileOwnership:
+    @pytest.fixture
+    def store(self, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        for name in ("a@example.com", "b@example.com"):
+            s.create_user(name, PASSWORD, name)
+            s.user_repo.update(name, managed_by="scim")
+        s.create_user("manual@example.com", PASSWORD, "Manual")
+        yield s
+        s.engine.dispose()
+
+    def _run(self, store, *args):
+        result = CliRunner().invoke(commands, ["reconcile-ownership", "--url", str(store.engine.url), *args])
+        assert result.exit_code == 0, result.output
+        return result.output
+
+    def test_a_dry_run_changes_nothing(self, store):
+        output = self._run(store, "--set-owner", "manual", "--from-owner", "scim")
+
+        assert "would change" in output
+        assert store.get_user_profile("a@example.com").managed_by == "scim"
+
+    def test_the_dry_run_diff_is_what_apply_does(self, store):
+        """If these ever diverge, an operator approves one thing and runs another."""
+        planned = [line for line in self._run(store, "--set-owner", "manual", "--from-owner", "scim").splitlines() if "->" in line]
+
+        applied = [line for line in self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply").splitlines() if "->" in line]
+
+        assert planned == applied
+
+    def test_apply_writes(self, store):
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply")
+
+        assert store.get_user_profile("a@example.com").managed_by == "manual"
+        assert store.get_user_profile("b@example.com").managed_by == "manual"
+
+    def test_rows_owned_by_someone_else_are_untouched(self, store):
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply")
+
+        assert store.get_user_profile("manual@example.com").managed_by in (None, "manual")
+
+    def test_one_user_can_be_targeted(self, store):
+        self._run(store, "--set-owner", "manual", "--username", "a@example.com", "--apply")
+
+        assert store.get_user_profile("a@example.com").managed_by == "manual"
+        assert store.get_user_profile("b@example.com").managed_by == "scim"
+
+    def test_a_mistaken_run_can_be_rolled_back(self, store, tmp_path):
+        journal = tmp_path / "ownership.json"
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply", "--journal", str(journal))
+        assert store.get_user_profile("a@example.com").managed_by == "manual"
+
+        result = CliRunner().invoke(commands, ["restore-ownership", "--url", str(store.engine.url), "--journal", str(journal), "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert store.get_user_profile("a@example.com").managed_by == "scim"
+        assert store.get_user_profile("b@example.com").managed_by == "scim"
+
+    def test_a_restore_is_a_dry_run_too_without_apply(self, store, tmp_path):
+        journal = tmp_path / "ownership.json"
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply", "--journal", str(journal))
+
+        CliRunner().invoke(commands, ["restore-ownership", "--url", str(store.engine.url), "--journal", str(journal)])
+
+        assert store.get_user_profile("a@example.com").managed_by == "manual", "a restore without --apply changed something"
+
+    def test_the_journal_records_what_it_found(self, store, tmp_path):
+        journal = tmp_path / "ownership.json"
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply", "--journal", str(journal))
+
+        recorded = json.loads(journal.read_text())
+
+        assert recorded["set_owner"] == "manual"
+        assert sorted(entry["username"] for entry in recorded["previous"]) == ["a@example.com", "b@example.com"]
+        assert {entry["managed_by"] for entry in recorded["previous"]} == {"scim"}
+
+
+class TestTheOwningSourceIsNotLockedOut:
+    """The failure the guard is most likely to cause is not a bypass — it is refusing the writes
+    it was supposed to permit.
+
+    Attribution has to reach the store, or every write looks like ``manual`` and ``enforce``
+    refuses a directory's own sync on the rows that directory owns. That is a lockout of exactly
+    the users the guard exists to protect, and it is invisible to a test that always passes
+    ``written_by`` explicitly.
+    """
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        s.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        s.create_user("scim-owned@example.com", PASSWORD, "Directory User")
+        s.user_repo.update("scim-owned@example.com", managed_by="scim")
+        yield s
+        s.engine.dispose()
+
+    @pytest.fixture
+    def enforcing(self, monkeypatch):
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.ENFORCE)
+
+    def test_the_store_carries_attribution_through(self, store, enforcing):
+        """``store.update_user`` is what every production caller uses."""
+        store.update_user(username="scim-owned@example.com", is_admin=True, written_by="scim")
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is True
+
+    def test_a_login_at_the_owning_provider_is_not_refused(self, store, enforcing, monkeypatch):
+        """The concrete lockout: the directory owns the row, and its own users log in."""
+        import mlflow_oidc_auth.user as user_module
+
+        monkeypatch.setattr(user_module, "store", store)
+        # Re-owning is itself an operator action, so it goes through the override — which is the
+        # break-glass path working, before the case below exercises the ordinary one.
+        store.user_repo.update("scim-owned@example.com", managed_by="oidc:entra", written_by="manual", admin_override=True)
+
+        created, message = user_module.create_user(
+            username="scim-owned@example.com",
+            display_name="Directory User",
+            written_by="oidc:entra",
+        )
+
+        assert created is False and "already exists" in message
+
+    def test_a_login_at_a_different_provider_is_refused_clearly(self, store, enforcing, monkeypatch):
+        """And when it *is* a foreign write, the error says so rather than reporting that the
+        user already exists — which is what the create fallback used to turn it into."""
+        from mlflow.exceptions import MlflowException
+
+        import mlflow_oidc_auth.user as user_module
+
+        monkeypatch.setattr(user_module, "store", store)
+
+        with pytest.raises(MlflowException, match="managed by"):
+            user_module.create_user(username="scim-owned@example.com", display_name="X", written_by="oidc:entra")
+
+    def test_an_unattributed_write_still_works_in_report_mode(self, store, monkeypatch):
+        """Every caller that has not been taught to attribute itself yet — the default mode is
+        what keeps them working while that happens."""
+        import mlflow_oidc_auth.repository.user as user_repo
+
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.REPORT)
+
+        store.update_user(username="scim-owned@example.com", is_admin=True)
+
+        assert store.get_user_profile("scim-owned@example.com").is_admin is True
+
+
+class TestTheReconcileCommandRefusesFootguns:
+    @pytest.fixture
+    def store(self, tmp_path):
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        s = SqlAlchemyStore()
+        s.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        s.create_user("a@example.com", PASSWORD, "A")
+        s.user_repo.update("a@example.com", managed_by="scim")
+        yield s
+        s.engine.dispose()
+
+    def _run(self, store, *args):
+        return CliRunner().invoke(commands, ["reconcile-ownership", "--url", str(store.engine.url), *args])
+
+    @pytest.mark.parametrize("owner", ["scmi", " manual", "SCIM", "oidc:", "", "anything"])
+    def test_an_owner_no_source_presents_is_refused(self, store, owner):
+        """Under enforce, a typo'd owner means every writer conflicts with it forever — usually
+        typed by someone already repairing a lockout."""
+        result = self._run(store, "--set-owner", owner, "--from-owner", "scim", "--apply")
+
+        assert result.exit_code != 0
+        assert store.get_user_profile("a@example.com").managed_by == "scim"
+
+    def test_re_owning_everything_needs_saying_so(self, store):
+        result = self._run(store, "--set-owner", "scim", "--apply")
+
+        assert result.exit_code != 0
+        assert "--all" in result.output
+
+    def test_all_makes_it_explicit(self, store):
+        result = self._run(store, "--set-owner", "manual", "--all", "--apply")
+
+        assert result.exit_code == 0, result.output
+        assert store.get_user_profile("a@example.com").managed_by == "manual"
+
+    def test_a_username_is_matched_as_stored(self, store):
+        """Typed in display capitalisation, this used to report "no rows to change" — read during
+        a repair, that means "ownership is already fine"."""
+        result = self._run(store, "--set-owner", "manual", "--username", "A@Example.com", "--apply")
+
+        assert result.exit_code == 0, result.output
+        assert store.get_user_profile("a@example.com").managed_by == "manual"
+
+    def test_a_journal_is_never_overwritten(self, store, tmp_path):
+        journal = tmp_path / "ownership.json"
+        journal.write_text("{}")
+
+        result = self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply", "--journal", str(journal))
+
+        assert result.exit_code != 0, "the first run's prior ownership would have been lost"
+
+    def test_a_restore_leaves_rows_that_changed_since(self, store, tmp_path):
+        journal = tmp_path / "ownership.json"
+        self._run(store, "--set-owner", "manual", "--from-owner", "scim", "--apply", "--journal", str(journal))
+        # Somebody re-owns it deliberately afterwards.
+        store.user_repo.update("a@example.com", managed_by="oidc:entra")
+
+        result = CliRunner().invoke(commands, ["restore-ownership", "--url", str(store.engine.url), "--journal", str(journal), "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert store.get_user_profile("a@example.com").managed_by == "oidc:entra", "a newer decision was reverted"
+        assert "left alone" in result.output

--- a/mlflow_oidc_auth/tests/test_ownership_guard.py
+++ b/mlflow_oidc_auth/tests/test_ownership_guard.py
@@ -16,6 +16,9 @@ from click.testing import CliRunner
 
 from mlflow_oidc_auth.db.cli import commands
 from mlflow_oidc_auth.ownership import Enforcement, evaluate_write, parse_enforcement
+from mlflow_oidc_auth.routers._prefix import USERS_ROUTER_PREFIX
+
+OWNERSHIP_ROUTE = f"{USERS_ROUTER_PREFIX}/ownership"
 
 PASSWORD = "ownership-token"  # not a credential: only ever seeded into a tmp_path database
 
@@ -417,3 +420,83 @@ class TestTheReconcileCommandRefusesFootguns:
         assert result.exit_code == 0, result.output
         assert store.get_user_profile("a@example.com").managed_by == "oidc:entra", "a newer decision was reverted"
         assert "left alone" in result.output
+
+
+class TestRepairFromTheAdminApi:
+    """The break-glass path an operator can actually reach.
+
+    A guard whose only recovery needs shell and database access has produced the state it exists
+    to prevent, so the promise in the module docstring has to be backed by a route.
+    """
+
+    @pytest.fixture
+    def client(self, tmp_path, monkeypatch):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        import mlflow_oidc_auth.routers.users as users_router
+        import mlflow_oidc_auth.repository.user as user_repo
+        from mlflow_oidc_auth.dependencies import check_admin_permission
+        from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
+
+        store = SqlAlchemyStore()
+        store.init_db(f"sqlite:///{tmp_path / 'auth.db'}")
+        store.create_user("keeper@example.com", PASSWORD, "Keeper", is_admin=True)
+        store.create_user("locked@example.com", PASSWORD, "Locked Out", is_admin=True)
+        store.user_repo.update("locked@example.com", managed_by="scim")
+
+        monkeypatch.setattr(users_router, "store", store)
+        monkeypatch.setattr(user_repo.config, "MANAGED_BY_ENFORCEMENT", Enforcement.ENFORCE)
+
+        app = FastAPI()
+        app.include_router(users_router.users_router)
+        app.dependency_overrides[check_admin_permission] = lambda: "keeper@example.com"
+
+        with TestClient(app) as test_client:
+            yield test_client, store
+        store.engine.dispose()
+
+    def test_an_administrator_can_hand_a_row_back_to_manual(self, client):
+        """The decommissioned-directory case, without touching the database."""
+        test_client, store = client
+
+        response = test_client.patch(OWNERSHIP_ROUTE, json={"username": "locked@example.com", "managed_by": "manual"})
+
+        assert response.status_code == 200, response.text
+        assert response.json()["previous"] == "scim"
+        assert store.get_user_profile("locked@example.com").managed_by == "manual"
+
+    def test_and_the_row_is_writable_again_afterwards(self, client):
+        test_client, store = client
+        test_client.patch(OWNERSHIP_ROUTE, json={"username": "locked@example.com", "managed_by": "manual"})
+
+        store.update_user(username="locked@example.com", is_admin=True, written_by="oidc:entra")
+
+        assert store.get_user_profile("locked@example.com").is_admin is True
+
+    @pytest.mark.parametrize("owner", ["scmi", "", "SCIM", "oidc:", "'; drop table users; --"])
+    def test_an_owner_no_source_presents_is_refused(self, client, owner):
+        test_client, store = client
+
+        response = test_client.patch(OWNERSHIP_ROUTE, json={"username": "locked@example.com", "managed_by": owner})
+
+        assert response.status_code == 400
+        assert store.get_user_profile("locked@example.com").managed_by == "scim"
+
+    def test_an_unknown_user_is_404(self, client):
+        test_client, _ = client
+
+        response = test_client.patch(OWNERSHIP_ROUTE, json={"username": "nobody@example.com", "managed_by": "manual"})
+
+        assert response.status_code == 404
+
+    def test_the_change_is_audited_with_the_administrator(self, client, monkeypatch):
+        test_client, _ = client
+        events = []
+        monkeypatch.setattr("mlflow_oidc_auth.routers.users.emit_audit_event", lambda event, **kwargs: events.append((event, kwargs)))
+
+        test_client.patch(OWNERSHIP_ROUTE, json={"username": "locked@example.com", "managed_by": "manual"})
+
+        assert [event for event, _ in events] == ["user.ownership_set"]
+        assert events[0][1]["actor"] == "keeper@example.com"
+        assert events[0][1]["detail"] == {"from": "scim", "to": "manual"}

--- a/mlflow_oidc_auth/tests/test_sqlalchemy_store.py
+++ b/mlflow_oidc_auth/tests/test_sqlalchemy_store.py
@@ -298,6 +298,8 @@ class TestSqlAlchemyStore:
             is_service_account=False,
             active=None,
             managed_by=None,
+            written_by=None,
+            admin_override=False,
         )
         assert result == mock_user
 

--- a/mlflow_oidc_auth/tests/test_user.py
+++ b/mlflow_oidc_auth/tests/test_user.py
@@ -1,6 +1,7 @@
 import string
 from unittest.mock import patch
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 
 from mlflow_oidc_auth import user
 
@@ -102,7 +103,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_new_user_default_params(self, mock_store, mock_generate_token):
         """Test creating new user with default parameters"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("bob", 2)
         mock_store.create_user.return_value = dummy
 
@@ -123,7 +124,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_new_user_with_admin_flag(self, mock_store, mock_generate_token):
         """Test creating new user with admin flag"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("admin_user", 5)
         mock_store.create_user.return_value = dummy
 
@@ -144,7 +145,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_new_user_with_service_account_flag(self, mock_store, mock_generate_token):
         """Test creating new user with service account flag"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("service_user", 6)
         mock_store.create_user.return_value = dummy
 
@@ -165,7 +166,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_new_user_with_both_flags(self, mock_store, mock_generate_token):
         """Test creating new user with both admin and service account flags"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("super_user", 7)
         mock_store.create_user.return_value = dummy
 
@@ -185,7 +186,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_edge_case_empty_username(self, mock_store):
         """Test creating user with empty username"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("", 8)
         mock_store.create_user.return_value = dummy
 
@@ -196,7 +197,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_edge_case_empty_display_name(self, mock_store):
         """Test creating user with empty display name"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("test_user", 9)
         mock_store.create_user.return_value = dummy
 
@@ -207,7 +208,7 @@ class TestCreateUser:
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_special_characters_in_username(self, mock_store):
         """Test creating user with special characters in username"""
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy = DummyUser("user@domain.com", 10)
         mock_store.create_user.return_value = dummy
 
@@ -303,7 +304,7 @@ class TestUserModuleIntegration:
     def test_user_creation_and_group_assignment_workflow(self, mock_store):
         """Test complete workflow of creating user and assigning groups"""
         # Setup mocks for user creation
-        mock_store.get_user_profile.side_effect = MlflowException("User not found")
+        mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
         dummy_user = DummyUser("workflow_user", 100)
         mock_store.create_user.return_value = dummy_user
 
@@ -351,7 +352,9 @@ def test_create_user_already_exists(mock_store):
 @patch("mlflow_oidc_auth.user.store")
 def test_create_user_new_user(mock_store, mock_generate_token):
     """Legacy test for backward compatibility"""
-    mock_store.get_user_profile.side_effect = Exception
+    # What the store actually raises for a missing user — a bare Exception described a store
+    # that does not exist, and would propagate rather than lead to a create.
+    mock_store.get_user_profile.side_effect = MlflowException("User not found", RESOURCE_DOES_NOT_EXIST)
     dummy = DummyUser("bob", 2)
     mock_store.create_user.return_value = dummy
     result = user.create_user("bob", "Bob", is_admin=False, is_service_account=True)

--- a/mlflow_oidc_auth/tests/test_user.py
+++ b/mlflow_oidc_auth/tests/test_user.py
@@ -57,7 +57,7 @@ class TestCreateUser:
 
         assert result == (False, "User alice (ID: 1) already exists")
         mock_store.get_user_profile.assert_called_once_with("alice")
-        mock_store.update_user.assert_called_once_with(username="alice", is_admin=False, is_service_account=False)
+        mock_store.update_user.assert_called_once_with(username="alice", is_admin=False, is_service_account=False, written_by=None, admin_override=False)
 
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_already_exists_with_admin_flag(self, mock_store):
@@ -70,7 +70,7 @@ class TestCreateUser:
 
         assert result == (False, "User alice (ID: 1) already exists")
         mock_store.get_user_profile.assert_called_once_with("alice")
-        mock_store.update_user.assert_called_once_with(username="alice", is_admin=True, is_service_account=False)
+        mock_store.update_user.assert_called_once_with(username="alice", is_admin=True, is_service_account=False, written_by=None, admin_override=False)
 
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_already_exists_with_service_account_flag(self, mock_store):
@@ -83,7 +83,7 @@ class TestCreateUser:
 
         assert result == (False, "User charlie (ID: 3) already exists")
         mock_store.get_user_profile.assert_called_once_with("charlie")
-        mock_store.update_user.assert_called_once_with(username="charlie", is_admin=False, is_service_account=True)
+        mock_store.update_user.assert_called_once_with(username="charlie", is_admin=False, is_service_account=True, written_by=None, admin_override=False)
 
     @patch("mlflow_oidc_auth.user.store")
     def test_create_user_already_exists_with_both_flags(self, mock_store):
@@ -96,7 +96,7 @@ class TestCreateUser:
 
         assert result == (False, "User dave (ID: 4) already exists")
         mock_store.get_user_profile.assert_called_once_with("dave")
-        mock_store.update_user.assert_called_once_with(username="dave", is_admin=True, is_service_account=True)
+        mock_store.update_user.assert_called_once_with(username="dave", is_admin=True, is_service_account=True, written_by=None, admin_override=False)
 
     @patch("mlflow_oidc_auth.user.generate_token", return_value="test_password_123")
     @patch("mlflow_oidc_auth.user.store")
@@ -343,7 +343,7 @@ def test_create_user_already_exists(mock_store):
     result = user.create_user("alice", "Alice", is_admin=True)
     assert result == (False, f"User alice (ID: 1) already exists")
     mock_store.get_user_profile.assert_called_once_with("alice")
-    mock_store.update_user.assert_called_once_with(username="alice", is_admin=True, is_service_account=False)
+    mock_store.update_user.assert_called_once_with(username="alice", is_admin=True, is_service_account=False, written_by=None, admin_override=False)
 
 
 @patch("mlflow_oidc_auth.user.MlflowException", Exception)

--- a/mlflow_oidc_auth/user.py
+++ b/mlflow_oidc_auth/user.py
@@ -4,6 +4,7 @@ import string
 from typing import Optional
 
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 
 from mlflow_oidc_auth.store import store
 
@@ -40,9 +41,12 @@ def create_user(
         )
         return False, f"User {user.username} (ID: {user.id}) already exists"
     except MlflowException as exc:
-        if "is managed by" in str(exc):
-            # An ownership refusal is not "this user does not exist" — creating them instead
-            # would report RESOURCE_ALREADY_EXISTS and bury the real reason.
+        # Only "there is no such user" means "go create them". Every other refusal — an
+        # ownership conflict (#319), the last-active-admin guard, a validation error — is a real
+        # answer, and falling through to create would re-report it as RESOURCE_ALREADY_EXISTS
+        # with the actual reason left in the log. Keyed on the error code rather than the
+        # message, so rewording an exception cannot quietly restore that.
+        if exc.error_code != ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
             raise
         password = generate_token()
         user = store.create_user(

--- a/mlflow_oidc_auth/user.py
+++ b/mlflow_oidc_auth/user.py
@@ -1,6 +1,8 @@
 import secrets
 import string
 
+from typing import Optional
+
 from mlflow.exceptions import MlflowException
 
 from mlflow_oidc_auth.store import store
@@ -12,12 +14,36 @@ def generate_token() -> str:
     return new_password
 
 
-def create_user(username: str, display_name: str, is_admin: bool = False, is_service_account: bool = False) -> tuple:
+def create_user(
+    username: str,
+    display_name: str,
+    is_admin: bool = False,
+    is_service_account: bool = False,
+    written_by: Optional[str] = None,
+    admin_override: bool = False,
+) -> tuple:
+    """Create or refresh a user record.
+
+    ``written_by`` names the source performing the write, for the ownership guard (#319). Without
+    it every write looks like ``manual``, so under ``enforce`` a directory's own sync would be
+    refused on the rows it owns — the guard would lock out precisely the users it exists to
+    protect.
+    """
     try:
         user = store.get_user_profile(username)
-        store.update_user(username=username, is_admin=is_admin, is_service_account=is_service_account)
+        store.update_user(
+            username=username,
+            is_admin=is_admin,
+            is_service_account=is_service_account,
+            written_by=written_by,
+            admin_override=admin_override,
+        )
         return False, f"User {user.username} (ID: {user.id}) already exists"
-    except MlflowException:
+    except MlflowException as exc:
+        if "is managed by" in str(exc):
+            # An ownership refusal is not "this user does not exist" — creating them instead
+            # would report RESOURCE_ALREADY_EXISTS and bury the real reason.
+            raise
         password = generate_token()
         user = store.create_user(
             username=username,


### PR DESCRIPTION
Closes #319. Per-provider policy (#318) says what each source *should* write; this is what stops one source silently overwriting a row another owns when it writes something else.

## Staged, because the failure mode is lockout

`MANAGED_BY_ENFORCEMENT` has three states and defaults to the middle one:

| Value | Behaviour |
|---|---|
| `off` | No evaluation |
| `report` | **Default.** Audits `user.ownership_conflict`; the write proceeds |
| `enforce` | The write is refused |

A guard that refuses writes cannot be recovered from inside a system that has just refused the write that would fix it — so the telemetry exists a release before the enforcement, and an operator can look at their own traffic before turning it on. **An administrator action is permitted in every mode and always audited**; the admin API writes as an explicit override.

## Ownership never changes implicitly

Not at startup, not on a configuration change, not as a side effect of a login — Grafana shipped a silent runtime branch that reset existing users, and the lesson is that this is an operator action with a diff they read first.

```bash
mlflow-oidc db reconcile-ownership --url "$DB" --from-owner scim --set-owner manual            # dry run
mlflow-oidc db reconcile-ownership --url "$DB" --from-owner scim --set-owner manual --apply --journal /tmp/own.json
mlflow-oidc db restore-ownership   --url "$DB" --journal /tmp/own.json --apply                 # rollback
```

The dry-run diff and the applied diff come from the same query. This is also the repair path when a source is turned off: `--from-owner` it, `--set-owner manual`.

## The review finding that mattered

The guard was wired into `UserRepository.update`, but **every production caller goes through `store.update_user`**, which carried no attribution. So under `enforce` every write to a directory-owned row was refused — *including that directory's own sync* — and `create_user` caught the refusal, fell into its create branch and reported "user already exists". That is a lockout of exactly the users the guard exists to protect, with an error pointing somewhere else.

My tests passed `written_by=` explicitly in every case, so the production shape — the caller that omits it — had no test. Attribution now reaches the store, the login path writes as `oidc:<provider>`, the admin API writes as an override, and the case is tested *through* the caller.

## Also from that review

- `Enforcement` is a `str`-Enum, so `enforcement is Enforcement.ENFORCE` is False for any caller holding the raw configured string — the guard would have been silently off while every log line said `enforce`. Now `==`, and an unrecognised value reports rather than falling through to "allowed".
- The permitted-conflict audit is emitted **after** the commit, so it cannot claim a cross-source write that a rollback undid — the same reason the session-revocation audit moved in #351.
- `--set-owner` is validated against owners a source actually presents. A typo under `enforce` means every writer conflicts with it forever, and it is usually typed by someone already repairing a lockout.
- Re-owning every row requires `--all`; a username is matched as stored rather than as typed; a journal is never overwritten; and a restore leaves rows deliberately re-owned since it was written, naming them.

## Validation

```
pre-commit run --all-files              # passed
pytest -m 'not integration' .../tests   # 3909 passed, 14 skipped
pytest mlflow_oidc_auth/tests/perf/     # 37 passed — no query added to the auth path
```

46 tests in `test_ownership_guard.py`: the three modes, break glass in every mode, the guard on the write path, the lockout scenarios, the reconcile/restore round trip and the CLI footguns.

## Known, not addressed

- **The guard covers `update` only.** `set_user_groups` and `delete` are unguarded, and `user_groups.managed_by` exists but is never read — so a second provider can still replace group membership, which is where permissions actually live. That is the next slice and wants its own issue rather than a quiet extension of this one; `report` mode makes the gap visible in the meantime.
- Bulk ownership changes are audited with `actor="cli"` and no operator identity.
- The bearer provisioning path logs an ownership refusal as "may already exist".

🤖 Generated with [Claude Code](https://claude.com/claude-code)