### PR TITLE
fix(auth): bridge AuthContext to FastAPI routes via ContextVar

### DIFF
--- a/mlflow_oidc_auth/bridge/user.py
+++ b/mlflow_oidc_auth/bridge/user.py
@@ -3,22 +3,44 @@ Flask Hooks Bridge - Compatibility Layer for Flask Hooks with FastAPI Auth
 
 Provides functions to retrieve authentication context from Flask's WSGI environ,
 where it was injected by AuthAwareWSGIMiddleware from FastAPI's ASGI scope.
+
+For FastAPI-native routes (OTel traces, gateway, etc.) that never enter Flask,
+a ContextVar fallback allows the same bridge functions to work when the
+FastAPI permission middleware sets the AuthContext before running validators.
 """
+
+from contextvars import ContextVar
 
 from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
 from mlflow_oidc_auth.logger import get_logger
 
 logger = get_logger()
 
+_auth_context_var: ContextVar[AuthContext | None] = ContextVar("_auth_context_var", default=None)
+
+
+def set_auth_context(ctx: AuthContext) -> None:
+    """Set AuthContext in the ContextVar for non-Flask contexts (FastAPI-native routes)."""
+    _auth_context_var.set(ctx)
+
+
+def clear_auth_context() -> None:
+    """Clear the ContextVar after request processing."""
+    _auth_context_var.set(None)
+
 
 def get_auth_context() -> AuthContext:
-    """Get the full AuthContext from Flask request environ.
+    """Get the full AuthContext from Flask request environ or ContextVar fallback.
+
+    Checks Flask's WSGI environ first (for routes that pass through
+    AuthAwareWSGIMiddleware), then falls back to the ContextVar (for
+    FastAPI-native routes where the permission middleware sets it).
 
     Returns:
         AuthContext object containing username, is_admin, and workspace.
 
     Raises:
-        Exception: If AuthContext is not available in the environ.
+        Exception: If AuthContext is not available from either source.
     """
     try:
         from flask import request
@@ -31,11 +53,16 @@ def get_auth_context() -> AuthContext:
     except Exception as e:
         logger.debug(f"Could not access AuthContext from Flask request: {e}")
 
+    ctx = _auth_context_var.get()
+    if isinstance(ctx, AuthContext):
+        logger.debug(f"Retrieved AuthContext from ContextVar: {ctx.username}")
+        return ctx
+
     raise Exception("Could not retrieve AuthContext")
 
 
 def get_fastapi_username() -> str:
-    """Get username from FastAPI authentication context via Flask request environ.
+    """Get username from the current authentication context.
 
     Returns:
         Username if authenticated.
@@ -53,7 +80,7 @@ def get_fastapi_username() -> str:
 
 
 def get_fastapi_admin_status() -> bool:
-    """Get admin status from FastAPI authentication context via Flask request environ.
+    """Get admin status from the current authentication context.
 
     Returns:
         True if user is admin, False otherwise.
@@ -65,7 +92,7 @@ def get_fastapi_admin_status() -> bool:
 
 
 def get_request_workspace() -> str | None:
-    """Get the current workspace from Flask request environ.
+    """Get the current workspace from the authentication context.
 
     Returns:
         Workspace name if workspaces are enabled and header was present, None otherwise.

--- a/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/middleware/fastapi_permission_middleware.py
@@ -19,6 +19,8 @@ from typing import Any
 from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse, PlainTextResponse
 
+from mlflow_oidc_auth.bridge.user import clear_auth_context, set_auth_context
+from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
 from mlflow_oidc_auth.logger import get_logger
 from mlflow_oidc_auth.utils.permissions import can_use_gateway_endpoint
 
@@ -232,6 +234,13 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
         if is_admin:
             return await call_next(request)
 
+        # Bridge AuthContext into ContextVar so downstream permission code
+        # (e.g. _apply_workspace_fallback) can resolve the workspace even
+        # though these routes never enter Flask
+        auth_context = request.scope.get(AUTH_CONTEXT_KEY)
+        if isinstance(auth_context, AuthContext):
+            set_auth_context(auth_context)
+
         # Run the validator
         try:
             if not await validator(username, request):
@@ -245,5 +254,7 @@ def add_fastapi_permission_middleware(app: FastAPI) -> None:
                 "Permission denied",
                 status_code=403,
             )
+        finally:
+            clear_auth_context()
 
         return await call_next(request)

--- a/mlflow_oidc_auth/tests/bridge/test_user.py
+++ b/mlflow_oidc_auth/tests/bridge/test_user.py
@@ -7,6 +7,8 @@ Updated to use AuthContext pattern instead of individual environ keys.
 import pytest
 from unittest.mock import Mock, patch
 from mlflow_oidc_auth.bridge.user import (
+    set_auth_context,
+    clear_auth_context,
     get_auth_context,
     get_fastapi_username,
     get_fastapi_admin_status,
@@ -387,6 +389,90 @@ class TestBridgeErrorHandling:
             # Verify log messages contain expected content
             log_calls = [call.args[0] for call in mock_logger.debug.call_args_list]
             assert any("Retrieved AuthContext from Flask environ" in msg for msg in log_calls)
+
+
+class TestContextVarFallback:
+    """Test ContextVar fallback for FastAPI-native routes (no Flask context)."""
+
+    def setup_method(self):
+        clear_auth_context()
+
+    def teardown_method(self):
+        clear_auth_context()
+
+    def test_get_auth_context_from_contextvar(self):
+        """When Flask is unavailable, get_auth_context falls back to the ContextVar."""
+        ctx = AuthContext(username="fastapi@example.com", is_admin=False, workspace="team-ws")
+        set_auth_context(ctx)
+
+        with patch.dict("sys.modules", {"flask": None}):
+            result = get_auth_context()
+            assert result is ctx
+            assert result.username == "fastapi@example.com"
+            assert result.workspace == "team-ws"
+
+    def test_get_request_workspace_from_contextvar(self):
+        """get_request_workspace returns workspace from ContextVar when Flask is unavailable"""
+        set_auth_context(AuthContext(username="user@example.com", is_admin=False, workspace="my-ws"))
+
+        with patch.dict("sys.modules", {"flask": None}):
+            assert get_request_workspace() == "my-ws"
+
+    def test_get_request_workspace_none_from_contextvar(self):
+        """get_request_workspace returns None when ContextVar has no workspace."""
+        set_auth_context(AuthContext(username="user@example.com", is_admin=False))
+
+        with patch.dict("sys.modules", {"flask": None}):
+            assert get_request_workspace() is None
+
+    def test_contextvar_cleared(self):
+        """After clear_auth_context, get_auth_context raises."""
+        set_auth_context(AuthContext(username="user@example.com", is_admin=False))
+        clear_auth_context()
+
+        with patch.dict("sys.modules", {"flask": None}):
+            with pytest.raises(Exception, match="Could not retrieve AuthContext"):
+                get_auth_context()
+
+    def test_flask_environ_takes_precedence(self):
+        """Flask env is preferred over ContextVar when both are available."""
+        flask_ctx = AuthContext(username="flask@example.com", is_admin=False, workspace="flask-ws")
+        cv_ctx = AuthContext(username="cv@example.com", is_admin=False, workspace="cv-ws")
+        set_auth_context(cv_ctx)
+
+        mock_request = Mock()
+        mock_request.environ = {"mlflow_oidc_auth": flask_ctx}
+
+        with patch.dict("sys.modules", {"flask": Mock(request=mock_request)}):
+            result = get_auth_context()
+            assert result.username == "flask@example.com"
+            assert result.workspace == "flask-ws"
+
+    def test_contextvar_used_when_flask_environ_empty(self):
+        """ContextVar is used when Flask environ exists but has no AuthContext."""
+        cv_ctx = AuthContext(username="cv@example.com", is_admin=False, workspace="cv-ws")
+        set_auth_context(cv_ctx)
+
+        mock_request = Mock()
+        mock_request.environ = {}
+
+        with patch.dict("sys.modules", {"flask": Mock(request=mock_request)}):
+            result = get_auth_context()
+            assert result.username == "cv@example.com"
+
+    def test_get_fastapi_username_from_context_var(self):
+        """get_fastapi_username works via ContextVar fallback."""
+        set_auth_context(AuthContext(username="fastapi@example.com", is_admin=False))
+
+        with patch.dict("sys.modules", {"flask": None}):
+            assert get_fastapi_username() == "fastapi@example.com"
+
+    def test_get_fastapi_admin_status_from_context_var(self):
+        """get_fastapi_admin_status works via ContextVar fallback."""
+        set_auth_context(AuthContext(username="fastapi@example.com", is_admin=True))
+
+        with patch.dict("sys.modules", {"flask": None}):
+            assert get_fastapi_admin_status() is True
 
 
 class TestBridgeDataValidation:

--- a/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
+++ b/mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py
@@ -338,7 +338,7 @@ class TestMCPServerRegistryValidator:
 # ---------------------------------------------------------------------------
 
 
-def _create_app_with_auth(username=None, is_admin=False):
+def _create_app_with_auth(username=None, is_admin=False, workspace=None):
     """Create a test FastAPI app with auth context and permission middleware.
 
     Starlette ``@app.middleware("http")`` uses LIFO ordering: the last middleware
@@ -346,6 +346,7 @@ def _create_app_with_auth(username=None, is_admin=False):
     permission middleware FIRST, then the auth-context middleware, so that
     auth context is set before the permission middleware reads it.
     """
+    from mlflow_oidc_auth.entities.auth_context import AUTH_CONTEXT_KEY, AuthContext
     from mlflow_oidc_auth.middleware.fastapi_permission_middleware import (
         add_fastapi_permission_middleware,
     )
@@ -382,6 +383,7 @@ def _create_app_with_auth(username=None, is_admin=False):
         async def inject_auth_context(request: Request, call_next):
             request.state.username = username
             request.state.is_admin = is_admin
+            request.scope[AUTH_CONTEXT_KEY] = AuthContext(username=username, is_admin=is_admin, workspace=workspace)
             return await call_next(request)
 
     return app
@@ -529,3 +531,85 @@ class TestFastapiPermissionMiddlewareIntegration:
         client = TestClient(app)
         response = client.get("/gateway/my-ep/mlflow/invocations")
         assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: AuthContext ContextVar bridging for workspace resolution
+# ---------------------------------------------------------------------------
+
+
+class TestAuthContextBridging:
+    """Test that the middleware bridges AuthContext via ContextVar for FastAPI-native routes."""
+
+    @patch("mlflow_oidc_auth.utils.effective_experiment_permission")
+    def test_otel_validator_receives_workspace_via_contextvar(self, mock_perm):
+        """Workspace is available via get_request_workspace during OTel validatio.n"""
+        from mlflow_oidc_auth.bridge.user import get_request_workspace
+
+        captured_workspace = {}
+
+        def capture_workspace(experiment_id, username):
+            captured_workspace["value"] = get_request_workspace()
+            result = MagicMock()
+            result.permission.can_update = True
+            return result
+
+        mock_perm.side_effect = capture_workspace
+
+        app = _create_app_with_auth(username="user@example.com", is_admin=False, workspace="team-ws")
+        client = TestClient(app)
+        response = client.get("/v1/traces", headers={"X-Mlflow-Experiment-Id": "42"})
+
+        assert response.status_code == 200
+        assert captured_workspace["value"] == "team-ws"
+
+    @patch("mlflow_oidc_auth.utils.effective_experiment_permission")
+    def test_contextvar_cleared_after_request(self, mock_perm):
+        """ContextVar is cleared after the middleware processes the request."""
+        from mlflow_oidc_auth.bridge.user import _auth_context_var
+
+        mock_result = MagicMock()
+        mock_result.permission.can_update = True
+        mock_perm.return_value = mock_result
+
+        app = _create_app_with_auth(username="user@example.com", is_admin=False, workspace="team-ws")
+        client = TestClient(app)
+        response = client.get("/v1/traces", headers={"X-Mlflow-Experiment-Id": "42"})
+
+        assert _auth_context_var.get() is None
+
+    @patch("mlflow_oidc_auth.utils.effective_experiment_permission")
+    def test_contextvar_cleared_on_validator_exception(self, mock_perm):
+        """ContextVar is cleared when the validator raises."""
+        from mlflow_oidc_auth.bridge.user import _auth_context_var
+
+        mock_perm.side_effect = RuntimeError("boom")
+
+        app = _create_app_with_auth(username="user@example.com", is_admin=False, workspace="team-ws")
+        client = TestClient(app)
+        response = client.get("/v1/traces", headers={"X-Mlflow-Experiment-Id": "42"})
+
+        assert response.status_code == 403
+        assert _auth_context_var.get() is None
+
+    @patch("mlflow_oidc_auth.utils.effective_experiment_permission")
+    def test_no_workspace_header_contextvar_has_none_workspace(self, mock_perm):
+        """With workspace header, ContextVar AuthContext has workspace=None."""
+        from mlflow_oidc_auth.bridge.user import get_request_workspace
+
+        captured_workspace = {}
+
+        def capture_workspace(experiment_id, username):
+            captured_workspace["value"] = get_request_workspace()
+            result = MagicMock()
+            result.permission.can_update = True
+            return result
+
+        mock_perm.side_effect = capture_workspace
+
+        app = _create_app_with_auth(username="user@example.com", is_admin=False, workspace=None)
+        client = TestClient(app)
+        response = client.get("/v1/traces", headers={"X-Mlflow-Experiment-Id": "42"})
+
+        assert response.status_code == 200
+        assert captured_workspace["value"] is None


### PR DESCRIPTION
## Summary

`get_auth_context()` only reads Flask's `request.environ`. FastAPI-native routes never enter Flask, so it always raises -> `get_request_workspace()` returns `None` -> `apply_workspace_fallback() is skipped` -> `DEFAULT_MLFLOW_PERMISSION` applies.
Users whose only grant is workspace-level MANAGE get 403 on `/v1/traces

The `AuthContext` is already in the ASGI scope at `request.scope["mlflow_oidc_auth"] (set by `AuthMiddleware`); it just never reaches the bridge.

Closes #369

## Changes

`bridge/user.py` - add `_auth_context_var` with `set_auth_context()`/`clear_auth_context()`. `get_auth_context()` tries Flask environ first, then falls back to the ContextVar.

`middleware/fastapi_permission_middleware.py` - set the `AuthContext` from the ASGI scope before running the validator; clear it in `finally`.
Mirrors the existing `WorkspaceContextMiddleware` ContextVar pattern.

## Security
- Deny-by-default preserved - every failure path returns `None`/raises/`False`
- `ContextVar` is per-`asyncio.Task`, so no cross-request leakage; `finally` adds defence in depth
- Flask environ keeps precedence - no bypass
- No new `is_admin` path - admin bypass reads `request.state` and returns before `set_auth_context`
- No new DB queries on the auth path; `AuthContext` is a frozen dataclass

## Test plan
- [x] `pre-commit run --all-files` - 8/8 hooks pass, no files rewritten
- [x] `pytest mlflow_oidc_auth/tests/bridge/test_user.py` - 44 passed, incl. 8 new (ContextVar fallback, cleanup, Flask-environ precedence)
- [x] `pytest mlflow_oidc_auth/tests/middleware/test_fastapi_permission_middleware.py` - 56 passed, incl. 4 new (workspace propagation into the validator, cleanup on success and on exception, no-workspace case
- [x] `pytest mlflow_oidc_auth/tests/utils/test_permissions.py -k workspace` - 9 passed, existing workspace-fallback behaviour unchanged
- [x] `pytest mlflow_oidc_auth/tests/ --ignore=mlflow_oidc_auth/tests/hooks` - 3588 passed, 14 skipped, 1 failed (see below) 
- [x] `hooks/` run file-by-file per AGENTS.md's documented hang - 9 of 10 files clean

**Two pre-existing failures, unrelated to this change.** Both reproduce identically on the parent commit `76a6dd0` with none of this PR's code::
- `test_app.py::test_mcp_server_registry_router_included` - asserts `/api/3.0/mlflow/mcp-servers` is registered; absent in MLflow 3.14.0, the declared floor
- `hooks/test_artifact_proxy_coverage.py` - 9 failed, 57 passed
 
- [ ] Manual: workspace-MANAGE-only user POSTs `/v1/traces` -> 200