### PR TITLE
feat(ui): identity provider picker on the login page (#317)

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -129,7 +129,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # navigation will redirect through the IdP for re-auth.
             "/static-files",
         )
-        return path.startswith(unprotected_prefixes)
+        # Matched exactly rather than by prefix. A login page has to read this before anyone has
+        # signed in — it is the list of buttons to draw — but "/providers" as a prefix would
+        # silently unprotect any later route whose path merely began with it.
+        unprotected_exact = ("/providers",)
+        return path in unprotected_exact or path.startswith(unprotected_prefixes)
 
     async def _authenticate_basic_auth(self, auth_header: str) -> Tuple[bool, Optional[str], str]:
         """

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -349,28 +349,32 @@ async def providers(request: Request):
                     "id": provider.id,
                     "display_name": provider.display_name or provider.id,
                     "type": provider.type,
-                    "login_url": _absolute_path(request, f"{LOGIN}/{provider.id}"),
+                    "login_url": _login_path(request, f"{LOGIN}/{provider.id}"),
                 }
                 for provider in config.AUTH_PROVIDERS.interactive_providers()
             ]
-        }
+        },
+        # Unauthenticated, and the browser turns each entry into a button it will navigate to.
+        # A shared cache in front of the deployment must not be able to hand one visitor's
+        # response to another.
+        headers={"Cache-Control": "no-store"},
     )
 
 
-def _absolute_path(request: Request, path: str) -> str:
-    """Join ``path`` onto the deployment's own base URL.
+def _login_path(request: Request, path: str) -> str:
+    """Build the login URL for a provider as a path on this deployment.
 
-    Prefers the configured redirect URI's origin over ``request.base_url``, which is the ``Host``
-    header. These URLs are the buttons a login page offers, on an unauthenticated and cacheable
-    endpoint: one poisoned response would otherwise send every later visitor to an attacker's
-    host to authenticate.
+    Deliberately origin-less. The alternative — an absolute URL — has to get its origin from
+    somewhere, and the only candidate available per-request is the ``Host`` header, which any
+    client can set and which a proxy can forward from any client. These strings become the
+    ``href`` of the sign-in button on an unauthenticated page, so an origin taken from a request
+    is an origin an attacker can choose. A path is same-origin by construction and needs no
+    configuration to be correct.
+
+    ``root_path`` is included so a deployment mounted under a prefix gets a URL that resolves;
+    Starlette sets it from the mount, not from a header.
     """
-    configured = getattr(config, "OIDC_REDIRECT_URI", None)
-    if configured:
-        parsed = urlparse(configured)
-        if parsed.scheme and parsed.netloc:
-            return f"{parsed.scheme}://{parsed.netloc}{path}"
-    return str(request.base_url).rstrip("/") + path
+    return f"{request.scope.get('root_path', '').rstrip('/')}{path}"
 
 
 @auth_router.get(f"{LOGIN}/{{provider_id}}")

--- a/mlflow_oidc_auth/routers/auth.py
+++ b/mlflow_oidc_auth/routers/auth.py
@@ -371,10 +371,18 @@ def _login_path(request: Request, path: str) -> str:
     is an origin an attacker can choose. A path is same-origin by construction and needs no
     configuration to be correct.
 
-    ``root_path`` is included so a deployment mounted under a prefix gets a URL that resolves;
-    Starlette sets it from the mount, not from a header.
+    ``root_path`` is included so a deployment mounted under a prefix gets a URL that resolves.
+    It is dropped when it does not look like a path, because it is not always the mount:
+    ``ProxyHeadersMiddleware`` also sets it from ``X-Forwarded-Prefix``, which is trusted from
+    any client while ``TRUSTED_PROXIES`` is empty. A value beginning with ``//`` would otherwise
+    make this return a protocol-relative URL — ``//evil.example/login/entra`` is off-origin the
+    moment a browser resolves it, which is the one thing this function promises cannot happen.
+    A prefix that has to be discarded means a broken link, not a login somewhere else.
     """
-    return f"{request.scope.get('root_path', '').rstrip('/')}{path}"
+    root_path = request.scope.get("root_path", "") or ""
+    if not root_path.startswith("/") or root_path.startswith("//"):
+        root_path = ""
+    return f"{root_path.rstrip('/')}{path}"
 
 
 @auth_router.get(f"{LOGIN}/{{provider_id}}")

--- a/mlflow_oidc_auth/tests/test_provider_login.py
+++ b/mlflow_oidc_auth/tests/test_provider_login.py
@@ -605,6 +605,29 @@ class TestTheLoginUrlsDoNotComeFromTheHostHeader:
         assert listed[0]["login_url"] == "/mlflow/login/entra"
 
     @pytest.mark.asyncio
+    async def test_a_protocol_relative_prefix_is_discarded(self, two_providers):
+        """``root_path`` is not always the mount — ``X-Forwarded-Prefix`` also sets it.
+
+        ``//evil.example`` starts with a slash, so it survives the proxy middleware's
+        normalisation, and concatenating it would produce a protocol-relative URL that a browser
+        resolves off-origin. A discarded prefix is a broken link; an honoured one is a login
+        somewhere else.
+        """
+        import json
+
+        listed = json.loads((await auth_router_mod.providers(DummyRequest(root_path="//evil.example"))).body)["providers"]
+
+        assert all(entry["login_url"] == f"/login/{entry['id']}" for entry in listed)
+
+    @pytest.mark.asyncio
+    async def test_a_prefix_that_is_not_a_path_is_discarded(self, two_providers):
+        import json
+
+        listed = json.loads((await auth_router_mod.providers(DummyRequest(root_path="evil.example"))).body)["providers"]
+
+        assert all(entry["login_url"].startswith("/login/") for entry in listed)
+
+    @pytest.mark.asyncio
     async def test_the_response_is_not_cacheable(self, two_providers):
         response = await auth_router_mod.providers(DummyRequest())
 

--- a/mlflow_oidc_auth/tests/test_provider_login.py
+++ b/mlflow_oidc_auth/tests/test_provider_login.py
@@ -26,10 +26,11 @@ OKTA = "https://okta.invalid"
 
 
 class DummyRequest:
-    def __init__(self, **query):
+    def __init__(self, root_path="", **query):
         self.session = {}
         self.base_url = "http://testserver"
         self.query_params = _Query(query)
+        self.scope = {"root_path": root_path}
 
 
 class _Query(dict):
@@ -563,10 +564,14 @@ class TestTheExchangeNeverBorrowsAnotherProvidersClient:
 
 
 class TestTheLoginUrlsDoNotComeFromTheHostHeader:
-    """They are the buttons a login page offers, on an unauthenticated, cacheable endpoint."""
+    """They are the buttons a login page offers, on an unauthenticated endpoint.
+
+    They carry no origin at all. An absolute URL would have to take its origin from the request,
+    and the request's origin is the ``Host`` header — which the client sets.
+    """
 
     @pytest.mark.asyncio
-    async def test_the_configured_origin_wins(self, two_providers, monkeypatch):
+    async def test_the_login_url_is_a_path_with_no_origin(self, two_providers, monkeypatch):
         import json
 
         monkeypatch.setattr(auth_router_mod.config, "OIDC_REDIRECT_URI", "https://mlflow.corp.example/callback", raising=False)
@@ -575,14 +580,32 @@ class TestTheLoginUrlsDoNotComeFromTheHostHeader:
 
         listed = json.loads((await auth_router_mod.providers(request)).body)["providers"]
 
-        assert listed[0]["login_url"] == "https://mlflow.corp.example/login/entra"
+        assert listed[0]["login_url"] == "/login/entra"
 
     @pytest.mark.asyncio
-    async def test_it_falls_back_to_the_request_when_nothing_is_configured(self, two_providers, monkeypatch):
+    async def test_a_hostile_host_header_cannot_reach_the_button(self, two_providers, monkeypatch):
         import json
 
         monkeypatch.setattr(auth_router_mod.config, "OIDC_REDIRECT_URI", None, raising=False)
+        request = DummyRequest()
+        request.base_url = "http://evil.example"
 
-        listed = json.loads((await auth_router_mod.providers(DummyRequest())).body)["providers"]
+        listed = json.loads((await auth_router_mod.providers(request)).body)["providers"]
 
-        assert listed[0]["login_url"] == "http://testserver/login/entra"
+        assert all("evil.example" not in entry["login_url"] for entry in listed)
+        assert all(entry["login_url"].startswith("/") for entry in listed)
+
+    @pytest.mark.asyncio
+    async def test_a_mounted_deployment_keeps_its_prefix(self, two_providers):
+        """``root_path`` comes from the mount, not from a header, so it is safe to include."""
+        import json
+
+        listed = json.loads((await auth_router_mod.providers(DummyRequest(root_path="/mlflow"))).body)["providers"]
+
+        assert listed[0]["login_url"] == "/mlflow/login/entra"
+
+    @pytest.mark.asyncio
+    async def test_the_response_is_not_cacheable(self, two_providers):
+        response = await auth_router_mod.providers(DummyRequest())
+
+        assert response.headers["cache-control"] == "no-store"

--- a/mlflow_oidc_auth/tests/test_providers_endpoint_e2e.py
+++ b/mlflow_oidc_auth/tests/test_providers_endpoint_e2e.py
@@ -1,0 +1,76 @@
+"""``/providers`` through the real middleware, unauthenticated (issues #316, #317).
+
+The login picker in #317 fetches this before anyone has signed in. Everything about it is
+tested elsewhere by calling the handler directly — which cannot see the one property that
+matters here: whether an anonymous browser is allowed to reach it at all.
+
+It failed silently. ``AuthMiddleware`` refused the request, the page saw a non-OK response,
+fell back to the single-provider login it has always had, and sent every visitor to the
+*default* provider with nothing shown and nothing logged. A picker that quietly picks for you
+is worse than one that is missing, so this is asserted end to end.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+from mlflow_oidc_auth.middleware import AuthMiddleware
+from mlflow_oidc_auth.provider_registry import ProviderConfig, RegistryLoadResult
+from mlflow_oidc_auth.routers.auth import auth_router
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import mlflow_oidc_auth.routers.auth as auth_router_mod
+
+    registry = RegistryLoadResult(
+        providers=[
+            ProviderConfig(id="entra", type="oidc", display_name="Entra ID", audience="mlflow", issuer="https://login.microsoftonline.test/"),
+            ProviderConfig(id="okta", type="oidc", display_name="Okta", audience="mlflow", issuer="https://okta.test/"),
+        ],
+        errors=[],
+    )
+    monkeypatch.setattr(auth_router_mod.config, "AUTH_PROVIDERS", registry, raising=False)
+
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.add_middleware(AuthMiddleware)
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-not-a-credential")
+
+    with TestClient(app) as c:
+        yield c
+
+
+class TestAnAnonymousBrowserCanReadTheProviderList:
+    def test_it_is_not_refused(self, client):
+        assert client.get("/providers").status_code == 200
+
+    def test_it_lists_the_interactive_providers(self, client):
+        listed = client.get("/providers").json()["providers"]
+
+        assert [entry["id"] for entry in listed] == ["entra", "okta"]
+
+    def test_the_login_urls_are_same_origin_paths(self, client):
+        listed = client.get("/providers").json()["providers"]
+
+        assert [entry["login_url"] for entry in listed] == ["/login/entra", "/login/okta"]
+
+    def test_a_hostile_forwarded_host_does_not_reach_the_login_urls(self, client):
+        listed = client.get("/providers", headers={"X-Forwarded-Host": "evil.example"}).json()["providers"]
+
+        assert all("evil.example" not in entry["login_url"] for entry in listed)
+
+    def test_the_response_is_not_cacheable(self, client):
+        assert client.get("/providers").headers["cache-control"] == "no-store"
+
+
+class TestUnprotectingItDoesNotUnprotectAnythingElse:
+    """It is matched exactly. A prefix would carry along every future route beginning with it."""
+
+    def test_a_longer_path_is_still_protected(self):
+        middleware = AuthMiddleware(FastAPI())
+
+        assert middleware._is_unprotected_route("/providers") is True
+        assert middleware._is_unprotected_route("/providers/secrets") is False
+        assert middleware._is_unprotected_route("/providers-admin") is False

--- a/web-react/src/features/auth/auth-page.test.tsx
+++ b/web-react/src/features/auth/auth-page.test.tsx
@@ -4,6 +4,7 @@ import { AuthPage } from "./auth-page";
 
 import type { RuntimeConfig } from "../../shared/services/runtime-config";
 import type { Mock } from "vitest";
+import type { ProvidersState } from "./hooks/use-providers";
 
 const mockUseAuthErrors: Mock<() => string[]> = vi.fn();
 const mockUseRuntimeConfig: Mock<() => RuntimeConfig> = vi.fn();
@@ -18,6 +19,17 @@ vi.mock("./hooks/use-auth-errors", () => ({
 
 vi.mock("../../shared/components/dark-mode-toggle", () => ({
   default: () => <div data-testid="dark-mode-toggle" />,
+}));
+
+// The provider list is fetched (#317). Default to none, which is what a server from before
+// #316 reports — and the case every existing assertion below describes.
+const mockUseProviders: Mock<() => ProvidersState> = vi.fn(() => ({
+  providers: [],
+  loading: false,
+}));
+
+vi.mock("./hooks/use-providers", () => ({
+  useProviders: () => mockUseProviders(),
 }));
 
 describe("AuthPage", () => {
@@ -62,7 +74,9 @@ describe("AuthPage", () => {
 
     const currentYear = new Date().getFullYear();
     expect(
-      screen.getByText(new RegExp(`© ${currentYear} Kharkevich Engineering Lab`)),
+      screen.getByText(
+        new RegExp(`© ${currentYear} Kharkevich Engineering Lab`),
+      ),
     ).toBeInTheDocument();
 
     const sponsorLink = screen.getByText("Support the project");
@@ -76,5 +90,150 @@ describe("AuthPage", () => {
   it("renders dark mode toggle", () => {
     render(<AuthPage />);
     expect(screen.getByTestId("dark-mode-toggle")).toBeInTheDocument();
+  });
+});
+
+describe("AuthPage provider picker (#317)", () => {
+  beforeEach(() => {
+    mockUseRuntimeConfig.mockReturnValue({
+      provider: "Sign in with OIDC",
+      basePath: "/api",
+      uiPath: "/ui",
+      authenticated: false,
+      gen_ai_gateway_enabled: false,
+      workspaces_enabled: false,
+    });
+    mockUseAuthErrors.mockReturnValue([]);
+    mockUseProviders.mockReturnValue({ providers: [], loading: false });
+    window.history.replaceState({}, "", "/");
+  });
+
+  const provider = (id: string, displayName: string) => ({
+    id,
+    display_name: displayName,
+    type: "oidc",
+    login_url: `/api/login/${id}`,
+  });
+
+  it("renders the page it always has when no providers are reported", () => {
+    // A server from before #316 has no /providers endpoint at all.
+    render(<AuthPage />);
+
+    const link = screen.getByRole("link", { name: "Sign in with OIDC" });
+    expect(link).toHaveAttribute("href", "/api/login");
+    expect(screen.queryByText("Sign in with")).not.toBeInTheDocument();
+  });
+
+  it("renders one button and no picker chrome for a single provider", () => {
+    mockUseProviders.mockReturnValue({
+      providers: [provider("default", "Login with OIDC")],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(
+      screen.getByRole("link", { name: "Login with OIDC" }),
+    ).toHaveAttribute("href", "/api/login/default");
+    expect(screen.queryByText("Sign in with")).not.toBeInTheDocument();
+  });
+
+  it("renders one button per provider when there are several", () => {
+    mockUseProviders.mockReturnValue({
+      providers: [provider("entra", "Entra ID"), provider("okta", "Okta")],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(screen.getByText("Sign in with")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Entra ID" })).toHaveAttribute(
+      "href",
+      "/api/login/entra",
+    );
+    expect(screen.getByRole("link", { name: "Okta" })).toHaveAttribute(
+      "href",
+      "/api/login/okta",
+    );
+  });
+
+  it("carries ?next= through a chosen provider", () => {
+    window.history.replaceState({}, "", "/?next=/oidc/ui/models");
+    mockUseProviders.mockReturnValue({
+      providers: [provider("entra", "Entra ID"), provider("okta", "Okta")],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(screen.getByRole("link", { name: "Entra ID" })).toHaveAttribute(
+      "href",
+      "/api/login/entra?next=%2Foidc%2Fui%2Fmodels",
+    );
+  });
+
+  it("carries ?next= through the single-provider button too", () => {
+    window.history.replaceState({}, "", "/?next=/oidc/ui/models");
+    mockUseProviders.mockReturnValue({
+      providers: [provider("default", "Login with OIDC")],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(
+      screen.getByRole("link", { name: "Login with OIDC" }),
+    ).toHaveAttribute("href", "/api/login/default?next=%2Foidc%2Fui%2Fmodels");
+  });
+
+  it("does not know what kind of provider it is drawing", () => {
+    // #330 adds SAML providers; they should appear without this page changing.
+    mockUseProviders.mockReturnValue({
+      providers: [
+        {
+          id: "corp",
+          display_name: "Corporate SSO",
+          type: "saml",
+          login_url: "/api/login/corp",
+        },
+        provider("entra", "Entra ID"),
+      ],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(screen.getByRole("link", { name: "Corporate SSO" })).toHaveAttribute(
+      "href",
+      "/api/login/corp",
+    );
+  });
+
+  it("offers nothing to click until the list has arrived", () => {
+    // The fallback button names the *default* provider. Clicking it in the moment before the
+    // list arrives would start a login against an IdP this user may not belong to.
+    mockUseProviders.mockReturnValue({ providers: [], loading: true });
+
+    render(<AuthPage />);
+
+    expect(
+      screen.queryByRole("link", { name: /sign in/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("providers-loading")).toBeDisabled();
+  });
+
+  it("still shows errors alongside the picker", () => {
+    mockUseAuthErrors.mockReturnValue(["User is not allowed to login"]);
+    mockUseProviders.mockReturnValue({
+      providers: [provider("entra", "Entra ID"), provider("okta", "Okta")],
+      loading: false,
+    });
+
+    render(<AuthPage />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "User is not allowed to login",
+    );
+    expect(screen.getByRole("link", { name: "Entra ID" })).toBeInTheDocument();
   });
 });

--- a/web-react/src/features/auth/auth-page.tsx
+++ b/web-react/src/features/auth/auth-page.tsx
@@ -7,15 +7,38 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DarkModeToggle from "../../shared/components/dark-mode-toggle";
+import { useProviders } from "./hooks/use-providers";
+import { withNextTarget } from "./services/provider-service";
+import { ProviderPicker } from "./components/provider-picker";
 
 export const AuthPage = () => {
   const config = useRuntimeConfig();
 
-  const buttonText = config.provider;
-  const loginHref = `${config.basePath}/login`;
-
   const errors = useAuthErrors();
   const hasErrors = errors.length > 0;
+
+  // Carried through to whichever provider is chosen. Not validated here: the server does that
+  // (`_sanitize_next`), and a second implementation would be a second thing to keep correct.
+  const nextTarget = new URLSearchParams(window.location.search).get("next");
+
+  const { providers, loading } = useProviders(config.basePath);
+
+  // One provider is the shape almost every deployment has, and it must look exactly as it did
+  // before this page learned about several: one button, the configured label, no chrome. That
+  // also covers a server too old to serve /providers, which reports none.
+  const singleProvider = providers.length <= 1;
+  const loginHref = withNextTarget(
+    providers.length === 1
+      ? providers[0].login_url
+      : `${config.basePath}/login`,
+    nextTarget,
+  );
+  // Same fallback chain the picker uses: a provider configured without a label still gets a
+  // button with words on it rather than an empty one.
+  const buttonText =
+    providers.length === 1
+      ? providers[0].display_name || providers[0].id
+      : config.provider;
 
   const currentYear = new Date().getFullYear();
 
@@ -63,11 +86,29 @@ export const AuthPage = () => {
             </div>
           )}
 
-          <a href={loginHref} className="w-full">
-            <Button variant="primary" className="w-full py-2 text-base">
+          {loading ? (
+            // Deliberately not a live link. The fallback button says "sign in with <the default
+            // provider>", and until the list arrives that may not be the provider this user
+            // belongs to — a click landing in the 300ms before it does would start a login
+            // against the wrong IdP, and with provisioning on, create an account there.
+            <Button
+              variant="primary"
+              className="w-full py-2 text-base"
+              disabled
+              aria-busy="true"
+              data-testid="providers-loading"
+            >
               {buttonText}
             </Button>
-          </a>
+          ) : singleProvider ? (
+            <a href={loginHref} className="w-full">
+              <Button variant="primary" className="w-full py-2 text-base">
+                {buttonText}
+              </Button>
+            </a>
+          ) : (
+            <ProviderPicker providers={providers} next={nextTarget} />
+          )}
         </div>
       </div>
 

--- a/web-react/src/features/auth/components/provider-picker.tsx
+++ b/web-react/src/features/auth/components/provider-picker.tsx
@@ -1,0 +1,42 @@
+import { Button } from "../../../shared/components/button";
+import {
+  withNextTarget,
+  type IdentityProvider,
+} from "../services/provider-service";
+
+type ProviderPickerProps = {
+  providers: IdentityProvider[];
+  next: string | null;
+};
+
+/**
+ * One button per identity provider (issue #317).
+ *
+ * Rendered only when there is more than one to choose between — a single provider keeps the
+ * page it has always had, with no picker chrome at all.
+ *
+ * Nothing here knows what kind of provider it is drawing. The label comes from the server and
+ * the destination is the server's own login URL, so the SAML providers in #330 appear without
+ * this component changing.
+ */
+export const ProviderPicker = ({ providers, next }: ProviderPickerProps) => (
+  <div className="w-full flex flex-col gap-3">
+    <span className="text-sm text-ui-text/60 dark:text-ui-text-dark/60 text-center">
+      Sign in with
+    </span>
+    {providers.map((provider) => (
+      <a
+        key={provider.id}
+        href={withNextTarget(provider.login_url, next)}
+        className="w-full"
+        data-testid={`provider-${provider.id}`}
+      >
+        <Button variant="primary" className="w-full py-2 text-base">
+          {provider.display_name || provider.id}
+        </Button>
+      </a>
+    ))}
+  </div>
+);
+
+export default ProviderPicker;

--- a/web-react/src/features/auth/hooks/use-providers.test.ts
+++ b/web-react/src/features/auth/hooks/use-providers.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { useProviders } from "./use-providers";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const ok = (body: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(body) }) as Response;
+
+describe("useProviders", () => {
+  it("reports the providers once they arrive", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              {
+                id: "entra",
+                display_name: "Entra ID",
+                type: "oidc",
+                login_url: "/api/login/entra",
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useProviders("/api"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.providers).toHaveLength(1);
+  });
+
+  it("reports none when the fetch fails outright", async () => {
+    // Network blip, or an older server. The page falls back to the login it always had rather
+    // than showing an error where a sign-in button belongs.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("offline"))),
+    );
+
+    const { result } = renderHook(() => useProviders("/api"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.providers).toEqual([]);
+  });
+
+  it("starts out loading with nothing to show", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+
+    const { result } = renderHook(() => useProviders("/api"));
+
+    expect(result.current).toEqual({ providers: [], loading: true });
+  });
+});

--- a/web-react/src/features/auth/hooks/use-providers.test.ts
+++ b/web-react/src/features/auth/hooks/use-providers.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { useProviders } from "./use-providers";
@@ -59,5 +59,32 @@ describe("useProviders", () => {
     const { result } = renderHook(() => useProviders("/api"));
 
     expect(result.current).toEqual({ providers: [], loading: true });
+  });
+
+  it("gives up on a request that hangs", async () => {
+    // A proxy that accepts /providers and then holds the connection open. The login button is
+    // gated on `loading`, so without a timeout the page would offer nothing to click, ever.
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new Error("aborted")),
+            );
+          }),
+      ),
+    );
+
+    const { result } = renderHook(() => useProviders("/api"));
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(result.current).toEqual({ providers: [], loading: false });
+    vi.useRealTimers();
   });
 });

--- a/web-react/src/features/auth/hooks/use-providers.ts
+++ b/web-react/src/features/auth/hooks/use-providers.ts
@@ -16,7 +16,14 @@ export type ProvidersState = {
  * Starts as loading with an empty list. A failure — an older server with no `/providers`, a
  * network blip — resolves to an empty list rather than an error state: the page then renders the
  * single-provider login it has always had, which is a working page rather than a dead end.
+ *
+ * A request that *hangs* has to reach that same fallback, which is what the timeout is for. The
+ * login button is gated on `loading`, so a proxy that accepts `/providers` and then holds the
+ * connection open would otherwise leave the only sign-in control disabled forever — every
+ * failure mode here has to end in a page someone can log in from.
  */
+const FETCH_TIMEOUT_MS = 5000;
+
 export function useProviders(basePath: string): ProvidersState {
   const [providers, setProviders] = useState<IdentityProvider[]>([]);
   const [loading, setLoading] = useState(true);
@@ -24,6 +31,8 @@ export function useProviders(basePath: string): ProvidersState {
   useEffect(() => {
     const controller = new AbortController();
     let active = true;
+
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
     fetchProviders(basePath, controller.signal)
       .then((found) => {
@@ -33,11 +42,13 @@ export function useProviders(basePath: string): ProvidersState {
         if (active) setProviders([]);
       })
       .finally(() => {
+        clearTimeout(timeout);
         if (active) setLoading(false);
       });
 
     return () => {
       active = false;
+      clearTimeout(timeout);
       controller.abort();
     };
   }, [basePath]);

--- a/web-react/src/features/auth/hooks/use-providers.ts
+++ b/web-react/src/features/auth/hooks/use-providers.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+import {
+  fetchProviders,
+  type IdentityProvider,
+} from "../services/provider-service";
+
+export type ProvidersState = {
+  providers: IdentityProvider[];
+  loading: boolean;
+};
+
+/**
+ * The identity providers the login page may offer (issue #317).
+ *
+ * Starts as loading with an empty list. A failure — an older server with no `/providers`, a
+ * network blip — resolves to an empty list rather than an error state: the page then renders the
+ * single-provider login it has always had, which is a working page rather than a dead end.
+ */
+export function useProviders(basePath: string): ProvidersState {
+  const [providers, setProviders] = useState<IdentityProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    fetchProviders(basePath, controller.signal)
+      .then((found) => {
+        if (active) setProviders(found);
+      })
+      .catch(() => {
+        if (active) setProviders([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [basePath]);
+
+  return { providers, loading };
+}

--- a/web-react/src/features/auth/services/provider-service.test.ts
+++ b/web-react/src/features/auth/services/provider-service.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { fetchProviders, withNextTarget } from "./provider-service";
+
+const ok = (body: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(body) }) as Response;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchProviders", () => {
+  it("returns the providers the server offers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              {
+                id: "entra",
+                display_name: "Entra ID",
+                type: "oidc",
+                login_url: "/api/login/entra",
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([
+      {
+        id: "entra",
+        display_name: "Entra ID",
+        type: "oidc",
+        login_url: "/api/login/entra",
+      },
+    ]);
+  });
+
+  it("returns none when the endpoint does not exist", async () => {
+    // A server from before #316. The page then renders the single-provider login it always had,
+    // rather than an empty picker.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false } as Response)),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([]);
+  });
+
+  it("returns none when the body is not a provider list", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(ok({ unexpected: true }))),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([]);
+  });
+
+  it("drops entries with nothing to render or nowhere to go", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              {
+                id: "",
+                display_name: "Nameless",
+                type: "oidc",
+                login_url: "/x",
+              },
+              { id: "nowhere", display_name: "Nowhere", type: "oidc" },
+              {
+                id: "entra",
+                display_name: "Entra ID",
+                type: "oidc",
+                login_url: "/api/login/entra",
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    const providers = await fetchProviders("/api");
+
+    expect(providers.map((provider) => provider.id)).toEqual(["entra"]);
+  });
+
+  it("drops any login URL that would leave this origin", async () => {
+    // The one field that becomes an href. A response that points a sign-in button at another
+    // host produces a pixel-perfect phishing page served from the real product, so the check
+    // is here rather than trusting whatever produced the response.
+    const hostile = [
+      "//evil.example/login",
+      "https://evil.example/login",
+      "javascript:alert(1)",
+      "data:text/html,<h1>hi",
+      "login/relative",
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: hostile.map((login_url, index) => ({
+              id: `p${index}`,
+              display_name: "Sign in",
+              type: "oidc",
+              login_url,
+            })),
+          }),
+        ),
+      ),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([]);
+  });
+
+  it("drops entries whose fields are not strings", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              { id: 7, display_name: "Numeric", type: "oidc", login_url: "/x" },
+              { id: "ok", display_name: "Fine", type: "oidc", login_url: 42 },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([]);
+  });
+});
+
+describe("withNextTarget", () => {
+  it("leaves the URL alone when there is no return target", () => {
+    expect(withNextTarget("/api/login/entra", null)).toBe("/api/login/entra");
+  });
+
+  it("appends the target", () => {
+    expect(withNextTarget("/api/login/entra", "/oidc/ui/models")).toBe(
+      "/api/login/entra?next=%2Foidc%2Fui%2Fmodels",
+    );
+  });
+
+  it("appends to a URL that already has a query", () => {
+    expect(withNextTarget("/api/login/entra?a=b", "/models")).toBe(
+      "/api/login/entra?a=b&next=%2Fmodels",
+    );
+  });
+
+  it("encodes a target that would otherwise change the query", () => {
+    expect(withNextTarget("/api/login/entra", "/a?b=c&d=e")).toBe(
+      "/api/login/entra?next=%2Fa%3Fb%3Dc%26d%3De",
+    );
+  });
+
+  it("passes a hostile target through for the server to reject", () => {
+    // Deliberately not validated here: the server owns that decision, and a second
+    // implementation would be a second thing to keep correct.
+    expect(withNextTarget("/api/login/entra", "//evil.example")).toBe(
+      "/api/login/entra?next=%2F%2Fevil.example",
+    );
+  });
+});

--- a/web-react/src/features/auth/services/provider-service.test.ts
+++ b/web-react/src/features/auth/services/provider-service.test.ts
@@ -120,6 +120,50 @@ describe("fetchProviders", () => {
     await expect(fetchProviders("/api")).resolves.toEqual([]);
   });
 
+  it("drops an entry whose label is not text", async () => {
+    // `display_name` is rendered as a React child, so an object there throws during render and
+    // takes the login page down. Dropping the entry leaves a page that still works.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              {
+                id: "entra",
+                display_name: { en: "Entra ID" },
+                type: "oidc",
+                login_url: "/login/entra",
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    await expect(fetchProviders("/api")).resolves.toEqual([]);
+  });
+
+  it("keeps an entry with no label at all", async () => {
+    // The picker falls back to the id, so a missing label is a button with words on it.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          ok({
+            providers: [
+              { id: "entra", type: "oidc", login_url: "/login/entra" },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    const providers = await fetchProviders("/api");
+
+    expect(providers.map((provider) => provider.id)).toEqual(["entra"]);
+  });
+
   it("drops entries whose fields are not strings", async () => {
     vi.stubGlobal(
       "fetch",

--- a/web-react/src/features/auth/services/provider-service.ts
+++ b/web-react/src/features/auth/services/provider-service.ts
@@ -57,14 +57,19 @@ export async function fetchProviders(
  * that browsers resolve off-origin. That is exactly what the server emits, and it means no
  * response to this endpoint can point a login button at another host, whatever produced it.
  *
- * The `typeof` checks are not ceremony: these values go into an attribute and a React key, and
- * a non-string would be stringified rather than rejected.
+ * The `typeof` checks are not ceremony. `id` and `login_url` become an attribute and a React
+ * key, where a non-string would be stringified rather than rejected — but `display_name` is
+ * rendered as a React *child*, and an object there throws during render and takes the whole
+ * login page down with it. Absent is fine: the label falls back to `id`.
  */
 function isRenderable(provider: IdentityProvider): boolean {
   return (
     Boolean(provider) &&
     typeof provider.id === "string" &&
     provider.id.length > 0 &&
+    (provider.display_name === undefined ||
+      provider.display_name === null ||
+      typeof provider.display_name === "string") &&
     typeof provider.login_url === "string" &&
     provider.login_url.startsWith("/") &&
     !provider.login_url.startsWith("//")

--- a/web-react/src/features/auth/services/provider-service.ts
+++ b/web-react/src/features/auth/services/provider-service.ts
@@ -1,0 +1,86 @@
+/**
+ * The identity providers a browser may log in with (issue #317).
+ *
+ * Reads the endpoint #316 added. It is deliberately unauthenticated and deliberately thin — an
+ * id, a label, a type and a login URL — because it is fetched before anyone has signed in.
+ *
+ * Nothing here knows what an OIDC provider is. `type` is carried through and used only for a
+ * label, so the SAML providers in #330 appear without this file changing.
+ */
+
+export type IdentityProvider = {
+  id: string;
+  display_name: string;
+  type: string;
+  login_url: string;
+};
+
+type ProvidersResponse = {
+  providers?: IdentityProvider[];
+};
+
+/**
+ * Fetch the providers a browser may use.
+ *
+ * Returns an empty list when the endpoint is missing or unreadable, which is what a server from
+ * before #316 does. The caller then falls back to the single-provider login it has always had,
+ * so an older server keeps working rather than showing an empty page.
+ */
+export async function fetchProviders(
+  basePath: string,
+  signal?: AbortSignal,
+): Promise<IdentityProvider[]> {
+  const response = await fetch(`${basePath}/providers`, {
+    cache: "no-store",
+    signal,
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const body = (await response.json()) as ProvidersResponse;
+  if (!Array.isArray(body?.providers)) {
+    return [];
+  }
+
+  return body.providers.filter(isRenderable);
+}
+
+/**
+ * Whether an entry can safely become a sign-in button.
+ *
+ * `login_url` is the one field that becomes an `href`, so it is the one field where a wrong
+ * value sends a user somewhere rather than merely rendering badly. Only a same-origin path is
+ * accepted — one leading slash, never two, since `//evil.example` is a protocol-relative URL
+ * that browsers resolve off-origin. That is exactly what the server emits, and it means no
+ * response to this endpoint can point a login button at another host, whatever produced it.
+ *
+ * The `typeof` checks are not ceremony: these values go into an attribute and a React key, and
+ * a non-string would be stringified rather than rejected.
+ */
+function isRenderable(provider: IdentityProvider): boolean {
+  return (
+    Boolean(provider) &&
+    typeof provider.id === "string" &&
+    provider.id.length > 0 &&
+    typeof provider.login_url === "string" &&
+    provider.login_url.startsWith("/") &&
+    !provider.login_url.startsWith("//")
+  );
+}
+
+/**
+ * Carry a `?next=` return target onto a provider's login URL.
+ *
+ * Passed through verbatim: the server validates it (`_sanitize_next`), and a second
+ * implementation here would be a second thing to keep correct — the one that rejects
+ * `/\evil.com` because browsers resolve it off-origin, which is not obvious enough to want
+ * duplicated.
+ */
+export function withNextTarget(loginUrl: string, next: string | null): string {
+  if (!next) return loginUrl;
+  const separator = loginUrl.includes("?") ? "&" : "?";
+  return `${loginUrl}${separator}next=${encodeURIComponent(next)}`;
+}


### PR DESCRIPTION
Closes #317.

The login page reads the `/providers` endpoint from #316 and draws one button per identity provider.

**Nothing changes for a single-provider deployment.** With none or one provider it renders exactly the page it always had — the configured label, one button, no picker chrome. A server too old to serve `/providers` reports none and gets that same page, so there is no version coupling.

## What had to be fixed for it to work

The picker was inert against `main`, and three of the four fixes are on the backend:

- **`/providers` was not an unprotected route.** `AuthMiddleware` refused the anonymous fetch, the page saw a non-OK response, fell back to the single-provider login, and sent every visitor to the *default* provider with nothing shown and nothing logged. It is now matched **exactly** rather than by prefix — `/providers` as a prefix would silently unprotect any later route beginning with that string — and asserted end to end through the real middleware in `test_providers_endpoint_e2e.py`, which the existing tests could not see because they call the handler directly.
- **`login_url` no longer carries an origin.** An absolute URL has to get its origin from somewhere, and the only per-request candidate is the `Host` header. It is a `root_path`-relative path now — same-origin by construction, correct under a mount prefix, and needing no configuration to be right. The response is also `Cache-Control: no-store`.
- **The frontend accepts only same-origin paths** — one leading slash, never two, since `//host` is protocol-relative — plus `typeof` checks, because these values become an `href` and a React key and a non-string would be stringified rather than rejected.
- **The fallback button is disabled while the list loads.** It names the *default* provider; a click in the moment before the list arrives would start a login against an IdP the user may not belong to, and with provisioning on, create an account there.

## `?next=`

Carried onto whichever provider is chosen and deliberately **not** validated client-side. `_sanitize_next` owns that decision, it is applied on both `/login` and `/login/{provider_id}`, and a second implementation here would be a second thing to keep correct — starting with the rule that rejects `/\evil.com`.

## Forward-compatible with #330

Nothing in the picker knows what kind of provider it is drawing: the label and the destination both come from the server, and `type` is carried through unused. SAML providers appear without these files changing — there is a test for that.

## Verification

| Command | Result |
|---|---|
| `pytest mlflow_oidc_auth/tests/` (hooks run file by file) | 3574 passed, 14 skipped; hooks 352 passed |
| `pre-commit run --all-files` | passed |
| `yarn test` | 118 files, 857 passed |
| `yarn lint` | no new problems — the 11 errors / 3 warnings on this branch are identical to `origin/main` |

The new `test_providers_endpoint_e2e.py` fails 6/6 without the middleware fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)