### PR TITLE
fix(app): register MLflow's MCP server registry router

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Request → ProxyHeaders → Auth → WorkspaceContext → Session → Route Han
 |-----------|---------|
 | **ProxyHeadersMiddleware** | Reads `X-Forwarded-*` headers from reverse proxies. Updates the request's scheme, host, port, and client IP. When `TRUSTED_PROXIES` is configured, only applies headers from requests originating within the trusted CIDR ranges |
 | **AuthMiddleware** | Authenticates the user via basic auth, JWT bearer token, or session cookie. Sets `request.state.username`, `request.state.is_admin`, and `request.scope["mlflow_oidc_auth"]`. When `OIDC_AUDIENCE` is configured, JWT `aud` claim is validated |
-| **FastAPIPermissionMiddleware** | Enforces RBAC on MLflow's native FastAPI routers (gateway invocations, chat completions, embeddings). Extracts the gateway endpoint name from the URL path and checks USE permission before forwarding |
+| **FastAPIPermissionMiddleware** | Enforces RBAC on MLflow's native FastAPI routers (gateway invocations, chat completions, embeddings). Extracts the gateway endpoint name from the URL path and checks USE permission before forwarding. On the MCP server registry, reads are open to any authenticated user and mutations are admin-only |
 | **WorkspaceContextMiddleware** | When workspaces are enabled, reads the `X-MLFLOW-WORKSPACE` header and sets MLflow's workspace ContextVar so tracking store operations run in the correct workspace |
 | **SessionMiddleware** | Starlette's built-in cookie-based session. Decodes/encodes the signed session cookie |
 

--- a/mlflow_oidc_auth/app.py
+++ b/mlflow_oidc_auth/app.py
@@ -192,6 +192,18 @@ def _include_mlflow_fastapi_routers(oidc_app: FastAPI) -> None:
     except ImportError:
         logger.debug("mlflow.server.assistant.api not available — Assistant endpoints disabled")
 
+    # MCP server registry: /api/3.0/mlflow/mcp-servers/* and the /ajax-api twin.
+    # The router carries no prefix of its own; MLflow mounts one copy per prefix,
+    # so we do the same rather than going through `_include_router`.
+    try:
+        from mlflow.server.mcp_server_api import get_mcp_server_api_route_prefixes, mcp_server_router
+
+        for route_prefix in get_mcp_server_api_route_prefixes():
+            oidc_app.include_router(mcp_server_router, prefix=route_prefix)
+        logger.info("Included MLflow MCP server registry router (/api/3.0/mlflow/mcp-servers)")
+    except ImportError:
+        logger.debug("mlflow.server.mcp_server_api not available — MCP registry endpoints disabled")
+
 
 def create_app() -> FastAPI:
     """Create a FastAPI application with OIDC integration.

--- a/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
@@ -46,6 +46,10 @@ _GEMINI_STREAM = re.compile(r"^/gateway/gemini/v1beta/models/([^/:]+):streamGene
 # Pattern: /gateway/{endpoint_name}/mlflow/invocations
 _INVOCATIONS_RE = re.compile(r"^/gateway/([^/]+)/mlflow/invocations$")
 
+# MCP server registry, mounted by MLflow under both the API and the UI prefix
+# (mlflow.server.mcp_server_api.get_mcp_server_api_route_prefixes)
+_MCP_SERVER_PREFIXES = ("/api/3.0/mlflow/mcp-servers", "/ajax-api/3.0/mlflow/mcp-servers")
+
 
 # ---------------------------------------------------------------------------
 # Endpoint-name extraction (mirrors upstream _extract_gateway_endpoint_name)
@@ -142,6 +146,22 @@ def _get_require_authentication_validator() -> Callable[[str, Request], Awaitabl
     return validator
 
 
+def _get_mcp_server_registry_validator() -> Callable[[str, Request], Awaitable[bool]]:
+    """Return a validator for the MCP server registry routes.
+
+    The registry is a single catalog shared by every tenant, and there is no
+    per-server permission model for it yet. Reading it is open to any
+    authenticated user; mutating it is admin-only. Admins never reach this
+    validator (the middleware short-circuits on ``is_admin``), so denying
+    every write method here is what makes mutation admin-only.
+    """
+
+    async def validator(username: str, request: Request) -> bool:
+        return request.method in ("GET", "HEAD")
+
+    return validator
+
+
 # ---------------------------------------------------------------------------
 # Route → validator dispatcher
 # ---------------------------------------------------------------------------
@@ -166,6 +186,9 @@ def _find_fastapi_validator(
 
     if path.startswith("/ajax-api/3.0/mlflow/assistant"):
         return _get_require_authentication_validator()
+
+    if path.startswith(_MCP_SERVER_PREFIXES):
+        return _get_mcp_server_registry_validator()
 
     return None
 

--- a/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
@@ -126,6 +126,13 @@ class TestFindFastapiValidator:
         assert self._find("/ajax-api/3.0/mlflow/assistant") is not None
         assert self._find("/ajax-api/3.0/mlflow/assistant/chat") is not None
 
+    def test_mcp_server_registry_routes_return_validator(self):
+        """Test MCP server registry routes return a validator on both prefixes."""
+        assert self._find("/api/3.0/mlflow/mcp-servers") is not None
+        assert self._find("/api/3.0/mlflow/mcp-servers/com.example/server") is not None
+        assert self._find("/ajax-api/3.0/mlflow/mcp-servers") is not None
+        assert self._find("/ajax-api/3.0/mlflow/mcp-servers/endpoints") is not None
+
     def test_flask_route_returns_none(self):
         """Test Flask-handled routes return None (pass-through)."""
         assert self._find("/api/2.0/mlflow/experiments/list") is None
@@ -286,6 +293,44 @@ class TestRequireAuthenticationValidator:
         request = MagicMock(spec=Request)
         result = await validator("user@example.com", request)
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: MCP server registry validator
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerRegistryValidator:
+    """Test the MCP server registry validator: reads open, writes admin-only."""
+
+    def _validator(self):
+        from mlflow_oidc_auth.middleware.fastapi_permission_middleware import (
+            _get_mcp_server_registry_validator,
+        )
+
+        return _get_mcp_server_registry_validator()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["GET", "HEAD"])
+    async def test_reads_allowed_for_any_user(self, method):
+        """Test that a non-admin authenticated user may read the registry."""
+        validator = self._validator()
+        request = MagicMock(spec=Request)
+        request.method = method
+        assert await validator("user@example.com", request) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["POST", "PATCH", "DELETE", "PUT"])
+    async def test_writes_denied_for_non_admin(self, method):
+        """Test that a non-admin authenticated user may not mutate the registry.
+
+        Admins never reach this validator, so denying here is what makes
+        mutation admin-only.
+        """
+        validator = self._validator()
+        request = MagicMock(spec=Request)
+        request.method = method
+        assert await validator("user@example.com", request) is False
 
 
 # ---------------------------------------------------------------------------

--- a/mlflow_oidc_auth/tests/test_app.py
+++ b/mlflow_oidc_auth/tests/test_app.py
@@ -409,6 +409,41 @@ class TestCreateApp:
             mock_get_all_routers.assert_called_once()
 
 
+class TestIncludeMlflowFastapiRouters:
+    """Test that MLflow's FastAPI-native routers reach the OIDC app.
+
+    Anything missing here falls through to the Flask WSGI mount, which has no
+    rule for it, so the UI gets a plain 404 instead of the feature.
+    """
+
+    def _paths(self):
+        from mlflow_oidc_auth.app import _include_mlflow_fastapi_routers
+
+        oidc_app = FastAPI()
+        _include_mlflow_fastapi_routers(oidc_app)
+        return set(oidc_app.openapi()["paths"])
+
+    def test_mcp_server_registry_router_included(self):
+        """Test the MCP server registry is served on both the API and UI prefix."""
+        paths = self._paths()
+        assert "/api/3.0/mlflow/mcp-servers" in paths
+        assert "/ajax-api/3.0/mlflow/mcp-servers" in paths
+
+    def test_gateway_and_assistant_routers_included(self):
+        """Test the previously registered routers are still included."""
+        paths = self._paths()
+        assert "/gateway/mlflow/v1/chat/completions" in paths
+        assert "/ajax-api/3.0/mlflow/assistant/config" in paths
+
+    def test_missing_mlflow_module_is_tolerated(self):
+        """Test an unavailable MLflow module disables its routes instead of raising."""
+        with patch.dict("sys.modules", {"mlflow.server.mcp_server_api": None}):
+            paths = self._paths()
+
+        assert "/api/3.0/mlflow/mcp-servers" not in paths
+        assert "/gateway/mlflow/v1/chat/completions" in paths
+
+
 class TestAppModuleImports:
     """Test module-level imports and dependencies."""
 


### PR DESCRIPTION
Fixes #365

## Problem

MLflow 3.15 added an MCP server registry, served from a FastAPI-native router at `/api/3.0/mlflow/mcp-servers` plus the `/ajax-api/3.0/mlflow/mcp-servers` twin that the web UI calls (`mlflow.server.mcp_server_api`).

`_include_mlflow_fastapi_routers()` re-registers MLflow's native routers from a fixed list of four (otel, jobs, gateway, assistant). That router is not in it, so every registry request misses FastAPI, falls through to the `AuthAwareWSGIMiddleware(flask_app)` mount, and Flask returns its plain HTML 404. The MLflow UI maps any 404 to `NotFoundError`, so the MCP Registry page renders "The requested resource was not found." with no hint of the cause.

Reproduced on the same MLflow build, with `--app-name` as the only variable:

| server | `GET /ajax-api/3.0/mlflow/mcp-servers` |
|---|---|
| `mlflow server` | 200 `{"mcp_servers":[],"next_page_token":null}` |
| `mlflow server --app-name=oidc-auth` | 404, Flask HTML |

The backend store needs nothing: MLflow's own migrations already create `mcp_servers`, `mcp_server_versions`, `mcp_server_tags`, `mcp_server_version_tags`, `mcp_server_aliases` and `mcp_access_endpoints`. Only the route wiring is missing.

## Change

- `app.py`: include `mcp_server_router` once per prefix from `get_mcp_server_api_route_prefixes()`, matching what MLflow's own `create_fastapi_app()` does. Wrapped in `try/except ImportError` like the neighbouring routers, so a server on an MLflow release without the module is unaffected.
- `middleware/fastapi_permission_middleware.py`: a validator for the new paths, so they are not unmapped routes. The registry is one catalog shared by every tenant and has no per-server permission model, so reads are open to any authenticated user and write methods are denied. Admins short-circuit the validator, which is what makes mutation admin-only.
- `docs/architecture.md`: note that policy in the middleware table.

I kept the policy deliberately conservative rather than reusing `_get_require_authentication_validator()`, since letting any authenticated user create or delete entries in a shared catalog seemed like the wrong default. Happy to change it, or to model MCP server permissions properly as a follow-up, if you would rather go that way.

## Scope note

`artifact_router` is missing from the same list for the same reason. I left it out: moving artifact upload/download from Flask to the native ASGI path is a behaviour change for existing deployments and deserves its own PR and its own testing.

## Verification

```
pre-commit run --files <the 5 changed files>          # all hooks pass
pytest mlflow_oidc_auth/tests/ --ignore=.../hooks     # 3577 passed, 14 skipped
pytest mlflow_oidc_auth/tests/hooks/test_*.py         # run file by file per AGENTS.md, 352 passed
```

End to end against MLflow 3.15.1 under `mlflow server --app-name=oidc-auth`:

| identity | request | before | after |
|---|---|---|---|
| non-admin | `GET /ajax-api/3.0/mlflow/mcp-servers` | 404 | 200 |
| non-admin | `POST /api/3.0/mlflow/mcp-servers` | 404 | 403 Permission denied |
| admin | `POST /api/3.0/mlflow/mcp-servers` | 404 | 200, server created |

New tests: registry paths resolve to a validator on both prefixes; reads allowed and writes denied for a non-admin; both prefixes present on the app after `_include_mlflow_fastapi_routers()`; the previously registered routers still present; a stubbed-out `mlflow.server.mcp_server_api` disables only its own routes instead of raising.

