### PR TITLE
perf(auth): offload basic-auth verification from the ASGI event loop (#244)

### DIFF
--- a/mlflow_oidc_auth/middleware/auth_middleware.py
+++ b/mlflow_oidc_auth/middleware/auth_middleware.py
@@ -7,9 +7,11 @@ Authorization (what the user can do) is handled by RBACMiddleware.
 """
 
 from typing import Optional, Tuple
+import asyncio
 import base64
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from cachetools import TTLCache
 from fastapi import Request, Response
@@ -30,6 +32,19 @@ from mlflow_oidc_auth.store import store
 from mlflow_oidc_auth.utils.oidc_field_extraction import extract_username, extract_display_name, BEARER_TOKEN_SOURCE
 
 logger = get_logger()
+
+# Basic auth used to run synchronously on the ASGI event loop, which limited each worker to one
+# database/hash verification at a time while also blocking every unrelated request (issue #244).
+# The single-thread executor keeps that per-process concurrency bound when offloading: legacy
+# scrypt hashes are CPU-intensive, and an unauthenticated caller must not be able to fan out
+# enough concurrent verifications to exhaust the database pool.
+_BASIC_AUTH_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlflow-oidc-basic-auth")
+
+
+def _authenticate_basic_auth_sync(username: str, password: str) -> bool:
+    """Resolve the lazy store and verify one basic-auth credential in a worker thread."""
+    return store.authenticate_user(username, password)
+
 
 # Why an authenticated-looking request was turned away. Reported separately because a deleted
 # account and a deactivated one are different operational events, and an operator reading the
@@ -147,8 +162,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
             decoded_credentials = base64.b64decode(encoded_credentials).decode("utf-8")
             username, password = decoded_credentials.split(":", 1)
 
-            # Authenticate against store
-            if store.authenticate_user(username.lower(), password):
+            # Store initialization, SQLAlchemy, and password verification are synchronous. Keep
+            # them off the ASGI event loop; the dedicated executor preserves the previous
+            # one-verification-per-process bound.
+            if await asyncio.get_running_loop().run_in_executor(
+                _BASIC_AUTH_EXECUTOR,
+                _authenticate_basic_auth_sync,
+                username.lower(),
+                password,
+            ):
                 logger.debug(f"User {username} authenticated via basic auth")
                 return True, username.lower(), ""
             else:

--- a/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_auth_middleware.py
@@ -9,11 +9,14 @@ This module tests authentication middleware behavior including:
 - ASGI scope injection for WSGI compatibility
 """
 
+import threading
+
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi import Response
 from fastapi.responses import RedirectResponse
 
+from mlflow_oidc_auth.middleware import auth_middleware as middleware_module
 from mlflow_oidc_auth.middleware.auth_middleware import AuthMiddleware
 
 
@@ -114,6 +117,31 @@ class TestAuthMiddleware:
             assert username is None
             assert error == "Invalid basic auth credentials"
             mock_store.authenticate_user.assert_called_once_with("invalid", "invalid")
+
+    @pytest.mark.asyncio
+    async def test_authenticate_basic_auth_offloads_store_lookup(self, auth_middleware, mock_store):
+        """The synchronous database/hash path must run on the worker thread, not the event loop."""
+        verifying_threads = []
+
+        def record_thread(username, password):
+            verifying_threads.append(threading.current_thread())
+            return True
+
+        mock_store.authenticate_user.side_effect = record_thread
+        with patch("mlflow_oidc_auth.middleware.auth_middleware.store", mock_store):
+            auth_header = "Basic YWRtaW5AZXhhbXBsZS5jb206YWRtaW5fcGFzcw=="
+
+            success, username, error = await auth_middleware._authenticate_basic_auth(auth_header)
+
+        assert success is True
+        assert username == "admin@example.com"
+        assert error == ""
+        mock_store.authenticate_user.assert_called_once_with("admin@example.com", "admin_pass")
+        assert len(verifying_threads) == 1
+        assert verifying_threads[0] is not threading.current_thread()
+        assert verifying_threads[0].name.startswith("mlflow-oidc-basic-auth")
+        # max_workers=1 is the security bound: one credential verification per process at a time.
+        assert middleware_module._BASIC_AUTH_EXECUTOR._max_workers == 1
 
     @pytest.mark.asyncio
     async def test_authenticate_basic_auth_malformed_header(self, auth_middleware, mock_store):


### PR DESCRIPTION
## What

Addresses item 2 of #244: basic auth ran the store lookup and password-hash verification synchronously inside the async `AuthMiddleware`, blocking the ASGI event loop for every concurrent request. Legacy scrypt token hashes take ~90 ms to verify, so under PAT-heavy load one worker's event loop stalls and unrelated requests (session, bearer, health-adjacent) queue behind credential verification.

This PR moves the verification onto a dedicated single-thread executor:

- `_BASIC_AUTH_EXECUTOR = ThreadPoolExecutor(max_workers=1)` at module level; the store lookup + hash verify run via `loop.run_in_executor(...)`.
- A tiny `_authenticate_basic_auth_sync` wrapper resolves the lazy store singleton inside the worker thread, so first-touch store initialization (engine creation, migrations) also stays off the event loop.

Stdlib only — no new dependencies.

## Why `max_workers=1`

The old synchronous code had an accidental but useful property: one verification per process at a time. The single-thread executor keeps that bound deliberately, so an unauthenticated caller cannot fan out concurrent scrypt work or database connections by spraying basic-auth requests. What changes is only *who waits*: the event loop stays responsive while a verification is in flight, instead of every request on the worker stalling behind it.

## What deliberately does not change

- Query count on the per-request auth path is unchanged (the perf baseline suite enforcing the 2-statement budget passes).
- Exception behavior is unchanged: a worker-thread exception re-raises at the `await` into the existing fail-closed handler → denial, never a grant. (#244 also notes that DB failures masquerade as invalid credentials; returning 503 instead of 401 for those is a behavior change and belongs in a separate PR.)
- Complements #337: that made *new* token hashes cheap; this keeps *legacy* scrypt verifications (and any store latency) from blocking the loop until tokens are rotated.

## End-to-end validation

Measured through the real middleware with no mocks on the auth path: a real store (SQLite + Alembic migrations), a real user whose hash was rewritten to the legacy scrypt format (~90 ms/verify), the real `AuthMiddleware` in the same order as `create_app()`, real HTTP via httpx's ASGI transport. A `/health` probe polled every 2 ms while 4 valid basic-auth requests verified concurrently:

| | before (main) | after (this PR) |
|---|---|---|
| 4 concurrent basic-auth requests, wall time | 655 ms | 575 ms |
| `/health` probes served during that window | **1** | 49 |
| `/health` max / median latency | **653 ms / 653 ms** | 60 ms / 5.3 ms |

On main the event loop is fully blocked for the whole burst — a single health check took 653 ms. With this PR the loop stays responsive while auth throughput is unchanged (total ≈ 4 × single verify on both sides, confirming the preserved one-at-a-time bound). Correctness held on both: 401 for missing/wrong/unknown credentials, 200 for the valid PAT, `/health` open.

## Testing

- New regression test asserts behaviorally that the store lookup runs on the dedicated worker thread (checked by thread identity/name), not the event loop, and that the concurrency bound is 1. The pre-existing success/failure tests exercise the real offload path end to end, including the denial path.
- `pytest mlflow_oidc_auth/tests/middleware/ mlflow_oidc_auth/tests/perf/` — all pass; full suite locally ~3,900 tests pass, including the `hooks/` files run individually.
- `pre-commit run --all-files` — all hooks pass (same command and Python version as the CI job).
- Every PR gate was additionally simulated offline against its exact CI configuration (title/commit regexes, tox selection, `norecursedirs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
